### PR TITLE
Unit test

### DIFF
--- a/src/FileType_HDF5.f90
+++ b/src/FileType_HDF5.f90
@@ -474,16 +474,28 @@ MODULE FileType_HDF5
         write_attribute_d0
       !> @copybrief FileType_HDF5::read_str_attribure_help
       !> @copyoc FileType_HDF5_read_str_attribure_help
+<<<<<<< d0b2bde1837c2f8987ee6898143e2b7c5b53329a
       PROCEDURE,PASS,PRIVATE :: read_attribute_st0 
       !> @copybrief FileType_HDF5::read_attribute_i0
       !> @copyoc FileType_HDF5_read_attribute_i0
       PROCEDURE,PASS,PRIVATE :: read_attribute_i0 
+=======
+      PROCEDURE,PASS,PRIVATE :: read_attribute_st0_helper 
+      !> @copybrief FileType_HDF5::read_attribure_i0
+      !> @copyoc FileType_HDF5_read_attribure_i0
+      PROCEDURE,PASS,PRIVATE :: read_attribure_i0 
+>>>>>>> Adds functionality to support writing and reading attributes to HDF5 objects.
       !> @copybrief FileType_HDF5::read_attribute_d0
       !> @copyoc FileType_HDF5_read_attribute_d0
       PROCEDURE,PASS,PRIVATE :: read_attribute_d0
       !> Generic typebound interface for all @c attribute writes
+<<<<<<< d0b2bde1837c2f8987ee6898143e2b7c5b53329a
       GENERIC :: read_attribute => read_attribute_st0, read_attribute_i0,&
         read_attribute_d0
+=======
+      GENERIC :: read_attribute => read_attribute_st0_helper,&
+        read_attribure_i0, read_attribute_d0
+>>>>>>> Adds functionality to support writing and reading attributes to HDF5 objects.
   ENDTYPE
 
   !> @brief Type that is a container so as to have an array of pointers to HDF5 files

--- a/src/FileType_HDF5.f90
+++ b/src/FileType_HDF5.f90
@@ -474,28 +474,16 @@ MODULE FileType_HDF5
         write_attribute_d0
       !> @copybrief FileType_HDF5::read_str_attribure_help
       !> @copyoc FileType_HDF5_read_str_attribure_help
-<<<<<<< d0b2bde1837c2f8987ee6898143e2b7c5b53329a
       PROCEDURE,PASS,PRIVATE :: read_attribute_st0 
       !> @copybrief FileType_HDF5::read_attribute_i0
       !> @copyoc FileType_HDF5_read_attribute_i0
       PROCEDURE,PASS,PRIVATE :: read_attribute_i0 
-=======
-      PROCEDURE,PASS,PRIVATE :: read_attribute_st0_helper 
-      !> @copybrief FileType_HDF5::read_attribure_i0
-      !> @copyoc FileType_HDF5_read_attribure_i0
-      PROCEDURE,PASS,PRIVATE :: read_attribure_i0 
->>>>>>> Adds functionality to support writing and reading attributes to HDF5 objects.
       !> @copybrief FileType_HDF5::read_attribute_d0
       !> @copyoc FileType_HDF5_read_attribute_d0
       PROCEDURE,PASS,PRIVATE :: read_attribute_d0
       !> Generic typebound interface for all @c attribute writes
-<<<<<<< d0b2bde1837c2f8987ee6898143e2b7c5b53329a
       GENERIC :: read_attribute => read_attribute_st0, read_attribute_i0,&
         read_attribute_d0
-=======
-      GENERIC :: read_attribute => read_attribute_st0_helper,&
-        read_attribure_i0, read_attribute_d0
->>>>>>> Adds functionality to support writing and reading attributes to HDF5 objects.
   ENDTYPE
 
   !> @brief Type that is a container so as to have an array of pointers to HDF5 files

--- a/src/FileType_HDF5.f90
+++ b/src/FileType_HDF5.f90
@@ -6659,7 +6659,6 @@ MODULE FileType_HDF5
        INTEGER :: num_dims
        INTEGER(HID_T) :: attr_id, dspace_id, obj_id
        INTEGER(HSIZE_T),DIMENSION(1) :: dims
-       CHARACTER(LEN=LEN(obj_name)+1) :: path
 
        num_dims=1
        dims(1)=1
@@ -6698,7 +6697,6 @@ MODULE FileType_HDF5
        INTEGER :: num_dims
        INTEGER(HID_T) :: attr_id, dspace_id, obj_id
        INTEGER(HSIZE_T),DIMENSION(1) :: dims
-       CHARACTER(LEN=LEN(obj_name)+1) :: path
 
        num_dims=1
        dims(1)=1
@@ -6742,7 +6740,7 @@ MODULE FileType_HDF5
        CALL open_attribute(this,obj_id,attr_name,attr_id)
 
        CALL h5aget_storage_size_f(attr_id,max_size,error)
-       CALL read_attribute_st0_helper(this,attr_id,max_size,attr_name,attr_val)
+       CALL read_attribute_st0_helper(attr_id,max_size,attr_val)
 
        CALL close_attribute(this,attr_id)
        CALL close_object(this,obj_id)
