### PR TITLE
Have Futility_DBC check if MPI is intialized

### DIFF
--- a/src/Futility_DBC.f90
+++ b/src/Futility_DBC.f90
@@ -74,7 +74,6 @@ MODULE Futility_DBC
     INTEGER :: mpierr
     LOGICAL :: mpiInit
     CALL MPI_Initialized(mpiInit,mpierr)
-    print *, mpiInit
     IF(mpiInit) THEN
       CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
       CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)

--- a/src/Futility_DBC.f90
+++ b/src/Futility_DBC.f90
@@ -72,8 +72,16 @@ MODULE Futility_DBC
     INTEGER :: rank,nproc
 #ifdef HAVE_MPI
     INTEGER :: mpierr
-    CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
-    CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+    LOGICAL :: mpiInit
+    CALL MPI_Initialized(mpiInit,mpierr)
+    print *, mpiInit
+    IF(mpiInit) THEN
+      CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
+      CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+   ELSE
+      rank=0
+      nproc=1
+   ENDIF
 #else
     rank=0
     nproc=1

--- a/unit_tests/testDBC/testDBC.f90
+++ b/unit_tests/testDBC/testDBC.f90
@@ -17,11 +17,17 @@ PROGRAM testDBC
 #ifdef HAVE_MPI
   INCLUDE "mpif.h"
   INTEGER(SIK) :: mpierr
-  CALL MPI_Init(mpierr)
 #endif
 
   CALL GET_COMMAND_ARGUMENT(1,arg)
   READ(arg,*) iopt
+
+#ifdef HAVE_MPI
+  ! Do not init MPI for the no_stop_on_fail test.  This test calls DBC_Fail
+  ! but will not stop because of the failed REQUIRE.  It did still fail when trying
+  ! to call MPI routines without MPI_Init being called before a fix was put in.
+  IF(iopt/=5) CALL MPI_Init(mpierr)
+#endif
 
   SELECTCASE(iopt)
     CASE(1)
@@ -41,7 +47,7 @@ PROGRAM testDBC
   WRITE(*,*) "TEST PASSED"
 
 #ifdef HAVE_MPI
-      CALL MPI_Finalize(mpierr)
+  IF(iopt/=5) CALL MPI_Finalize(mpierr)
 #endif
 !
 !===============================================================================


### PR DESCRIPTION
Description:
Skip calling MPI_get_rank and MPI_get_nproc if not so it doesn't cause a
misleading error.

CASL Ticket # - N/A