### PR TITLE
Avogadro's number is changed to 6.022140857e+23 from Source NIST.

### DIFF
--- a/src/Constants_Conversion.f90
+++ b/src/Constants_Conversion.f90
@@ -42,8 +42,8 @@ MODULE Constants_Conversion
   REAL(SRK),PUBLIC,PARAMETER ::     RPI=ONE/PI
   REAL(SRK),PUBLIC,PARAMETER ::  RTWOPI=ONE/TWOPI
   REAL(SRK),PUBLIC,PARAMETER :: RFOURPI=ONE/FOURPI
-  !> Avogadro's Number
-  REAL(SRK),PUBLIC,PARAMETER :: Na=6.02214129000E+23_SRK !16 digits
+  !> Avogadro's Number; source: https://physics.nist.gov/cgi-bin/cuu/Value?na
+  REAL(SRK),PUBLIC,PARAMETER :: Na=6.022140857E+23_SRK
 
   ! Area conversion
   !> Conversion factor from barns to cm**2

--- a/src/Constants_Conversion.f90
+++ b/src/Constants_Conversion.f90
@@ -43,7 +43,7 @@ MODULE Constants_Conversion
   REAL(SRK),PUBLIC,PARAMETER ::  RTWOPI=ONE/TWOPI
   REAL(SRK),PUBLIC,PARAMETER :: RFOURPI=ONE/FOURPI
   !> Avogadro's Number; source: https://physics.nist.gov/cgi-bin/cuu/Value?na
-  REAL(SRK),PUBLIC,PARAMETER :: Na=6.022140857E+23_SRK
+  REAL(SRK),PUBLIC,PARAMETER :: NA=6.022140857E+23_SRK
 
   ! Area conversion
   !> Conversion factor from barns to cm**2


### PR DESCRIPTION
Description:
Avogadro's number is changed to 6.022140857e+23 from web page:
[https://physics.nist.gov/cgi-bin/cuu/Value?na](https://physics.nist.gov/cgi-bin/cuu/Value?na)

CASL Ticket # - #5478