@@ -6757,10 +6755,8 @@ MODULE FileType_HDF5
 !> @param attr_value the desired value of the attrbute
 !>  
 #ifdef FUTILITY_HAVE_HDF5
-    SUBROUTINE read_attribute_st0_helper(this,attr_id,length_max,attr_name,attr_val)
+    SUBROUTINE read_attribute_st0_helper(attr_id,length_max,attr_val)
        CHARACTER(LEN=*),PARAMETER :: myName='read_attribute_st0_helper_HDF5FileType'
-       CLASS(HDF5FileType),INTENT(INOUT) :: this
-       CHARACTER(LEN=*),INTENT(IN) :: attr_name
        TYPE(StringType),INTENT(INOUT)::attr_val
        INTEGER(SDK),INTENT(IN) :: length_max
         

--- a/src/UnitTest.h
+++ b/src/UnitTest.h
@@ -60,7 +60,7 @@
 #define ASSERT_APPROXEQA(b,a,msg) ASSERT(b.APPROXEQA.a,msg); FINFO()b,"/=",a
 
 ! ASSERT_SOFTEQ used for comparing reals within user defiend tolerance
-#define ASSERT_SOFTEQ(b,a,c,msg) ASSERT(SOFTEQ(b,a,c),msg); FINFO()b,"/=",a,"+",c
+#define ASSERT_SOFTEQ(b,a,c,msg) ASSERT(SOFTEQ(b,a,c),msg); FINFO()b,"/=",a,c
 
 #define ASSERTFAIL(bool,msg)  ASSERT(bool,msg); IF(utest_lastfail) STOP UTEST_FAIL_CODE
 

--- a/src/UnitTest.h
+++ b/src/UnitTest.h
@@ -27,22 +27,40 @@
 #define ASSERT(bool,msg)  CALL UTest_Assert(bool,__LINE__,msg)
 
 ! ASSERT_EQ used when values should be exactly equal
-#define ASSERT_EQ(val1,val2,msg) ASSERT(val1==val2,msg);FINFO() val1, " Should be ", val2
+#define ASSERT_EQ(b,a,msg) ASSERT(b==a,msg);FINFO() b, "Not =", a
+
+! ASSERT_LE used when b <= a
+#define ASSERT_LE(b,a,msg) ASSERT(b.LE.a,msg);FINFO() b, "Not <= ", a
+
+! ASSERT_LT used when b < a
+#define ASSERT_LT(b,a,msg) ASSERT(b.LT.a,msg);FINFO() b, "Not < ", a
+
+! ASSERT_GE used when b >= a
+#define ASSERT_GE(b,a,msg) ASSERT(b.GE.a,msg);FINFO() b, "Not >= ", a
+
+! ASSERT_GT used when b > a
+#define ASSERT_GT(b,a,msg) ASSERT(b.GT.a,msg);FINFO() b, "Not >", a
 
 ! ASSERT_APPROXEQ used when values are equal within specified precision
-#define ASSERT_APPROXEQ(val1,val2,msg) ASSERT(val1.APPROXEQ.val2,msg); FINFO()val1,val2
+#define ASSERT_APPROXEQ(b,a,msg) ASSERT(b.APPROXEQ.a,msg); FINFO()b,"/=",a
+
+! ASSERT_APPROXLE used when values are equal within specified precision
+#define ASSERT_APPROXLE(b,a,msg) ASSERT(b.APPROXLE.a,msg); FINFO()b,"Not <=",a
+
+! ASSERT_APPROXGE used when values are equal within specified precision
+#define ASSERT_APPROXGE(b,a,msg) ASSERT(b.APPROXGE.a,msg); FINFO()b,"Not >=",a
 
 ! ASSERT_APPROXEQF used to determine bitwise equivalence of reals
-#define ASSERT_APPROXEQF(val1,val2,msg) ASSERT(val1.APPROXEQF.val2,msg); FINFO() val1, val2
+#define ASSERT_APPROXEQF(b,a,msg) ASSERT(b.APPROXEQF.a,msg); FINFO() b,"/=", a
 
 ! ASSERT_APPROXEQR used to determine equivalence of very large or very small numbers
-#define ASSERT_APPROXEQR(val1,val2,msg) ASSERT(val1.APPROXEQR.val2,msg); FINFO() val1,val2
+#define ASSERT_APPROXEQR(b,a,msg) ASSERT(b.APPROXEQR.a,msg); FINFO() b,"/=",a
 
 ! ASSERT_APPROXEQA used for reals where equality is a comparison to defined epsilon 
-#define ASSERT_APPROXEQA(val1,val2,msg) ASSERT(val1.APPROXEQA.val2,msg); FINFO()val1,val2
+#define ASSERT_APPROXEQA(b,a,msg) ASSERT(b.APPROXEQA.a,msg); FINFO()b,"/=",a
 
 ! ASSERT_SOFTEQ used for comparing reals within user defiend tolerance
-#define ASSERT_SOFTEQ(val1,val2,tol,msg) ASSERT(SOFTEQ(val1,val2,tol),msg); FINFO()val1,val2,tol
+#define ASSERT_SOFTEQ(b,a,c,msg) ASSERT(SOFTEQ(b,a,c),msg); FINFO()b,"/=",a,"+",c
 
 #define ASSERTFAIL(bool,msg)  ASSERT(bool,msg); IF(utest_lastfail) STOP UTEST_FAIL_CODE
 

