### PR TITLE
Modification to MemProf to use better edit values

### DIFF
--- a/src/MemProf.f90
+++ b/src/MemProf.f90
@@ -163,12 +163,12 @@ MODULE MemProf
           thisMP%print_banner=.FALSE.
         ENDIF
         CALL thisMP%pe%world%barrier()
-        CALL getProcMemInfo(tmpL1,tmpL2)
-        thisMP%mem_current=REAL(tmpL1,SRK)/(1024.0_SRK*1024.0_SRK)
+        CALL getProcMemInfo(tmpL1,tmpL2) !tmpL1 in kB, and tmpL2 in bytes
+        thisMP%mem_current=REAL(tmpL1,SRK)*1000.0_SRK/(1024.0_SRK*1024.0_SRK*1024.0_SRK)
         loc(1)=thisMP%pe%world%rank
 
         mem=thisMP%mem_current
-        maxmem=mem
+        maxmem=REAL(tmpL2,SRK)/(1024.0_SRK*1024.0_SRK*1024.0_SRK)
         dmem=(thisMP%mem_current-thisMP%mem_old)*1024.0_SRK
         IF(thisMP%verbose) THEN
           WRITE(tmpchar,'(a)') 'Memory Use at '//TRIM(name)//':'
@@ -182,7 +182,7 @@ MODULE MemProf
         CALL thisMP%pe%world%allReduce(1,mem)
         mem=mem/REAL(thisMP%pe%world%nproc,SRK)
 
-        IF(dmem(1)>=thisMP%mem_threshold .AND. ASSOCIATED(thisMP%myLog) .AND. &
+        IF(ABS(dmem(1))>=thisMP%mem_threshold .AND. ASSOCIATED(thisMP%myLog) .AND. &
             thisMP%pe%world%master) THEN
           WRITE(tmpchar,'(a)') 'Memory Use at '//TRIM(name)//':'
           WRITE(amesg,'(a,3(f10.3),"  (",I4,")")') ADJUSTL(tmpchar), mem, maxmem, dmem, loc

--- a/src/getSysProcInfo.c
+++ b/src/getSysProcInfo.c
@@ -133,12 +133,13 @@ void getProcMemInfo(long long *curUsage, long long *peakUsage)
   char line[128];
 
   getrusage(RUSAGE_SELF, &usage);
-  *peakUsage = usage.ru_maxrss;
+  *peakUsage = usage.ru_maxrss; //usage.ru_maxrss is in kB
 
   file = fopen("/proc/self/status", "r");
   while (fgets(line, 128, file) != NULL)
   {
-    if (strncmp(line, "VmSize:", 7) == 0)
+    //if (strncmp(line, "VmSize:", 7) == 0)
+    if (strncmp(line, "VmRSS:", 6) == 0)
     {
       *curUsage = parseLine(line);
       break;


### PR DESCRIPTION
Description:
Using /proc/self/status VmRSS for the resident set size (RSS) versus
the VmSize parameter. The VmSize parameter will include memory from
shared libraries not explicitly allocated to physical memory or by
the program. This can lead to artificially high values that obfuscate
the actual memory usage.

The maximum memory (high water mark for the resident set size) is
also now utilized in the MemProf.f90 module. Previously it was just
the maximum value of VmSize.

Units are also now correct. Raw measurements in getSysProcInfo
are returned as "kilobytes" for peakUsage and "kB" for the RSS.

Generally:
kilobytes = 1000 bytes (or 1024 bytes, it is ambiguous)
kB        = 1000 bytes (may be used erroneously)
KB        = 1024 bytes (may be used erroneously)
KiB       = 1024 bytes (unambiguous, but not widely used)

The peakUsage is assumed to be 1024 bytes, and the VmRSS is assumed
to be 1000 bytes.