### PR TITLE
Creating a wrapper for PETSc call KSPSetOperators.

### DIFF
--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -686,7 +686,8 @@ MODULE LinearSolverTypes
     ENDSUBROUTINE setup_PreCond_LinearSolverType_Iterative
 !
 !-------------------------------------------------------------------------------
-!> @brief Wraps KSPSetOperators for when a new matrix is defined (as in reinitMat)
+!> @brief associates matrix with KSP (if PETSc), otherwise indicates that the
+!>        matrix is not decomposed and needs to be refactored (for LU)
 !> @param solver The linear solver to act on
 !>
     SUBROUTINE PETSc_updatedA(solver)

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -161,9 +161,9 @@ MODULE LinearSolverTypes
       PROCEDURE(linearsolver_sub_absintfc),DEFERRED,PASS :: clear
       !> Deferred routine for solving the linear system
       PROCEDURE(linearsolver_sub_absintfc),DEFERRED,PASS :: solve
-      !> @copybrief LinearSolverTypes::PETSc_updatedA
-      !> @copydetails LinearSolverTypes::PETSc_updatedA
-      PROCEDURE,PASS :: updatedA => PETSc_updatedA
+      !> Routine for updating status of M and isDecomposed when A has changed
+      !> and associates A with KSP if necessary
+      PROCEDURE,PASS :: updatedA
   ENDTYPE LinearSolverType_Base
 
   !> Explicitly defines the interface for the clear and solve routines
@@ -690,7 +690,7 @@ MODULE LinearSolverTypes
 !>        matrix is not decomposed and needs to be refactored (for LU)
 !> @param solver The linear solver to act on
 !>
-    SUBROUTINE PETSc_updatedA(solver)
+    SUBROUTINE updatedA(solver)
       CLASS(LinearSolverType_Base),INTENT(INOUT) :: solver
 #ifdef FUTILITY_HAVE_PETSC
       PetscErrorCode  :: iperr
@@ -708,7 +708,7 @@ MODULE LinearSolverTypes
 #endif
       solver%isDecomposed=.FALSE.
 
-    ENDSUBROUTINE PETSc_updatedA
+    ENDSUBROUTINE updatedA
 !
 !-------------------------------------------------------------------------------
 !> @brief Clears the Direct Linear Solver Type

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -705,6 +705,7 @@ MODULE LinearSolverTypes
 #endif
       ENDSELECT
 #endif
+      solver%isDecomposed=.FALSE.
 
     ENDSUBROUTINE PETSc_updatedA
 !
@@ -810,18 +811,6 @@ MODULE LinearSolverTypes
       solver%residual=0._SRK
       IF(LinearSolverType_Paramsflag) CALL LinearSolverType_Clear_ValidParams()
     ENDSUBROUTINE clear_LinearSolverType_Iterative
-!
-!-------------------------------------------------------------------------------
-!> @brief Tells the LinearSystem that A has been updated outside of solver
-!> @param solver The linear solver to act on
-!>
-!> This routine tells the LinearSystem that A has been updated outside of solver
-!>
-    SUBROUTINE updatedA(solver)
-      CLASS(LinearSolverType_Base),INTENT(INOUT) :: solver
-      solver%isDecomposed=.FALSE.
-
-    ENDSUBROUTINE updatedA
 !
 !-------------------------------------------------------------------------------
 !> @brief Solves the Linear System

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -64,7 +64,6 @@ PROGRAM testLinearSolver
   REGISTER_SUBTEST('TESTING NORMS PROCEDURE',testNorms)
   REGISTER_SUBTEST('testClear',testClear)
   REGISTER_SUBTEST('testInit',testInit)
-  REGISTER_SUBTEST('TestUpdatedA',testUpdatedA)
   REGISTER_SUBTEST('testDirectSolve',testDirectSolve)
   REGISTER_SUBTEST('testQRSolve',testQRSolve)
   REGISTER_SUBTEST('testIterativeOthers',testIterativeOthers)
@@ -433,87 +432,6 @@ CONTAINS
       DEALLOCATE(thisLS)
 
     ENDSUBROUTINE testInit
