### PR TITLE
Bug fix in nFields

### DIFF
--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -657,13 +657,12 @@ MODULE IO_Strings
         IF(aline(i:i) == "'" .OR. aline(i:i) == '"') THEN
           IF(inQuotes) THEN
             inQuotes=.FALSE.
-            n=n+1
+            n=n+2
             CYCLE
           ELSE
             inQuotes=.TRUE.
           ENDIF
         ENDIF
-
         !Process the spaces and multiplier characters if not in a quoted string
         IF(.NOT.inQuotes) THEN
           IF(aline(i:i) == ' ' .OR. ICHAR(aline(i:i)) == 9) THEN !ichar(tab)=9
@@ -684,6 +683,14 @@ MODULE IO_Strings
             READ(aline(i+1:multidcol-1),*,IOSTAT=ioerr) nmult
             IF(ioerr /= 0) nmult=1
             n=n+(nmult-1)*2
+
+            !If we are multiplying a quoted string need to subtract 1.
+            IF(multidcol < ncol) THEN
+              IF(aline(multidcol+1:multidcol+1) == '"' .OR. &
+                 aline(multidcol+1:multidcol+1) == "'") &
+                n=n-1
+            ENDIF
+
             multidata=.FALSE.
           ENDIF
           nonblankd=nonblank

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -116,15 +116,16 @@ PROGRAM testIOutil
       ASSERT(nFields(string) == -2,'bad double-quote')
       string='1'
       ASSERT(nFields(string) == 1,'1')
-      !string='XSMACRO "core mat mod" 0'
-      !ASSERT(nFields(string) == 3,'quotes')
-      !string=' XSMACRO "core mat mod" 0'
-      !ASSERT(nFields(string) == 3,'quotes')
-      !string='XSMACRO "core mat mod" 0 '
-      !ASSERT(nFields(string) == 3,'quotes')
-      !string=' XSMACRO "core mat mod" 0 '
-      !ASSERT(nFields(string) == 3,'quotes')
-
+      string='XSMACRO "core mat mod" 0'
+      ASSERT(nFields(string) == 3,'quotes')
+      string=' XSMACRO "core mat mod" 0'
+      ASSERT(nFields(string) == 3,'quotes')
+      string='XSMACRO "core mat mod" 0 '
+      ASSERT(nFields(string) == 3,'quotes')
+      string=' XSMACRO "core mat mod" 0 '
+      ASSERT(nFields(string) == 3,'quotes')
+      string=' XSMACRO "core mat mod" 0 "number 2"'
+      ASSERT(nFields(string) == 4,'quotes')
       string='arg1 nmult*arg2'
       ASSERT(nFields(string) == 2,'bad multi-arg')
       string='arg1 2*arg2'


### PR DESCRIPTION
Description:
Quoted strings were truncating the number of fields by 1.

Test updated to test quoted strings. This had been commented out. Quoted
strings also tested for multiples.