### PR TITLE
Stop deallocating LU factorization all the time

### DIFF
--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -471,8 +471,7 @@ CONTAINS
       CALL thisLS%updatedA()
       !Check
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Direct)
-        bool = .NOT.ALLOCATED(thisLS%M) .AND. .NOT.thisLS%isDecomposed &
-          .AND. .NOT.ALLOCATED(thisLS%IPIV)
+        bool = .NOT.thisLS%isDecomposed .AND. .NOT.ALLOCATED(thisLS%IPIV)
         ASSERT(bool, 'Direct%updatedA()')
       ENDSELECT
       CALL thisLS%clear()
@@ -508,7 +507,7 @@ CONTAINS
 
       !Check
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        bool = .NOT.thisLS%isDecomposed .AND. .NOT.ALLOCATED(thisLS%M)
+        bool = .NOT.thisLS%isDecomposed
         ASSERT(bool, 'Iterative%updatedA()')
       ENDSELECT
       CALL thisLS%clear()

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -471,7 +471,7 @@ CONTAINS
       CALL thisLS%updatedA()
       !Check
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Direct)
-        bool = .NOT.thisLS%isDecomposed .AND. .NOT.ALLOCATED(thisLS%IPIV)
+        bool = .NOT.thisLS%isDecomposed
         ASSERT(bool, 'Direct%updatedA()')
       ENDSELECT
       CALL thisLS%clear()


### PR DESCRIPTION
Current implementation would clear and deallocate the preconditioner whenever the matrix
is changed or the solver failed.  This ends up spending significant time in parameter list
and allocation time for mongoose which is solving a temperature equation many many times
per solve.  The changes represent about an order of magnitude speedup in mongoose.