--- a/src/UnitTest.h
+++ b/src/UnitTest.h
@@ -26,6 +26,24 @@
 ! Removed __FILE__ from ASSERT because path is too long
 #define ASSERT(bool,msg)  CALL UTest_Assert(bool,__LINE__,msg)
 
+! ASSERT_EQ used when values should be exactly equal
+#define ASSERT_EQ(val1,val2,msg) ASSERT(val1==val2,msg);FINFO() val1, " Should be ", val2
+
+! ASSERT_APPROXEQ used when values are equal within specified precision
+#define ASSERT_APPROXEQ(val1,val2,msg) ASSERT(val1.APPROXEQ.val2,msg); FINFO()val1,val2
+
+! ASSERT_APPROXEQF used to determine bitwise equivalence of reals
+#define ASSERT_APPROXEQF(val1,val2,msg) ASSERT(val1.APPROXEQF.val2,msg); FINFO() val1, val2
+
+! ASSERT_APPROXEQR used to determine equivalence of very large or very small numbers
+#define ASSERT_APPROXEQR(val1,val2,msg) ASSERT(val1.APPROXEQR.val2,msg); FINFO() val1,val2
+
+! ASSERT_APPROXEQA used for reals where equality is a comparison to defined epsilon 
+#define ASSERT_APPROXEQA(val1,val2,msg) ASSERT(val1.APPROXEQA.val2,msg); FINFO()val1,val2
+
+! ASSERT_SOFTEQ used for comparing reals within user defiend tolerance
+#define ASSERT_SOFTEQ(val1,val2,tol,msg) ASSERT(SOFTEQ(val1,val2,tol),msg); FINFO()val1,val2,tol
+
 #define ASSERTFAIL(bool,msg)  ASSERT(bool,msg); IF(utest_lastfail) STOP UTEST_FAIL_CODE
 
 #define STAY()  IF(utest_interactive) CALL UTest_Stay()

--- a/unit_tests/testHDF5FileType/testHDF5FileType.f90
+++ b/unit_tests/testHDF5FileType/testHDF5FileType.f90
@@ -761,7 +761,7 @@ PROGRAM testHDF5
       CALL h5%read_attribute('groupB->memB1',string_name,testST0)
       ASSERT(refST0==testST0,'string read fail')
       CALL h5%read_attribute('groupB->memB2',real_name,testD0)
-      ASSERT(refD0==testD0,'real_read fail')
+      ASSERT_SOFTEQ(refD0,testD0,1.E-12_SRK,'l')
 
       CALL h5%fread('groupR->memD0',testD0)
       ASSERT(testD0==refD0,'D0 Write Failure')

--- a/unit_tests/testUnitTest/testUnitTest.f90
+++ b/unit_tests/testUnitTest/testUnitTest.f90
@@ -9,6 +9,7 @@
 PROGRAM testUnitTest
 #include "UnitTest.h"
   USE UnitTest
+  USE IntrType
   IMPLICIT NONE
 
 #ifdef HAVE_MPI
@@ -25,17 +26,21 @@ PROGRAM testUnitTest
   SET_PREFIX("testUTest")
 
   ! Subtests
