### PR TITLE
Add static int to track the max number of threads

### DIFF
--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -57,6 +57,8 @@ MODULE ParallelEnv
   INTEGER,SAVE :: PE_COMM_DEFAULT=0
 #endif
 
+  INTEGER :: max_threads_requested=0
+
   PUBLIC :: PE_COMM_SELF
   PUBLIC :: PE_COMM_WORLD
   PUBLIC :: PE_COMM_NULL
@@ -1257,7 +1259,8 @@ MODULE ParallelEnv
 !$        myPE%nproc=MAX(1,PEparam)
 !$      ENDIF
 !$    ENDIF
-!$    IF(myPE%nproc > omp_get_max_threads()) THEN
+!$    IF(myPE%nproc > max_threads_requested) THEN
+!$      max_threads_requested = myPE%nproc
 !$      CALL omp_set_num_threads(myPE%nproc)
 !$    ENDIF
       myPE%initStat=.TRUE.


### PR DESCRIPTION
This is used to call omp_set_num_threads() to the proper value so that TPLs will
respect the desired number of threads per process.