### PR TITLE
Make PETSc use a nonzero initial guess by default.

### DIFF
--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -600,6 +600,9 @@ MODULE LinearSolverTypes
 #endif
                 ENDSELECT
 
+                !Always use a nonzero initial guess:
+                CALL KSPSetInitialGuessNonzero(solver%ksp,PETSC_TRUE,iperr)
+
                 !set preconditioner
                 IF((solver%solverMethod == GMRES) .OR. (solver%solverMethod == BICGSTAB)) THEN
                   CALL KSPGetPC(solver%ksp,solver%pc,iperr)


### PR DESCRIPTION
This means that, when a PETSc linear solver is called, the solution vector
passed to PETSc should be initialized.  This should be true in all CASL codes
and, if that's not the case, then the other codes should be changed so that
calls to PETSc solvers are always made with an initialized solution vector. To
preserve the same behavior, simply pass PETSc a solution vector initialized to
zero.

Previously, in many places where we already had a good estimate of the flux, we
were throwing away this information by starting with a naive guess of zero.
This change should reduce the number of linear solver iterations required for
convergence in all places where GMRES is called and a reasonable estimate of
the solution is known.