### PR TITLE
SuperLU Linear Solver

### DIFF
--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -1343,6 +1343,61 @@ CONTAINS
            .OR. thisLS%info /= 0
         ASSERT(bool, 'PARDISODirect%solve()')
       ENDSELECT
+      CALL thisLS%clear()
+#endif
+
+#ifdef FUTILITY_HAVE_PETSC
+      ! test with SuperLU through PETSc
+      ! initialize linear system
+      CALL pList%clear()
+      CALL pList%add('LinearSolverType->TPLType',PETSC)
+      CALL pList%add('LinearSolverType->solverMethod',LU)
+      CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
+      CALL pList%add('LinearSolverType->numberOMP',1_SNK)
+      CALL pList%add('LinearSolverType->timerName','testTimer')
+      CALL pList%add('LinearSolverType->matType',SPARSE)
+      CALL pList%add('LinearSolverType->A->MatrixType->n',3_SNK)
+      CALL pList%add('LinearSolverType->A->MatrixType->nnz',8_SNK)
+      CALL pList%add('LinearSolverType->x->VectorType->n',3_SNK)
+      CALL pList%add('LinearSolverType->b->VectorType->n',3_SNK)
+      CALL pList%validate(pList,optListLS)
+      CALL thisLS%init(pList)
+
+      !A=[1 0 1 ]  b=[4]    x=[1]
+      !  [2 5 -2]    [6]      [2]
+      !  [3 6 9 ]    [42]     [3]
+      WRITE(*,*) 'set A'
+      SELECTTYPE(A => thisLS%A); TYPE IS(PETScMatrixType)
+        CALL A%set(1,1,1._SRK)
+        CALL A%set(1,3,1._SRK)
+        CALL A%set(2,1,2._SRK)
+        CALL A%set(2,2,5._SRK)
+        CALL A%set(2,3,-2._SRK)
+        CALL A%set(3,1,3._SRK)
+        CALL A%set(3,2,6._SRK)
+        CALL A%set(3,3,9._SRK)
+      ENDSELECT
+
+      SELECTTYPE(b => thisLS%b); TYPE IS(PETScVectorType)
+        CALL b%set(1, 4._SRK)
+        CALL b%set(2, 6._SRK)
+        CALL b%set(3,42._SRK)
+      ENDSELECT
+
+      CALL thisLS%solve()
+
+      ! check X
+      SELECTTYPE(X => thisLS%X); TYPE IS(PETScVectorType)
+        IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+        ALLOCATE(dummyvec(X%n))
+        CALL X%get(dummyvec)
+        bool = (SOFTEQ(dummyvec(1),1._SRK,1E-14_SRK)  &
+           .AND.  SOFTEQ(dummyvec(2),2._SRK,1E-14_SRK)  &
+           .AND.  SOFTEQ(dummyvec(3),3._SRK,1E-14_SRK)) &
+           .OR. thisLS%info /= 0
+        ASSERT(bool, 'SuperLU Direct%solve()')
+      ENDSELECT
+      CALL thisLS%clear()
 #endif
 
     !end test of direct solver


### PR DESCRIPTION
Adding hooks to direct LS type to use SuperLU.  Right now, this is enabled by specifying PETSC as the TPL and LU as the solver method.