### PR TITLE
Fixes an issue with getMemUsage in Allocs

### DIFF
--- a/src/Allocs.f90
+++ b/src/Allocs.f90
@@ -641,26 +641,9 @@ MODULE Allocs
 !>
     FUNCTION getMemUsageChar_default() RESULT(memstring)
       CHARACTER(LEN=ALLOC_MEMSTRING_LENGTH) :: memstring
-      CHARACTER(LEN=5) :: unit
-      REAL(SRK) :: mem,bytes
-      REAL(SRK),PARAMETER :: KB2bytes=1024_SRK
-      REAL(SRK),PARAMETER :: MB2bytes=1048576_SRK
-      REAL(SRK),PARAMETER :: GB2bytes=1073741824_SRK
 
-      bytes=Alloc_nbytes
-      mem=bytes
-      unit='bytes'
-      IF(bytes >= KB2bytes .AND. bytes < MB2bytes) THEN
-        mem=bytes/KB2bytes
-        unit='KB'
-      ELSEIF(bytes >= MB2bytes .AND. bytes < GB2bytes) THEN
-        mem=bytes/MB2bytes
-        unit='MB'
-      ELSEIF(Alloc_nbytes >= GB2bytes) THEN
-        mem=bytes/GB2bytes
-        unit='GB'
-      ENDIF
-      WRITE(memstring,'(f8.2,a)') mem,' '//unit
+      memstring=getMemUsageChar_bytes(Alloc_nbytes)
+
     ENDFUNCTION getMemUsageChar_default
 !
 !-------------------------------------------------------------------------------
@@ -704,22 +687,11 @@ MODULE Allocs
     SUBROUTINE getMemUsage(memory,units)
       CHARACTER(LEN=*),INTENT(IN) :: units
       REAL(SRK),INTENT(INOUT) :: memory
-      CHARACTER(LEN=32) :: mem_string,mem_unit
       REAL(SRK),PARAMETER :: KB2bytes=1024_SRK
       REAL(SRK),PARAMETER :: MB2bytes=1048576_SRK
       REAL(SRK),PARAMETER :: GB2bytes=1073741824_SRK
 
-      ! Get memory usage for current process, then convert to bytes
-      mem_string=getMemUsageChar_default()
-      READ(mem_string,FMT='(f8.2,a)') memory,mem_unit
-      IF(TRIM(ADJUSTL(mem_unit))=='KB') THEN
-        memory=memory*KB2bytes
-      ELSEIF(TRIM(ADJUSTL(mem_unit))=='MB') THEN
-        memory=memory*MB2bytes
-      ELSEIF(TRIM(ADJUSTL(mem_unit))=='GB') THEN
-        memory=memory*GB2bytes
-      ENDIF
-
+      memory=Alloc_nbytes
       ! Total memory as bytes, convert to whatever was requrested
       IF(TRIM(ADJUSTL(units))=='KB') THEN
         memory=memory/KB2bytes

--- a/unit_tests/testAllocs/testAllocs.f90
+++ b/unit_tests/testAllocs/testAllocs.f90
@@ -65,16 +65,16 @@ PROGRAM testAllocs
 
       CALL dmallocA(tmpvar,1000000_SIK)
       CALL getMemUsage(memory,'whatever')
-      ASSERT(SOFTEQ(memory,8000634.87999_SRK,1.0E-4_SRK),'getMemUsage(memory,''bytes'')')
+      ASSERT(memory .APPROXEQA. 8000000.0_SRK,'getMemUsage(memory,''bytes'')')
 
       CALL getMemUsage(memory,'KB')
-      ASSERT(SOFTEQ(memory,7813.11999_SRK,1.0E-4_SRK),'getMemUsage(memory,''KB'')')
+      ASSERT(memory .APPROXEQA. 7812.5_SRK,'getMemUsage(memory,''KB'')')
 
       CALL getMemUsage(memory,'MB')
-      ASSERT(SOFTEQ(memory,7.62999999_SRK,1.0E-7_SRK),'getMemUsage(memory,''MB'')')
+      ASSERT(memory .APPROXEQA. 7.62939453125_SRK,'getMemUsage(memory,''MB'')')
 
       CALL getMemUsage(memory,'GB')
-      ASSERT(SOFTEQ(memory,0.00745117187_SRK,1.0E-10_SRK),'getMemUsage(memory,''GB'')')
+      ASSERT(memory .APPROXEQA. 7.450580596923828E-3_SRK,'getMemUsage(memory,''GB'')')
 
       CALL demallocA(tmpvar)
 


### PR DESCRIPTION
When using certain options in MPACT, the memstring variable returned
by getMemUsageChar_default had an unreadable value that caused an
ungraceful crash.  While this may ultimately be an issue with the
usage of Allocs in MPACT, these changes both eliminated redundant
code and resolved the ungraceful exit in MPACT.