### PR TITLE
Add -Werror=unused-variables flag for GNU

### DIFF
--- a/cmake/Futility_Configurations.cmake
+++ b/cmake/Futility_Configurations.cmake
@@ -219,6 +219,7 @@ ELSEIF(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         ${CSYM}cpp
         ${CSYM}fall-intrinsics
         ${CSYM}ffree-line-length-none
+        ${CSYM}Werror=unused-variable
        )
 
     SET(C_FLAGS


### PR DESCRIPTION
This should help in the dev process so we dont have to wait until
running on the CI before we find out that we missed something. We can
add more -Werror= flags as we squash more classes of warning