-!
-!-------------------------------------------------------------------------------
-    SUBROUTINE testUpdatedA()
-      CLASS(LinearSolverType_Base),ALLOCATABLE :: thisLS
-      LOGICAL(SBK) :: bool
-
-    !test Direct
-      ALLOCATE(LinearSolverType_Direct :: thisLS)
-
-      ! initialize matrix M
-      ALLOCATE(DenseSquareMatrixType :: thisLS%M)
-      CALL pList%clear()
-      CALL pList%add('MatrixType->n',10_SNK)
-      CALL pList%add('MatrixType->isSym',.TRUE.)
-      CALL thisLS%M%init(pList)
-      thisLS%isDecomposed=.TRUE.
-
-      ! initialize linear system
-      CALL pList%clear()
-      CALL pList%add('LinearSolverType->matType',SPARSE)
-      CALL pList%add('LinearSolverType->TPLType',NATIVE)
-      CALL pList%add('LinearSolverType->solverMethod',LU)
-      CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
-      CALL pList%add('LinearSolverType->numberOMP',1_SNK)
-      CALL pList%add('LinearSolverType->timerName','testTimer')
-      CALL pList%add('LinearSolverType->A->MatrixType->n',1_SNK)
-      CALL pList%add('LinearSolverType->A->MatrixType->nnz',1_SNK)
-      CALL pList%add('LinearSolverType->x->VectorType->n',1_SNK)
-      CALL pList%add('LinearSolverType->b->VectorType->n',1_SNK)
-      CALL pList%validate(pList,optListLS)
-      CALL thisLS%init(pList)
-
-      SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Direct)
-        ALLOCATE(thisLS%IPIV(10))
-      ENDSELECT
-      CALL thisLS%updatedA()
-      !Check
-      SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Direct)
-        bool = .NOT.thisLS%isDecomposed
-        ASSERT(bool, 'Direct%updatedA()')
-      ENDSELECT
-      CALL thisLS%clear()
-      DEALLOCATE(thisLS)
-
-    !test Iterative
-      ALLOCATE(LinearSolverType_Iterative :: thisLS)
-
-      ! initialize matrix M
-      ALLOCATE(DenseSquareMatrixType :: thisLS%M)
-      CALL pList%clear()
-      CALL pList%add('MatrixType->n',10_SNK)
-      CALL pList%add('MatrixType->isSym',.TRUE.)
-      CALL thisLS%M%init(pList)
-      thisLS%isDecomposed=.TRUE.
-
-      ! initialize linear system
-      CALL pList%clear()
-      CALL pList%add('LinearSolverType->matType',SPARSE)
-      CALL pList%add('LinearSolverType->TPLType',NATIVE)
-      CALL pList%add('LinearSolverType->solverMethod',BICGSTAB)
-      CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
-      CALL pList%add('LinearSolverType->numberOMP',1_SNK)
-      CALL pList%add('LinearSolverType->timerName','testTimer')
-      CALL pList%add('LinearSolverType->A->MatrixType->n',1_SNK)
-      CALL pList%add('LinearSolverType->A->MatrixType->nnz',1_SNK)
-      CALL pList%add('LinearSolverType->x->VectorType->n',1_SNK)
-      CALL pList%add('LinearSolverType->b->VectorType->n',1_SNK)
-      CALL pList%validate(pList,optListLS)
-      CALL thisLS%init(pList)
-
-      CALL thisLS%updatedA()
-
-      !Check
-      SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        bool = .NOT.thisLS%isDecomposed
-        ASSERT(bool, 'Iterative%updatedA()')
-      ENDSELECT
-      CALL thisLS%clear()
-      DEALLOCATE(thisLS)
-
-    ENDSUBROUTINE testUpdatedA
 !
 !-------------------------------------------------------------------------------
     SUBROUTINE testDirectSolve()


### PR DESCRIPTION
Description:
As part of restructuring reinitLS to only reinit the matrix, KSPSetOperators needs to be callable.

CASL Ticket # - 5106