### PR TITLE
Change release flag for GNU from Ofast to O3

### DIFF
--- a/cmake/Futility_Configurations.cmake
+++ b/cmake/Futility_Configurations.cmake
@@ -269,7 +269,7 @@ ELSEIF(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
        )
 
     SET(Fortran_FLAGS_RELEASE
-        ${CSYM}Ofast
+        ${CSYM}O3
        )
 ELSEIF(CMAKE_Fortran_COMPILER_ID STREQUAL "PGI")
 


### PR DESCRIPTION
We were using Ofast which enables non-standards-compliant optimizations.
Namely flushing subnormal floats to zero, which was causing actual
issues in some cases. The only remotely safe optimization is the
-fstack-arrays, which has also bit us a couple of times.