### PR TITLE
PartitionGraph - Fixed RMS to actually be RMS rather than 2-norm.

### DIFF
--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -1732,7 +1732,7 @@ MODULE PartitionGraph
           srms=srms+wtDif
         ENDDO !ig
         mmr=lgroup/sgroup
-        srms=100.0_SRK*SQRT(srms)/optSize
+        srms=100.0_SRK*SQRT(srms/REAL(thisGraph%nGroups,SRK))/optSize
 
         !Determine the total weight of cut edges, and the communication between
         !groups

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -828,7 +828,7 @@ PROGRAM testPartitionGraph
       bool=(mmr .APPROXEQ. 1.0588235294117647_SRK)
       ASSERT(bool,'max-min ratio')
       FINFO() mmr
-      bool=(srms .APPROXEQ. 4.7105571976599583_SRK)
+      bool=(srms .APPROXEQ. 2.7196414661021060_SRK)
       ASSERT(bool, 'group size rms (from optimal)')
       FINFO() srms
       bool=(ecut .APPROXEQ. 10.0_SRK)


### PR DESCRIPTION
Description:
RMS did not have 1/n inside the square root, thus it was more of a
2-norm. This has been fixed by adding the 1/n.

CASL Ticket # - #5014