### PR TITLE
Polygonize_Cylinder routine added.

### DIFF
--- a/src/Geom_Poly.f90
+++ b/src/Geom_Poly.f90
@@ -122,6 +122,7 @@ MODULE Geom_Poly
 
   INTERFACE Polygonize
     MODULE PROCEDURE Polygonize_Circle
+    MODULE PROCEDURE Polygonize_Cylinder
     MODULE PROCEDURE Polygonize_OBBox
     MODULE PROCEDURE Polygonize_ABBox
   ENDINTERFACE
@@ -1630,6 +1631,57 @@ MODULE Geom_Poly
         CALL g%clear()
       ENDIF
     ENDSUBROUTINE Polygonize_Circle
+!
+!-------------------------------------------------------------------------------
+!> @brief This routine will return a polygon type for a given circular geometry.
+!> @param circle The circle type to be turned into a polygon
+!> @param polygon The polygon type that corresponds to the circle type.
+!>
+    SUBROUTINE Polygonize_Cylinder(cylinder,polygon)
+      TYPE(CylinderType),INTENT(IN) :: cylinder
+      TYPE(PolygonType),INTENT(INOUT) :: polygon
+      REAL(SRK) :: v0(2),v1(2),v2(2),v3(2),r,c(3)
+      TYPE(GraphType) :: g
+
+      CALL polygon%clear()
+      IF(cylinder%r > 0.0_SRK .AND. cylinder%axis%p1%dim == 3) THEN
+        r=cylinder%r
+        c=cylinder%axis%p1%coord(1:3)
+        IF((cylinder%thetastt .APPROXEQA. 0.0_SRK) .AND. &
+           (cylinder%thetastp .APPROXEQA. TWOPI)) THEN
+
+          v0(1)=c(1)-r; v0(2)=c(2)
+          v1(1)=c(1); v1(2)=c(2)+r
+          v2(1)=c(1)+r; v2(2)=c(2)
+          v3(1)=c(1); v3(2)=c(2)-r
+
+          CALL g%insertVertex(v0)
+          CALL g%insertVertex(v1)
+          CALL g%insertVertex(v2)
+          CALL g%insertVertex(v3)
+          CALL g%defineQuadraticEdge(v0,v1,c(1:2),r)
+          CALL g%defineQuadraticEdge(v1,v2,c(1:2),r)
+          CALL g%defineQuadraticEdge(v2,v3,c(1:2),r)
+          CALL g%defineQuadraticEdge(v0,v3,c(1:2),r)
+        ELSE
+          v0(1)=c(1); v0(2)=c(2)
+          v1(1)=c(1)+r*COS(cylinder%thetastt)
+          v1(2)=c(2)+r*SIN(cylinder%thetastt)
+          v2(1)=c(1)+r*COS(cylinder%thetastp)
+          v2(2)=c(2)+r*SIN(cylinder%thetastp)
+
+          CALL g%insertVertex(v0)
+          CALL g%insertVertex(v1)
+          CALL g%insertVertex(v2)
+          CALL g%defineEdge(v0,v1)
+          CALL g%defineEdge(v0,v2)
+          CALL g%defineQuadraticEdge(v1,v2,c(1:2),r)
+        ENDIF
+
+        CALL polygon%set(g)
+        CALL g%clear()
+      ENDIF
+    ENDSUBROUTINE Polygonize_Cylinder
 !
 !-------------------------------------------------------------------------------
 !> @brief This routine will return a polygon type for a given OBBox  geometry.

--- a/src/Geom_Poly.f90
+++ b/src/Geom_Poly.f90
@@ -1633,9 +1633,9 @@ MODULE Geom_Poly
     ENDSUBROUTINE Polygonize_Circle
 !
 !-------------------------------------------------------------------------------
-!> @brief This routine will return a polygon type for a given circular geometry.
-!> @param circle The circle type to be turned into a polygon
-!> @param polygon The polygon type that corresponds to the circle type.
+!> @brief This routine will return a polygon type for a given cylindrical geometry.
+!> @param cylinder The cylinder type to be turned into a polygon
+!> @param polygon The polygon type that corresponds to the cylinder type.
 !>
     SUBROUTINE Polygonize_Cylinder(cylinder,polygon)
       TYPE(CylinderType),INTENT(IN) :: cylinder

--- a/unit_tests/testGeom_Poly/testGeom_Poly.f90
+++ b/unit_tests/testGeom_Poly/testGeom_Poly.f90
@@ -2180,9 +2180,11 @@ PROGRAM testGeom_Poly
 !-------------------------------------------------------------------------------
     SUBROUTINE testPolygonize()
       TYPE(PointType) :: testpoint
+      TYPE(PointType) :: testpoint_b,testpoint_t
       TYPE(ABBoxType) :: testABbox
       TYPE(OBBoxType) :: testOBbox
       TYPE(CircleType) :: testcircle
+      TYPE(CylinderType) :: testcyl
 
       !polygonize an OB box
       CALL testpoint%init(DIM=2,X=1.0_SRK,Y=1.0_SRK)
@@ -2254,6 +2256,35 @@ PROGRAM testGeom_Poly
       ASSERT(bool,'%quadEdge(4)')
       CALL testpoint%clear()
       CALL testcircle%clear()
+      CALL testPolyType%clear()
+
+      !polygonize a cylinder
+      CALL testpoint_b%init(DIM=3,X=1.0_SRK,Y=1.0_SRK,Z=0.0_SRK)
+      CALL testpoint_t%init(DIM=3,X=1.0_SRK,Y=1.0_SRK,Z=1.0_SRK)
+      CALL testcyl%set(testpoint_b,testpoint_t,2.0_SRK*SQRT(2.0_SRK))
+      CALL Polygonize(testcyl,testPolyType)
+      ASSERTFAIL(testPolyType%isinit,'init polygon from cylinder')
+      WRITE(*,*) 'nvert,nquadedge = ',testPolyType%nVert,testPolyType%nQuadEdge
+      ASSERT(testPolyType%nVert == 4,'%nVert')
+      ASSERT(testPolyType%nQuadEdge == 4,'%nQuadEdge')
+      bool=(testPolyType%quadEdge(1,1) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(2,1) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(3,1) .APPROXEQA. 2.0_SRK*SQRT(2.0_SRK))
+      ASSERT(bool,'%quadEdge(1)')
+      bool=(testPolyType%quadEdge(1,2) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(2,2) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(3,2) .APPROXEQA. 2.0_SRK*SQRT(2.0_SRK))
+      ASSERT(bool,'%quadEdge(2)')
+      bool=(testPolyType%quadEdge(1,3) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(2,3) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(3,3) .APPROXEQA. 2.0_SRK*SQRT(2.0_SRK))
+      ASSERT(bool,'%quadEdge(3)')
+      bool=(testPolyType%quadEdge(1,4) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(2,4) .APPROXEQA. 1.0_SRK) .AND. &
+        (testPolyType%quadEdge(3,4) .APPROXEQA. 2.0_SRK*SQRT(2.0_SRK))
+      ASSERT(bool,'%quadEdge(4)')
+      CALL testpoint%clear()
+      CALL testcyl%clear()
       CALL testPolyType%clear()
 
       !Polygonize an arc


### PR DESCRIPTION
The new Polygoinze_Cylinder routine is similar to the already-existing Polygonize_Circle routine. This was added for visualizing general cylinders in VTK. Test for cylinder added to Geom_Poly unit test.