-  REGISTER_SUBTEST("A",mysubroutineA)
-
-  REGISTER_SUBTEST("B",mysubroutineB)
-
+  REGISTER_SUBTEST("ASSERT Test",testASSERT)
+  REGISTER_SUBTEST("ASSERT_SOFTEQ_SDK Test",testASSERT_SOFTEQ_SDK)
+  REGISTER_SUBTEST("ASSERT_SOFTEQ_SSK Test",testASSERT_SOFTEQ_SSK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQA_SDK Test",testASSERT_APPROXEQA_SDK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQA_SSK Test",testASSERT_APPROXEQA_SSK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQF_SDK",testASSERT_APPROXEQF_SDK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQF_SSK",testASSERT_APPROXEQF_SSK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQ_SDK Test",testASSERT_APPROXEQ_SDK)
+  REGISTER_SUBTEST("ASSERT_APPROXEQ_SSK Test",testASSERT_APPROXEQ_SSK)
+  REGISTER_SUBTEST("ASSERT_EQ_SDK Test",testASSERT_EQ_SDK)
+  REGISTER_SUBTEST("ASSERT_EQ_SSK Test",testASSERT_EQ_SSK)
   ASSERT(.TRUE.,"in main")
-
-  REGISTER_SUBTEST("C",mysubroutineC)
-
   ! NEVER DO THIS IN YOUR UNIT TEST
-  !    This is testing failures as well as passing tests.  Expect 3 failures.
-  utest_nfail=utest_nfail-3
+  !    This is testing failures as well as passing tests.  Expect 21 failures.
+  utest_nfail=utest_nfail-21
   FINALIZE_TEST()
 
   STAY()
@@ -47,20 +52,94 @@ PROGRAM testUnitTest
   CONTAINS
 !
 !-------------------------------------------------------------------------------
-!> @brief description
-!> @param parameter    description
+!> @brief Tests the ASSERT macro and associated function calls 
 !>
-!> description
+    SUBROUTINE testASSERT()
+      COMPONENT_TEST("Passing ASSERT")
+        ASSERT(.TRUE.,"ASSERT given passing condtion")
+        FINFO() "   This is a test that you shouldn't see"
+      COMPONENT_TEST("Failing ASSERT")
+        ASSERT(.FALSE.,"Assert given failing condition")
+        FINFO() "   This is a test that you should see fail"
+    ENDSUBROUTINE testASSERT
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_SOFTEQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
 !>
-    SUBROUTINE mysubroutineA()
-      COMPONENT_TEST("SubA_1")
-        ASSERT(.TRUE.,"test 1")
-        FINFO() "This is a test that you shouldn't see"
-      COMPONENT_TEST("SubA_2")
-        ASSERTFAIL(.TRUE.,"test 2")
-        ASSERT(.FALSE.,"test 3")
-        FINFO() "This is a test that you should see"
-    ENDSUBROUTINE mysubroutineA
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing SOFTEQ to fail.
+!>
+    SUBROUTINE testASSERT_SOFTEQ_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-14_SDK
+      c=a+1.0E-14_SDK
+      d=a-0.98E-14_SDK
+      e=a-1.02E-14_SDK
+
+      COMPONENT_TEST("Passing SOFTEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_SOFTEQ(a,b,tol,'ASSERT_SOFTEQ given passing condition')
+      COMPONENT_TEST("Passing SOFTEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_SOFTEQ(a,d,tol,'ASSERT_SOFTEQ given passing condition')
+      COMPONENT_TEST("Failing SOFTEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_SOFTEQ(a,c,tol,'ASSERT_SOFTEQ given failing condition')
+      COMPONENT_TEST("Failing SOFTEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_SOFTEQ(a,e,tol,'ASSERT_SOFTEQ given failing condition')
+    ENDSUBROUTINE testASSERT_SOFTEQ_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_SOFTEQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing SOFTEQ to fail.
+!>
+    SUBROUTINE testASSERT_SOFTEQ_SSK()
+      REAL(SSK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SSK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-5_SSK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-5_SSK
+      c=a+1.0E-5_SSK
+      d=a-0.98E-5_SSK
+      e=a-1.0E-5_SSK
+
+      COMPONENT_TEST("Passing SOFTEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_SOFTEQ(a,b,tol,'ASSERT_SOFTEQ given passing condition')
+      COMPONENT_TEST("Passing SOFTEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_SOFTEQ(a,d,tol,'ASSERT_SOFTEQ given passing condition')
+      COMPONENT_TEST("Failing SOFTEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_SOFTEQ(a,c,tol,'ASSERT_SOFTEQ given failing condition')
+      COMPONENT_TEST("Failing SOFTEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_SOFTEQ(a,e,tol,'ASSERT_SOFTEQ given failing condition')
+    ENDSUBROUTINE testASSERT_SOFTEQ_SSK
 !
 !-------------------------------------------------------------------------------
 !> @brief description
@@ -68,12 +147,29 @@ PROGRAM testUnitTest
 !>
 !> description
 !>
-    SUBROUTINE mysubroutineB()
-      COMPONENT_TEST("SubB")
-        ASSERT(.TRUE.,"test 1")
-        ASSERTFAIL(.TRUE.,"test 2")
-        ASSERT(.FALSE.,"test 3")
-    ENDSUBROUTINE mysubroutineB
+    SUBROUTINE testASSERT_APPROXEQA_SDK()
+      REAL(SDK):: a,b,c,d,e
+
+      a=2.0_SDK
+      b=a+0.98E-14_SDK
+      c=a+1.0E-14_SDK
+      d=a-0.98E-14_SDK
+      e=a-1.02E-14_SDK
+
+      COMPONENT_TEST("Passing APPROXEQA")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQA(a,b,"ASSERT_APPROXEQA given passing condition")
+      COMPONENT_TEST("Passing APPROXEQA")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQA(a,d,"ASSERT_APPROXEQA given passing condition")
+      COMPONENT_TEST("Failing APPROXEQA")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQA(a,c,"ASSERT_APPROXEQA given failing condition")
+      COMPONENT_TEST("Failing APPROXEQA")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQA(a,e,"ASSERT_APPROXEQA given failing condition")
+    ENDSUBROUTINE testASSERT_APPROXEQA_SDK
+
 !
 !-------------------------------------------------------------------------------
 !> @brief description
@@ -81,14 +177,237 @@ PROGRAM testUnitTest
 !>
 !> description
 !>
-    SUBROUTINE mysubroutineC()
-      COMPONENT_TEST("SubC")
-        ASSERT(.TRUE.,"test 1")
-        ASSERTFAIL(.TRUE.,"test 2")
-        ASSERT(.FALSE.,"test 3")
+    SUBROUTINE testASSERT_APPROXEQA_SSK()
+      REAL(SSK):: a,b,c,d,e
+      a=2.0_SSK
+      b=a+0.98E-05_SSK
+      c=a+1.00E-05_SSK
+      d=a-0.98E-05_SSK
+      e=a-1.00E-05_SSK
 
 
-    ENDSUBROUTINE mysubroutineC
+      COMPONENT_TEST("Passing APPROXEQA")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQA(a,b,"ASSERT_APPROXEQA given passing condition")
+      COMPONENT_TEST("Passing APPROXEQA")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQA(a,d,"ASSERT_APPROXEQA given passing condition")
+      COMPONENT_TEST("Failing APPROXEQA")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQA(a,c,"ASSERT_APPROXEQA given failing condition")
+      COMPONENT_TEST("Failing APPROXEQA")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQA(a,e,"ASSERT_APPROXEQA given failing condition")
+    ENDSUBROUTINE testASSERT_APPROXEQA_SSK
 !
+!-------------------------------------------------------------------------------
+!> @brief description
+!> @param parameter    description
+!>
+!> description
+!>
+    SUBROUTINE testASSERT_APPROXEQF_SSK()
+      REAL(SSK):: a,b,c,d,e
+      a=2.0_SSK
+      b=a+0.0000025_SSK
+      c=a+0.0000026_SSK
+      d=a-0.0000012_SSK
+      e=a-0.0000013_SSK
+
+      COMPONENT_TEST("Passing _APPROXEQF")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQF(a,b,"should PASS")
+      COMPONENT_TEST("Passing _APPROXEQF")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQF(a,d,"should PASS")
+      COMPONENT_TEST("Failing _APPROXEQF")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQF(a,c,"should FAIL")
+      COMPONENT_TEST("Failing _APPROXEQF")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQF(a,e,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXEQF_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief description
+!> @param parameter    description
+!>
+!> description
+!>
+    SUBROUTINE testASSERT_APPROXEQF_SDK()
+      REAL(SDK):: a,b,c,d,e
+      a=2.0_SDK
+      b=a+0.0000000000000046_SDK
+      c=a+0.0000000000000047_SDK
+      d=a-0.0000000000000023_SDK
+      e=a-0.0000000000000024_SDK
+
+      COMPONENT_TEST("Passing _APPROXEQF")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQF(a,b,"should PASS")
+      COMPONENT_TEST("Passing _APPROXEQF")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQF(a,d,"should PASS")
+      COMPONENT_TEST("Failing _APPROXEQF")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQF(a,c,"should FAIL")
+      COMPONENT_TEST("Failing _APPROXEQF")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQF(a,e,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXEQF_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXEQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing APPROXEQ to fail.
+!>
+    SUBROUTINE testASSERT_APPROXEQ_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-14_SDK
+      c=a+1.5E-14_SDK
+      d=a-0.98E-14_SDK
+      e=a-1.02E-14_SDK
+
+      COMPONENT_TEST("Passing APPROXEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQ(a,b,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Passing APPROXEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQ(a,d,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Failing APPROXEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQ(a,c,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Failing APPROXEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQ(a,e,'ASSERT_APPROXEQ given failing condition')
+    ENDSUBROUTINE testASSERT_APPROXEQ_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXEQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing APPROXEQ to fail.
+!>
+    SUBROUTINE testASSERT_APPROXEQ_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-5_SSK
+      c=a+1.5E-5_SSK
+      d=a-0.98E-5_SSK
+      e=a-1.0E-5_SSK
+
+      COMPONENT_TEST("Passing APPROXEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQ(a,b,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Passing APPROXEQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXEQ(a,d,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Failing APPROXEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQ(a,c,'ASSERT_APPROXEQ given failing condition')
+      COMPONENT_TEST("Failing APPROXEQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXEQ(a,e,'ASSERT_APPROXEQ given failing condition')
+    ENDSUBROUTINE testASSERT_APPROXEQ_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_EQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing EQ to fail.
+!>
+    SUBROUTINE testASSERT_EQ_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+0.5E-15_SDK
+      d=a
+      e=a-0.2E-15_SDK
+
+      COMPONENT_TEST("Passing EQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_EQ(a,b,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Passing EQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_EQ(a,d,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Failing EQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_EQ(a,c,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Failing EQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_EQ(a,e,'ASSERT_EQ given failing condition')
+    ENDSUBROUTINE testASSERT_EQ_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_EQ macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+!> Supply reference and tolerance values. Construct two test values inside of
+!> the range [a-tol,a+tol], and two outside of the range. Esxpect tests named
+!> Failing EQ to fail.
+!>
+    SUBROUTINE testASSERT_EQ_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+1.2E-7_SSK
+      d=a
+      e=a-0.7E-7_SSK
+
+      COMPONENT_TEST("Passing EQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_EQ(a,b,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Passing EQ")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_EQ(a,d,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Failing EQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_EQ(a,c,'ASSERT_EQ given failing condition')
+      COMPONENT_TEST("Failing EQ")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_EQ(a,e,'ASSERT_EQ given failing condition')
+    ENDSUBROUTINE testASSERT_EQ_SSK
 ENDPROGRAM testUnitTest
 

--- a/unit_tests/testUnitTest/testUnitTest.f90
+++ b/unit_tests/testUnitTest/testUnitTest.f90
@@ -37,10 +37,22 @@ PROGRAM testUnitTest
   REGISTER_SUBTEST("ASSERT_APPROXEQ_SSK Test",testASSERT_APPROXEQ_SSK)
   REGISTER_SUBTEST("ASSERT_EQ_SDK Test",testASSERT_EQ_SDK)
   REGISTER_SUBTEST("ASSERT_EQ_SSK Test",testASSERT_EQ_SSK)
+  REGISTER_SUBTEST("ASSERT_LE_SDK Test",testASSERT_LE_SDK)
+  REGISTER_SUBTEST("ASSERT_LE_SSK Test",testASSERT_LE_SSK)
+  REGISTER_SUBTEST("ASSERT_LT_SDK Test",testASSERT_LT_SDK)
+  REGISTER_SUBTEST("ASSERT_LT_SSK Test",testASSERT_LT_SSK)
+  REGISTER_SUBTEST("ASSERT_GE_SDK Test",testASSERT_GE_SDK)
+  REGISTER_SUBTEST("ASSERT_GE_SSK Test",testASSERT_GE_SSK)
+  REGISTER_SUBTEST("ASSERT_GT_SDK Test",testASSERT_GT_SDK)
+  REGISTER_SUBTEST("ASSERT_GT_SSK Test",testASSERT_GT_SSK)
+  REGISTER_SUBTEST("ASSERT_APPROXLE_SDK Test",testASSERT_APPROXLE_SDK)
+  REGISTER_SUBTEST("ASSERT_APPROXLE_SSK Test",testASSERT_APPROXLE_SSK)
+  REGISTER_SUBTEST("ASSERT_APPROXGE_SDK Test",testASSERT_APPROXGE_SDK)
+  REGISTER_SUBTEST("ASSERT_APPROXGE_SSK Test",testASSERT_APPROXGE_SSK)
   ASSERT(.TRUE.,"in main")
   ! NEVER DO THIS IN YOUR UNIT TEST
-  !    This is testing failures as well as passing tests.  Expect 21 failures.
-  utest_nfail=utest_nfail-21
+  !    This is testing failures as well as passing tests.  Expect 37 failures.
+  utest_nfail=utest_nfail-37
   FINALIZE_TEST()
 
   STAY()
@@ -90,16 +102,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing SOFTEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_SOFTEQ(a,b,tol,'ASSERT_SOFTEQ given passing condition')
+        ASSERT_SOFTEQ(b,a,tol,'ASSERT_SOFTEQ given passing condition')
       COMPONENT_TEST("Passing SOFTEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_SOFTEQ(a,d,tol,'ASSERT_SOFTEQ given passing condition')
+        ASSERT_SOFTEQ(d,a,tol,'ASSERT_SOFTEQ given passing condition')
       COMPONENT_TEST("Failing SOFTEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_SOFTEQ(a,c,tol,'ASSERT_SOFTEQ given failing condition')
+        ASSERT_SOFTEQ(c,a,tol,'ASSERT_SOFTEQ given failing condition')
       COMPONENT_TEST("Failing SOFTEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_SOFTEQ(a,e,tol,'ASSERT_SOFTEQ given failing condition')
+        ASSERT_SOFTEQ(e,a,tol,'ASSERT_SOFTEQ given failing condition')
     ENDSUBROUTINE testASSERT_SOFTEQ_SDK
 !
 !-------------------------------------------------------------------------------
@@ -129,16 +141,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing SOFTEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_SOFTEQ(a,b,tol,'ASSERT_SOFTEQ given passing condition')
+        ASSERT_SOFTEQ(b,a,tol,'ASSERT_SOFTEQ given passing condition')
       COMPONENT_TEST("Passing SOFTEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_SOFTEQ(a,d,tol,'ASSERT_SOFTEQ given passing condition')
+        ASSERT_SOFTEQ(d,a,tol,'ASSERT_SOFTEQ given passing condition')
       COMPONENT_TEST("Failing SOFTEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_SOFTEQ(a,c,tol,'ASSERT_SOFTEQ given failing condition')
+        ASSERT_SOFTEQ(c,a,tol,'ASSERT_SOFTEQ given failing condition')
       COMPONENT_TEST("Failing SOFTEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_SOFTEQ(a,e,tol,'ASSERT_SOFTEQ given failing condition')
+        ASSERT_SOFTEQ(e,a,tol,'ASSERT_SOFTEQ given failing condition')
     ENDSUBROUTINE testASSERT_SOFTEQ_SSK
 !
 !-------------------------------------------------------------------------------
@@ -158,16 +170,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing APPROXEQA")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQA(a,b,"ASSERT_APPROXEQA given passing condition")
+        ASSERT_APPROXEQA(b,a,"ASSERT_APPROXEQA given passing condition")
       COMPONENT_TEST("Passing APPROXEQA")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQA(a,d,"ASSERT_APPROXEQA given passing condition")
+        ASSERT_APPROXEQA(d,a,"ASSERT_APPROXEQA given passing condition")
       COMPONENT_TEST("Failing APPROXEQA")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQA(a,c,"ASSERT_APPROXEQA given failing condition")
+        ASSERT_APPROXEQA(c,a,"ASSERT_APPROXEQA given failing condition")
       COMPONENT_TEST("Failing APPROXEQA")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQA(a,e,"ASSERT_APPROXEQA given failing condition")
+        ASSERT_APPROXEQA(e,a,"ASSERT_APPROXEQA given failing condition")
     ENDSUBROUTINE testASSERT_APPROXEQA_SDK
 
 !
@@ -188,16 +200,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing APPROXEQA")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQA(a,b,"ASSERT_APPROXEQA given passing condition")
+        ASSERT_APPROXEQA(b,a,"ASSERT_APPROXEQA given passing condition")
       COMPONENT_TEST("Passing APPROXEQA")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQA(a,d,"ASSERT_APPROXEQA given passing condition")
+        ASSERT_APPROXEQA(d,a,"ASSERT_APPROXEQA given passing condition")
       COMPONENT_TEST("Failing APPROXEQA")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQA(a,c,"ASSERT_APPROXEQA given failing condition")
+        ASSERT_APPROXEQA(c,a,"ASSERT_APPROXEQA given failing condition")
       COMPONENT_TEST("Failing APPROXEQA")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQA(a,e,"ASSERT_APPROXEQA given failing condition")
+        ASSERT_APPROXEQA(e,a,"ASSERT_APPROXEQA given failing condition")
     ENDSUBROUTINE testASSERT_APPROXEQA_SSK
 !
 !-------------------------------------------------------------------------------
@@ -216,16 +228,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing _APPROXEQF")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQF(a,b,"should PASS")
+        ASSERT_APPROXEQF(b,a,"should PASS")
       COMPONENT_TEST("Passing _APPROXEQF")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQF(a,d,"should PASS")
+        ASSERT_APPROXEQF(d,a,"should PASS")
       COMPONENT_TEST("Failing _APPROXEQF")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQF(a,c,"should FAIL")
+        ASSERT_APPROXEQF(c,a,"should FAIL")
       COMPONENT_TEST("Failing _APPROXEQF")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQF(a,e,"should FAIL")
+        ASSERT_APPROXEQF(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_APPROXEQF_SSK
 !
 !-------------------------------------------------------------------------------
@@ -244,16 +256,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing _APPROXEQF")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQF(a,b,"should PASS")
+        ASSERT_APPROXEQF(b,a,"should PASS")
       COMPONENT_TEST("Passing _APPROXEQF")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQF(a,d,"should PASS")
+        ASSERT_APPROXEQF(d,a,"should PASS")
       COMPONENT_TEST("Failing _APPROXEQF")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQF(a,c,"should FAIL")
+        ASSERT_APPROXEQF(c,a,"should FAIL")
       COMPONENT_TEST("Failing _APPROXEQF")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQF(a,e,"should FAIL")
+        ASSERT_APPROXEQF(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_APPROXEQF_SDK
 !
 !-------------------------------------------------------------------------------
@@ -283,16 +295,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing APPROXEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQ(a,b,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(b,a,"should PASS")
       COMPONENT_TEST("Passing APPROXEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQ(a,d,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(d,a,"should PASS")
       COMPONENT_TEST("Failing APPROXEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQ(a,c,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(c,a,"should FAIL")
       COMPONENT_TEST("Failing APPROXEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQ(a,e,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_APPROXEQ_SDK
 !
 !-------------------------------------------------------------------------------
@@ -321,16 +333,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing APPROXEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQ(a,b,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(b,a,"should PASS")
       COMPONENT_TEST("Passing APPROXEQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_APPROXEQ(a,d,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(d,a,"should PASS")
       COMPONENT_TEST("Failing APPROXEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQ(a,c,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(c,a,"should FAIL")
       COMPONENT_TEST("Failing APPROXEQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_APPROXEQ(a,e,'ASSERT_APPROXEQ given failing condition')
+        ASSERT_APPROXEQ(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_APPROXEQ_SSK
 !
 !-------------------------------------------------------------------------------
@@ -360,16 +372,16 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing EQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_EQ(a,b,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(b,a,"should PASS")
       COMPONENT_TEST("Passing EQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_EQ(a,d,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(d,a,"should PASS")
       COMPONENT_TEST("Failing EQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_EQ(a,c,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(c,a,"should FAIL")
       COMPONENT_TEST("Failing EQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_EQ(a,e,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_EQ_SDK
 !
 !-------------------------------------------------------------------------------
@@ -398,16 +410,397 @@ PROGRAM testUnitTest
 
       COMPONENT_TEST("Passing EQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_EQ(a,b,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(b,a,"should PASS")
       COMPONENT_TEST("Passing EQ")
       ! Test maximum delta without a failure, this should not cause output
-        ASSERT_EQ(a,d,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(d,a,"should PASS")
       COMPONENT_TEST("Failing EQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_EQ(a,c,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(c,a,"should FAIL")
       COMPONENT_TEST("Failing EQ")
       ! Test minimum delta to cause a failure, this should cause output
-        ASSERT_EQ(a,e,'ASSERT_EQ given failing condition')
+        ASSERT_EQ(e,a,"should FAIL")
     ENDSUBROUTINE testASSERT_EQ_SSK
-ENDPROGRAM testUnitTest
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_LE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_LE_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+0.5E-15_SDK
+      e=a-0.2E-15_SDK
 
+      COMPONENT_TEST("Passing LE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LE(b,a,"should PASS")
+      COMPONENT_TEST("Passing LE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LE(e,a,"should PASS")
+      COMPONENT_TEST("Failing LE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LE(c,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_LE_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_LE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_LE_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+1.2E-7_SSK
+      e=a-0.7E-7_SSK
+
+      COMPONENT_TEST("Passing LE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LE(b,a,"should PASS")
+      COMPONENT_TEST("Passing LE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LE(e,a,"should PASS")
+      COMPONENT_TEST("Failing LE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LE(c,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_LE_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_LT macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_LT_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+0.5E-15_SDK
+      e=a-0.2E-15_SDK
+
+      COMPONENT_TEST("Passing LT")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LT(e,a,"should PASS")
+      COMPONENT_TEST("Failing LT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LT(c,a,"should FAIL")
+      COMPONENT_TEST("Failing LT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LT(b,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_LT_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_LT macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_LT_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+1.2E-7_SSK
+      e=a-0.7E-7_SSK
+
+      COMPONENT_TEST("Passing LT")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_LT(e,a,"should PASS")
+      COMPONENT_TEST("Failing LT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LT(c,a,"should FAIL")
+      COMPONENT_TEST("Failing LT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_LT(b,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_LT_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_GE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_GE_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+0.5E-15_SDK
+      e=a-0.2E-15_SDK
+
+      COMPONENT_TEST("Passing GE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GE(b,a,"should PASS")
+      COMPONENT_TEST("Passing GE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GE(c,a,"should PASS")
+      COMPONENT_TEST("Failing GE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GE(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_GE_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_GE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_GE_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+1.2E-7_SSK
+      e=a-0.7E-7_SSK
+
+      COMPONENT_TEST("Passing GE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GE(b,a,"should PASS")
+      COMPONENT_TEST("Passing GE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GE(c,a,"should PASS")
+      COMPONENT_TEST("Failing GE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GE(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_GE_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_GT macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_GT_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+0.5E-15_SDK
+      e=a-0.2E-15_SDK
+
+      COMPONENT_TEST("Passing GT")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GT(c,a,"should PASS")
+      COMPONENT_TEST("Failing GT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GT(b,a,"should FAIL")
+      COMPONENT_TEST("Failing GT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GT(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_GT_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_GT macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_GT_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a
+      c=a+1.2E-7_SSK
+      e=a-0.7E-7_SSK
+
+      COMPONENT_TEST("Passing GT")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_GT(c,a,"should PASS")
+      COMPONENT_TEST("Failing GT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GT(b,a,"should FAIL")
+      COMPONENT_TEST("Failing GT")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_GT(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_GT_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXLE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_APPROXLE_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-14_SDK
+      c=a+1.5E-14_SDK
+      d=a-0.98E-14_SDK
+      e=a-1.02E-14_SDK
+
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(b,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(e,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(d,a,"should PASS")
+      COMPONENT_TEST("Failing APPROXLE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXLE(c,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXLE_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXLE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_APPROXLE_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-5_SSK
+      c=a+1.5E-5_SSK
+      d=a-0.98E-5_SSK
+      e=a-1.0E-5_SSK
+
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(b,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(e,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXLE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXLE(d,a,"should PASS")
+      COMPONENT_TEST("Failing APPROXLE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXLE(c,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXLE_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXGE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_APPROXGE_SDK()
+      REAL(SDK):: a,b,c,d,e,tol
+      !Initialize ref value
+      a=2.0_SDK
+      ! Declare a tolerance to test functionality of the statements
+      tol=1.0E-14_SDK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-14_SDK
+      c=a+1.5E-14_SDK
+      d=a-0.98E-14_SDK
+      e=a-1.02E-14_SDK
+
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(b,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(c,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(d,a,"should PASS")
+      COMPONENT_TEST("Failing APPROXGE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXGE(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXGE_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Tests the ASSERT_APPROXGE macro and associated function calss
+!> @param a - reference value
+!> @param b - test value
+!> @param c - test value
+!> @param d - test value
+!> @param e - test value
+!> @param tol - tolerance for test
+!>
+    SUBROUTINE testASSERT_APPROXGE_SSK()
+      REAL(SSK):: a,b,c,d,e
+
+      !Initialize ref value
+      a=2.0_SSK
+      ! Initialize test values on either side of tolerance
+      b=a+0.98E-5_SSK
+      c=a+1.5E-5_SSK
+      d=a-0.98E-5_SSK
+      e=a-1.0E-5_SSK
+
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(b,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(c,a,"should PASS")
+      COMPONENT_TEST("Passing APPROXGE")
+      ! Test maximum delta without a failure, this should not cause output
+        ASSERT_APPROXGE(d,a,"should PASS")
+      COMPONENT_TEST("Failing APPROXGE")
+      ! Test minimum delta to cause a failure, this should cause output
+        ASSERT_APPROXGE(e,a,"should FAIL")
+    ENDSUBROUTINE testASSERT_APPROXGE_SSK
+ENDPROGRAM testUnitTest


### PR DESCRIPTION
Add new ASSERT macros to unit_test.h to support outputting test and reference values on failure. Add tests for the new macros.

tested locally using HDF attribute read/write functions during setup. Eliminated a few unused variables in the process.