### PR TITLE
Add exceptions to MatrixType

### DIFF
--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -458,7 +458,16 @@ MODULE MatrixTypes_Native
             ENDIF
           ENDDO
           IF(found_ja) matrix%a(ja_index)=setval
+        ELSE
+          IF(matrix%jCount==0) THEN
+            CALL eMatrixType%raiseError(modName//'::'//myName//' - Matrix entries not defined.  '//&
+               'Ensure that setShape has been called.')
+          ELSEIF(i>matrix%n.or.i<0.or.j<0) THEN
+            CALL eMatrixType%raiseError(modName//'::'//myName//' - Passed row/col out of bounds.')
+          ENDIF
         ENDIF
+      ELSE
+         CALL eMatrixType%raiseError(modName//'::'//myName//' - Matrix not initialized.')
       ENDIF
     ENDSUBROUTINE set_SparseMatrixtype
 !
@@ -572,8 +581,16 @@ MODULE MatrixTypes_Native
             matrix%jCount=matrix%jCount+1
             IF(PRESENT(setval)) matrix%a(matrix%jCount)=setval
             matrix%ja(matrix%jCount)=j
+          ELSE
+            CALL eMatrixType%raiseError(modName//'::'//myName//&
+               ' - Failed consistency checks; ensure j values for row are in ascending'//&
+               ' order, entires are row-major, and the number of nonzeros are within bounds.')
           ENDIF
+        ELSE
+          CALL eMatrixType%raiseError(modName//'::'//myName//' - Passed row/col out of bounds.')
         ENDIF
+      ELSE
+        CALL eMatrixType%raiseError(modName//'::'//myName//' - Matrix not initialized.')
       ENDIF
     ENDSUBROUTINE set_shape_SparseMatrixType
 !

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -659,7 +659,7 @@ MODULE MatrixTypes_Native
 !>
 !> This routine gets the values of the sparse matrix.  If an (i,j) value
 !> is not present, then 0.0 is returned.  If the (i,j) location is out of
-!> bounds, then an exception is raised.
+!> bounds, fails if DBC is enabled.
 !>
     SUBROUTINE get_SparseMatrixType(matrix,i,j,getval)
       CHARACTER(LEN=*),PARAMETER :: myName='get_SparseMatrixType'

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -450,6 +450,7 @@ MODULE MatrixTypes_Native
       REQUIRE(j>0)
       REQUIRE(i>0)
       REQUIRE(i+1<=size(matrix%ia))
+      REQUIRE(i<=matrix%n)
 
       !currently written assuming no all-zero rows.
       !pretty safe assumption.

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -7,12 +7,14 @@
 ! can be found in LICENSE.txt in the head directory of this repository.        !
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testMatrixTypes
+#include "Futility_DBC.h"
 #include "UnitTest.h"
   USE ISO_FORTRAN_ENV
   USE ISO_C_BINDING
   USE UnitTest
   USE IntrType
   USE ExceptionHandler
+  USE Futility_DBC
   USE trilinos_interfaces
   USE ParameterLists
   USE ParallelEnv
@@ -97,7 +99,6 @@ PROGRAM testMatrixTypes
       REAL(SRK) :: dummy
       REAL(SRK),ALLOCATABLE :: dummyvec(:)
       LOGICAL(SBK) :: bool
-      CHARACTER(LEN=EXCEPTION_MAX_MESG_LENGTH) :: msg, refMsg
 #ifdef FUTILITY_HAVE_PETSC
       INTEGER(SIK) :: matsize1,matsize2
       CLASS(VectorType),ALLOCATABLE :: xPETScVector,yPETScVector
@@ -291,100 +292,30 @@ PROGRAM testMatrixTypes
           CALL thisMatrix%clear()
           
           ! Perform a series of exception tests:
-          ! 1. Try to set before matrix is initialized
-          CALL thisMatrix%SetShape(1,1,1._SRK)
-          msg=eMatrixType%getLastMessage()
-          refMsg = "#### EXCEPTION_ERROR #### - MATRIXTYPES_NATIVE::set_shape_SparseMatrixType"//&
-             " - Matrix not initialized."
-          ASSERT(trim(msg)==trim(refMsg), "")
-          CALL thisMatrix%SetShape(1,1)
-          msg=eMatrixType%getLastMessage()
-          ASSERT(trim(msg)==trim(refMsg), "")
-
+          ! These tests rely on DBC being hit, so if it's not available, don't do them
+#ifdef FUTILITY_DBC
+          DBC_STOP_ON_FAIL=.false.
+          ASSERT(DBC_COUNTER==0, "")
           CALL thisMatrix%init(pList)
 
-          ! 2. Try to set data before setShape is called
+          ! 1. Try to set data before setShape is called
+          ! Trips jcount>0 require
           CALL thisMatrix%set(1,1,1._SRK)
-          msg=eMatrixType%getLastMessage()
-          refMsg = "#### EXCEPTION_ERROR #### - MATRIXTYPES_NATIVE::set_SparseMatrixType - "//&
-            "Matrix entries not defined.  Ensure that setShape has been called."
-          ASSERT(trim(msg)==trim(refMsg), "")
+          ASSERT(DBC_COUNTER==1, "")
 
-          ! 3. Pass in j's out of order in setShape
+          ! 2. Pass in j's out of order in setShape
+          ! Hits only ordering require
           CALL thisMatrix%setShape(1,1)
           CALL thisMatrix%setShape(1,4)
           CALL thisMatrix%setShape(1,3)
-          msg=eMatrixType%getLastMessage()
-          refMsg = "#### EXCEPTION_ERROR #### - MATRIXTYPES_NATIVE::set_shape_SparseMatrixType - "//&
-            'Failed consistency checks; ensure j values for row are in ascending '//&
-            'order, entires are row-major, and the number of nonzeros are within bounds.'
-          ASSERT(trim(msg)==trim(refMsg), "")
-
-
-          ! 4. Pass in row/col out of bounds for setShape
-          CALL thisMatrix%SetShape(5,1)
-          msg=eMatrixType%getLastMessage()
-          refMsg = "#### EXCEPTION_ERROR #### - MATRIXTYPES_NATIVE::set_shape_SparseMatrixType - "//&
-            "Passed row/col out of bounds."
-          ASSERT(trim(msg)==trim(refMsg), "")
-          CALL thisMatrix%SetShape(0,1)
-          msg=eMatrixType%getLastMessage()
-          ASSERT(trim(msg)==trim(refMsg), "")
-          CALL thisMatrix%SetShape(1,0)
-          msg=eMatrixType%getLastMessage()
-          ASSERT(trim(msg)==trim(refMsg), "")
-
-          CALL thisMatrix%SetShape(1,1,1._SRK)
-
-          ! 5. Pass in row/col out of bounds for set
-          CALL thisMatrix%set(5,1,1._SRK)
-          msg=eMatrixType%getLastMessage()
-          refMsg = "#### EXCEPTION_ERROR #### - MATRIXTYPES_NATIVE::set_SparseMatrixType - "//&
-            "Passed row/col out of bounds."
-          ASSERT(trim(msg)==trim(refMsg), "")
-          CALL thisMatrix%set(0,1,1._SRK)
-          msg=eMatrixType%getLastMessage()
-          ASSERT(trim(msg)==trim(refMsg), "")
-          CALL thisMatrix%set(1,0,1._SRK)
-          msg=eMatrixType%getLastMessage()
-          ASSERT(trim(msg)==trim(refMsg), "")
+          ASSERT(DBC_COUNTER==2, "")
 
           CALL thisMatrix%clear()
+          DBC_STOP_ON_FAIL=.true.
+          DBC_COUNTER=0
+#endif
           ! Exception tests done
 
-          !off-nominal setShape cases
-          !test matrix with isInit set to false artificially
-          CALL thisMatrix%init(pList)
-          thisMatrix%isInit=.FALSE.
-          CALL thisMatrix%SetShape(1,1,1._SRK)
-          ASSERT(thisMatrix%a(1) /= 1._SRK, 'sparse%setShape(...)')
-          CALL thisMatrix%clear()
-          !test case where i and j are out of bounds (one at a time)
-          CALL thisMatrix%init(pList)
-          CALL thisMatrix%setShape(-1,1,2._SRK) !i<1
-          ASSERT(thisMatrix%a(1) /= 2._SRK, 'sparse%setShape(...)')
-          CALL thisMatrix%clear
-          CALL thisMatrix%init(pList)
-          CALL thisMatrix%setShape(1,-1,2._SRK) !j<1
-          ASSERT(thisMatrix%a(1) /= 2._SRK, 'sparse%setShape(...)')
-          CALL thisMatrix%clear
-          CALL thisMatrix%init(pList)
-          CALL thisMatrix%setShape(4,1,2._SRK) !i>n
-          ASSERT(thisMatrix%a(1) /= 2._SRK, 'sparse%setShape(...)')
-          !test check to see if i,j of new entry are below and to the right
-          !of previous i.j
-          CALL thisMatrix%clear()
-          CALL thisMatrix%init(pList)
-          CALL thisMatrix%setShape(1,2,1._SRK)
-          CALL thisMatrix%setShape(1,1,2._SRK)
-          ASSERT(thisMatrix%a(2) /= 2._SRK, 'sparse%setShape(...)')
-          CALL thisMatrix%clear
-          CALL thisMatrix%init(pList)
-          CALL thisMatrix%setShape(1,1,1._SRK)
-          CALL thisMatrix%setShape(2,2,2._SRK)
-          CALL thisMatrix%setShape(1,3,3._SRK)
-          ASSERT(thisMatrix%a(3) /= 3._SRK, 'sparse%setShape(...)')
-          WRITE(*,*) '  Passed: CALL sparse%setShape(...)'
           !test set (first initialize the values w/ setShape)
           CALL thisMatrix%clear()
           CALL thisMatrix%init(pList)
@@ -627,30 +558,10 @@ PROGRAM testMatrixTypes
       CALL pList%add('MatrixType->n',3)
       CALL pList%add('MatrixType->nnz',6)
       CALL thisMatrix%init(pList)
-      CALL thisMatrix%set(1,1,1._SRK) !since jCount = 0, expect no change
-      SELECTTYPE(thisMatrix)
-        TYPE IS(SparseMatrixType)
-          DO i=1,SIZE(thisMatrix%a)
-            ASSERT(thisMatrix%a(i) /= 1._SRK, 'sparse%set(...)')
-          ENDDO
-      ENDSELECT
-      !set uninit matrix.
-      CALL thisMatrix%clear()
-      CALL thisMatrix%set(1,1,1._SRK) !since isInit=.FALSE. expect no change
-      !no crash? good.
-      !pass out-of bounds i and j
-      CALL thisMatrix%clear()
-      CALL thisMatrix%init(pList)
       SELECTTYPE(thisMatrix)
         TYPE IS(SparseMatrixType); CALL thisMatrix%setShape(1,1)
       ENDSELECT
 
-      CALL thisMatrix%set(-1,1,1._SRK)
-      CALL thisMatrix%set(1,-1,1._SRK)
-      CALL thisMatrix%set(4,1,1._SRK)
-      CALL thisMatrix%set(1,4,1._SRK)
-      !no crash? good.
-      !i,j not in pre-defined shape
       CALL pList%clear()
       CALL pList%add('MatrixType->n',3_SNK)
       CALL pList%add('MatrixType->nnz',6_SNK)
@@ -709,27 +620,6 @@ PROGRAM testMatrixTypes
                  (dummyvec(8) == 3._SRK) .AND. &
                  (dummyvec(9) == 6._SRK)
           ASSERT(bool, 'sparse%get(...)') !column three check
-      ENDSELECT
-      !test with out of bounds i,j, make sure no crash.
-      SELECTTYPE(thisMatrix)
-        TYPE IS(SparseMatrixType)
-          CALL thisMatrix%get(4,2,dummy)
-          bool = (dummy == -1051._SRK)
-          ASSERT(bool, 'sparse%get(...)')
-          CALL thisMatrix%get(-1,2,dummy)
-          bool = (dummy == -1051._SRK)
-          ASSERT(bool, 'sparse%get(...)')
-          CALL thisMatrix%get(2,-1,dummy)
-          bool = dummy == -1051._SRK
-          ASSERT(bool, 'sparse%get(...)')
-      ENDSELECT
-      !test get with uninit, make sure no crash.
-      CALL thisMatrix%clear()
-      SELECTTYPE(thisMatrix)
-        TYPE IS(SparseMatrixType)
-          CALL thisMatrix%get(1,1,dummy)
-          bool = dummy == 0.0_SRK
-          ASSERT(bool, 'sparse%get(...)')
       ENDSELECT
       CALL thisMatrix%clear()
       WRITE(*,*) '  Passed: CALL sparse%get(...)'


### PR DESCRIPTION
Integrating the native solvers for sparse matrices would have went more smoothly if Futility would have warned me that I needed to call setShape before setting data and that the j values need to be in ascending order.  Added a few other exceptions that should help prevent unintended behavior.