### PR TITLE
Fix valgrind defects in ParallelEnv

### DIFF
--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -1049,12 +1049,12 @@ MODULE ParallelEnv
       REAL(SRK) :: rbuf(2,n)
       INTEGER(SIK) :: rank
       REQUIRE(myPE%initstat)
+      rank=0
       IF(PRESENT(root)) rank=root
       REQUIRE(rank >= 0)
       REQUIRE(rank < myPE%nproc)
       sbuf(1,:)=x(1:n)
       sbuf(2,:)=i(1:n)
-      rank=0
 #ifdef DBL
       CALL MPI_Allreduce(sbuf,rbuf,n,MPI_2DOUBLE_PRECISION,MPI_MAXLOC, &
         myPE%comm,mpierr)
@@ -1095,12 +1095,12 @@ MODULE ParallelEnv
       REAL(SRK) :: rbuf(2,n)
       INTEGER(SIK) :: rank
       REQUIRE(myPE%initstat)
+      rank=0
       IF(PRESENT(root)) rank=root
       REQUIRE(rank >= 0)
       REQUIRE(rank < myPE%nproc)
       sbuf(1,:)=x(1:n)
       sbuf(2,:)=i(1:n)
-      rank=0
 #ifdef DBL
       CALL MPI_Allreduce(sbuf,rbuf,n,MPI_2DOUBLE_PRECISION,MPI_MINLOC, &
         myPE%comm,mpierr)


### PR DESCRIPTION
In two routines, a value was being set after a DBC check, causing
stochastic failures.  The value was already being set in the wrong order,
but it does not currently get used in the MPI call, so the error showed
up only in the DBC checks.  I've left the unused value and optional
argument in place since I assume they were first added with some
intention to use them.