### PR TITLE
Update sundials ode solver to support multiple ODE solver objects

### DIFF
--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -183,11 +183,11 @@ PROGRAM testODESolver
   REGISTER_SUBTEST('testStep_Sundials_Linear',testStep_Sundials_Linear)
   DEALLOCATE(f)
   ALLOCATE(ODESolverInterface_TestExponential :: f)
-  SUNDIALS_ODE_INTERFACE=>f
+  testODE%f=>f
   REGISTER_SUBTEST('testStep_Sundials_Exp',testStep_Sundials_Exp)
   DEALLOCATE(f)
   ALLOCATE(ODESolverInterface_TestNonLinear :: f)
-  SUNDIALS_ODE_INTERFACE=>f
+  testODE%f=>f
   REGISTER_SUBTEST('testStep_Sundials_NonLinear',testStep_Sundials_NonLinear)
 #endif
   REGISTER_SUBTEST('testClear_Sundials',testClear_Sundials)


### PR DESCRIPTION
The sundials fortran interface effectively defines a singleton object
for the ode solver.  Since multiple ODE solvers are needed in Mongoose
in order to solve multiple pins at once.  This requires a lot of sundials
data to be global across all ODE solver types so module data structures are
used to hold a few logicals and data arrays that sundials requires.  Note that
this fix will only work if all ODE solvers have the same number of unknowns.
A better and more permanent fix would be to use the PETSc wrapper for
sundials or directly wrap the C interface for sundials if multiple size ODE solvers
are needed.