### PR TITLE
Hotfix testLS_MG

### DIFF
--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -26,8 +26,12 @@ PROGRAM testLinearSolver_Multigrid
   TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
-#include <finclude/petsc.h>
 #include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
 #undef IS
   PetscErrorCode  :: ierr
 


### PR DESCRIPTION
Adding full header logic to testLS_MG to account for PETSc 3.6+.