### PR TITLE
Update header doc to clarify a return value

### DIFF
--- a/src/FileType_Fortran.f90
+++ b/src/FileType_Fortran.f90
@@ -476,6 +476,8 @@ MODULE FileType_Fortran
 !> @param file the fortran file type object
 !> @returns val the value of the unit number
 !>
+!> Guaranteed to return -1 prior to initialize being called and after clear being 
+!> called
     PURE FUNCTION getUnitNo_fortran_file(file) RESULT(val)
       CLASS(FortranFileType),INTENT(IN) :: file
       INTEGER(SIK) :: val

--- a/unit_tests/testFileType_Fortran/testFileType_Fortran.f90
+++ b/unit_tests/testFileType_Fortran/testFileType_Fortran.f90
@@ -133,6 +133,14 @@ PROGRAM testFileType_Fortran
       CALL testFile%fopen()
       CALL testFile%fdelete()
       CALL testFile%clear()
+
+      ! Ensure unit number is as expected
+      ASSERT(testFile%getUnitNo()==-1, "")
+      call testFile%initialize(UNIT=12,FILE='.testFile.txt')
+      ASSERT(testFile%getUnitNo()==12, "")
+      call testFile%clear(ldel=.TRUE.)
+      ASSERT(testFile%getUnitNo()==-1, "")
+
     ENDSUBROUTINE testFortranFileType
 !
 ENDPROGRAM testFileType_Fortran


### PR DESCRIPTION
Is this okay to make this guarantee?  If I know it's negative 1 when the file wasn't opened, I can use iostat to allow the code to catch and ignore errors when I don't want to write to the file.