### PR TITLE
Simplify usage of DBC

### DIFF
--- a/src/DBC.f90
+++ b/src/DBC.f90
@@ -41,7 +41,6 @@ MODULE DBC
 #endif
 
   PRIVATE
-
 !
 ! List of Public items
   PUBLIC :: DBC_FAIL
@@ -54,24 +53,28 @@ MODULE DBC
 !>
 !> Self-explanatory.
 !>
-SUBROUTINE DBC_FAIL(test_char,mod_name,line)
-  CHARACTER(LEN=*),INTENT(IN) :: test_char
-  CHARACTER(LEN=*),INTENT(IN) :: mod_name
-  INTEGER,INTENT(IN) :: line
-  !> Variables for MPI tests
-  INTEGER :: rank=0,nproc=1
+  SUBROUTINE DBC_FAIL(test_char,mod_name,line)
+    CHARACTER(LEN=*),INTENT(IN) :: test_char
+    CHARACTER(LEN=*),INTENT(IN) :: mod_name
+    INTEGER,INTENT(IN) :: line
+    !> Variables for MPI tests
+    INTEGER :: rank,nproc
 #ifdef HAVE_MPI
-  INTEGER :: mpierr
-  CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
-  CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+    INTEGER :: mpierr
+    CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
+    CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+#else
+    rank=0
+    nproc=1
 #endif
 
-  WRITE(ERROR_UNIT,'(a,i5,a,i5,a,i5)') "DBC Failure: " // test_char // " in " // mod_name // &
-        " on line",line,":  process",rank+1," of",nproc
+    WRITE(ERROR_UNIT,'(a,i5,a,i5,a,i5)') "DBC Failure: "//test_char//" in "// &
+      mod_name//" on line",line,":  process",rank+1," of",nproc
+
 #ifndef __INTEL_COMPILER
-  CALL backtrace()
+    CALL backtrace()
 #endif
-  STOP 2
-ENDSUBROUTINE DBC_FAIL
+    STOP 2
+  ENDSUBROUTINE DBC_FAIL
 !
 ENDMODULE DBC

--- a/src/DBC.h
+++ b/src/DBC.h
@@ -10,6 +10,7 @@
 #ifdef FUTILITY_DBC
 #define REQUIRE(test)  IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
 #define ENSURE(test)   IF(.NOT. (test)) CALL DBC_FAIL("test",__FILE__,__LINE__)
+  USE DBC
 #else
 #define REQUIRE(test)  ! DBC REQUIRE - test
 #define ENSURE(test)   ! DBC ENSURE  - test

--- a/unit_tests/testDBC/testDBC.f90
+++ b/unit_tests/testDBC/testDBC.f90
@@ -8,7 +8,6 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testDBC
 #include "DBC.h"
-  USE DBC
   USE IntrType
   IMPLICIT NONE
   CHARACTER(LEN=*),PARAMETER :: modName="testDBC"


### PR DESCRIPTION
Description:
For client code that will use DBC, it would have to add two lines:
  #include "DBC.h"
  USE DBC

I've modified "DBC.h" to to include the USE statement when
FUTILITY_DBC is defined. Now client code wanting to use DBC should
just do:

  MODULE client
  #include "DBC.h"
  ...

Also:
  * made indentation consistent with other source files
  * changed variable definitions to avoid unnecessary implied save
    attribute

CASL Ticket # - #5200