### PR TITLE
Initialize nRestart so it doesn't lead to uninitialized variable warning

### DIFF
--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -1306,6 +1306,7 @@ MODULE LinearSolverTypes
       relConvTol=relConvTol_in
       absConvTol=absConvTol_in
       maxIters=maxIters_in
+      nRestart=-1_SRK
       IF(PRESENT(nRestart_in)) nRestart=nRestart_in
 #ifdef FUTILITY_HAVE_PETSC
       IF(PRESENT(dTol_in)) THEN


### PR DESCRIPTION
Description:

CASL Ticket # - N/A