### PR TITLE
Hotfix for changing characters to strings

### DIFF
--- a/src/VTUFiles.f90
+++ b/src/VTUFiles.f90
@@ -472,7 +472,7 @@ MODULE VTUFiles
     SUBROUTINE writepvtu_VTUXMLFileType(fileobj,funit,case,filen,procs,rank)
       CHARACTER(LEN=*),PARAMETER :: myName='writepvtu_VTUXMLFileType'
       CLASS(VTUXMLFileType),INTENT(INOUT) :: fileobj
-      TYPE(StringType),INTENT(IN) :: case,filen
+      CHARACTER(LEN=*),INTENT(IN) :: case,filen
       CHARACTER(LEN=128) :: sint
       INTEGER(SIK),INTENT(IN) :: funit,procs,rank
       INTEGER(SIK) :: i,j,iord

--- a/unit_tests/testVTUFiles/testVTUFiles.f90
+++ b/unit_tests/testVTUFiles/testVTUFiles.f90
@@ -187,7 +187,7 @@ PROGRAM testVTUFiles
       CALL MAKE_DIRECTORY('fsr_test',dir_status)
       str='test'
       str2='testPVTU'
-      CALL testVTUFile%writepvtu(666,str,str2,2,0)
+      CALL testVTUFile%writepvtu(666,TRIM(str),TRIM(str2),2,0)
       CALL testVTUFile%hasFile('testPVTU_0.vtu',bool)
       ASSERT(bool,'hasFile(...) testPVTU_0.vtu')
       CALL testVTUFile%hasFile('testPVTU_1.vtu',bool)


### PR DESCRIPTION
Description:
Character types can be variable length if they are dummy arguments.
These don't need to be changed to strings.