### PR TITLE
Changing load statements to point to correct path for petsc 3.6

### DIFF
--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -56,8 +56,12 @@ MODULE EigenvalueSolverTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
-#include <finclude/petsc.h>
 #include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
 !petscisdef.h defines the keyword IS, and it needs to be reset
 #ifdef FUTILITY_HAVE_SLEPC
 #include <finclude/slepcsys.h>

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -82,8 +82,12 @@ MODULE LinearSolverTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
-#include <finclude/petsc.h>
 #include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
 !petscisdef.h defines the keyword IS, and it needs to be reset
 #undef IS
 #endif

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -33,7 +33,12 @@ MODULE MatrixTypes_PETSc
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 
   PRIVATE

--- a/src/ODESolverTypes.f90
+++ b/src/ODESolverTypes.f90
@@ -55,8 +55,12 @@ MODULE ODESolverTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
-#include <finclude/petsc.h>
 #include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
 !petscisdef.h defines the keyword IS, and it needs to be reset
 #undef IS
 #endif

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -40,7 +40,12 @@ MODULE ParallelEnv
 #ifdef HAVE_MPI
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
   PetscBool :: petsc_isinit

--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -50,8 +50,12 @@ MODULE PartitionGraph
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
-#include <finclude/petsc.h>
 #include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
 !petscisdef.h defines the keyword IS, and it needs to be reset
 #ifdef FUTILITY_HAVE_SLEPC
 #include <finclude/slepcsys.h>

--- a/src/PreconditionerTypes.f90
+++ b/src/PreconditionerTypes.f90
@@ -51,7 +51,12 @@ MODULE PreconditionerTypes
   PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 #endif
 

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -86,7 +86,12 @@ MODULE VectorTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 #endif
 

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -28,7 +28,12 @@ MODULE VectorTypes_PETSc
 
 #ifdef FUTILITY_HAVE_PETSC
 
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 
   PRIVATE

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -28,7 +28,12 @@ PROGRAM testEigenvalueSolver
   CLASS(DistributedMatrixType),POINTER :: B => NULL()
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
 #ifdef FUTILITY_HAVE_SLEPC

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -25,7 +25,12 @@ PROGRAM testLinearSolver
   TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
 

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -22,7 +22,12 @@ PROGRAM testMatrixTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
 #else

--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -89,7 +89,12 @@ PROGRAM testODESolver
   CLASS(ODESolverInterface_Base),POINTER :: f
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
   CALL PETScInitialize(PETSC_NULL_CHARACTER,ierr)

--- a/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
+++ b/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
@@ -10,7 +10,12 @@ PROGRAM testParTPLPETSC
 
   IMPLICIT NONE
 
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 
   !define precision kinds

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -25,7 +25,12 @@ PROGRAM testPartitionGraph
   TYPE(ExceptionHandlerType),POINTER :: e
 
 #ifdef FUTILITY_HAVE_SLEPC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #include <finclude/slepc.h>
 #undef IS
   PetscErrorCode  :: ierr

--- a/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
+++ b/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
@@ -12,7 +12,12 @@ MODULE dummyPCShell
   USE MatrixTypes
   USE PreconditionerTypes
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 #endif
   TYPE,EXTENDS(PreconditionerType) :: dummyPCType

--- a/unit_tests/testTPLPETSC/testTPLPETSC.f90
+++ b/unit_tests/testTPLPETSC/testTPLPETSC.f90
@@ -10,7 +10,12 @@ PROGRAM testTPLPETSC
 
   IMPLICIT NONE
 
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 
   !define precision kinds

--- a/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
+++ b/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
@@ -11,7 +11,12 @@ PROGRAM testTPLSLEPC
   IMPLICIT NONE
 
 #include <finclude/slepc.h>
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
 
   !define precision kinds

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -21,7 +21,12 @@ PROGRAM testVectorTypes
   IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
 #include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
 #else


### PR DESCRIPTION
Already ran this against petsc 3.6.4 (which CASL is moving to):

100% tests passed, 0 tests failed out of 50

Subproject Time Summary:
Futility    =  78.24 sec*proc (50 tests)

Total Test time (real) =  13.81 sec