### PR TITLE
Removes DBC_ from REQUIRE and ENSURE interface

### DIFF
--- a/src/DBC.h
+++ b/src/DBC.h
@@ -8,9 +8,9 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 
 #ifdef FUTILITY_DBC
-#define DBC_REQUIRE(test)  IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
-#define DBC_ENSURE(test)   IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
+#define REQUIRE(test)  IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
+#define ENSURE(test)   IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
 #else
-#define DBC_REQUIRE(test)  ! DBC REQUIRE - test
-#define DBC_ENSURE(test)   ! DBC ENSURE  - test
+#define REQUIRE(test)  ! DBC REQUIRE - test
+#define ENSURE(test)   ! DBC ENSURE  - test
 #endif

--- a/unit_tests/testDBC/testDBC.f90
+++ b/unit_tests/testDBC/testDBC.f90
@@ -48,7 +48,7 @@ PROGRAM testDBC
 !>
     SUBROUTINE require_pass()
       WRITE(*,*) "Testing REQUIRE Passing"
-      DBC_REQUIRE(5==5)
+      REQUIRE(5==5)
 
     ENDSUBROUTINE require_pass
 !
@@ -57,7 +57,7 @@ PROGRAM testDBC
 !>
     SUBROUTINE ensure_pass()
       WRITE(*,*) "Testing ENSURE Passing"
-      DBC_ENSURE(5==5)
+      ENSURE(5==5)
 
     ENDSUBROUTINE ensure_pass
 !
@@ -66,7 +66,7 @@ PROGRAM testDBC
 !>
     SUBROUTINE require_fail()
       WRITE(*,*) "Testing REQUIRE Failing"
-      DBC_REQUIRE(8==5)
+      REQUIRE(8==5)
 
     ENDSUBROUTINE require_fail
 !
@@ -75,7 +75,7 @@ PROGRAM testDBC
 !>
     SUBROUTINE ensure_fail()
       WRITE(*,*) "Testing ENSURE Failing"
-      DBC_ENSURE(5==8)
+      ENSURE(5==8)
 
     ENDSUBROUTINE ensure_fail
 ENDPROGRAM testDBC


### PR DESCRIPTION
Aaron discovered that having DBC_ in front of ENSURE and REQUIRE messes up the line numbers in gfortran 4.8.
It appears that pretty much any other combintation will not result in having the wrong line numbers.  He
tried not having DBC_, using ABC_, appending _DBC, even appending DbC_, and several other combinations.
Since the previous review made prepending DBC_ as optional, I'm reverting the names back to the original name.