### PR TITLE
Fixes to MeuLu parameter list

### DIFF
--- a/src/trilinos_interfaces/trilinos_pc.cpp
+++ b/src/trilinos_interfaces/trilinos_pc.cpp
@@ -32,10 +32,8 @@ int PCStore::new_data(Teuchos::ParameterList &params)
         params.get("Ifpack Type", std::string("ILUT"));
         params.get("Ifpack Overlap", 0);
     } else if (pc_obj.pc_type == "MueLu") {
-        pc_obj.pc_db.get("ML Default Type", std::string("SA"));
         params.get("max levels", 8);
         params.get("smoother: type", std::string("RILUK"));
-        params.get("sa: damping factor", 1.0);
         // params.get("smoother: sweeps", 3);
         params.get("smoother: overlap", 1);
         params.get("aggregation: type", std::string("uncoupled"));


### PR DESCRIPTION
When we switched from ML to MeuLu, the ML Default Type parameter was
added to the incorrect parameter list, which is why it didn't cause issues.
This change gets rid of that parameter completely because multigrid algorithm
does the same thing.  sa: damping factor was also defined twice so the second
was not being used, yet the first value was incorrect and the second was correct
so I removed the first entry.

Ticket #3663