### PR TITLE
Add new getAll procedures for parallel vectors

### DIFF
--- a/src/VectorTypes_Base.f90
+++ b/src/VectorTypes_Base.f90
@@ -85,9 +85,11 @@ MODULE VectorTypes_Base
       PROCEDURE(vector_getOne_absintfc),DEFERRED,PASS :: getOne
       !> Deferred routine for getting all vector values
       PROCEDURE(vector_getAll_absintfc),DEFERRED,PASS :: getAll
+      !> Deferred routine for getting all vector values, entire vector at once
+      PROCEDURE(vector_getSelected_absintfc),DEFERRED,PASS :: getSelected
       !> Deferred routine for getting a range of vector values
       PROCEDURE(vector_getRange_absintfc),DEFERRED,PASS :: getRange
-      GENERIC :: get => getOne,getAll,getRange
+      GENERIC :: get => getOne,getAll,getSelected,getRange
   ENDTYPE VectorType
 !
 !List of Abstract Interfaces
@@ -189,6 +191,18 @@ MODULE VectorTypes_Base
       REAL(SRK),INTENT(INOUT) :: getval(:)
       INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
     ENDSUBROUTINE vector_getAll_absintfc
+  ENDINTERFACE
+
+  !> Explicitly defines the interface for the get (vector) routine of all vector
+  !> types
+  ABSTRACT INTERFACE
+    SUBROUTINE vector_getSelected_absintfc(thisVector,indices,getval,ierr)
+      IMPORT :: SIK,SRK,VectorType
+      CLASS(VectorType),INTENT(INOUT) :: thisVector
+      INTEGER(SIK),INTENT(IN):: indices(:)
+      REAL(SRK),INTENT(INOUT) :: getval(:)
+      INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+    ENDSUBROUTINE vector_getSelected_absintfc
   ENDINTERFACE
 
   !> Explicitly defines the interface for the get (scalar) routine of all vector

--- a/src/VectorTypes_Base.f90
+++ b/src/VectorTypes_Base.f90
@@ -76,11 +76,13 @@ MODULE VectorTypes_Base
       PROCEDURE(vector_setAll_scalar_absintfc),DEFERRED,PASS :: setAll_scalar
       !> Deferred routine for setting all vector values with array
       PROCEDURE(vector_setAll_array_absintfc),DEFERRED,PASS :: setAll_array
+      !> Deferred routine for setting selected vector values with array
+      PROCEDURE(vector_setSelected_absintfc),DEFERRED,PASS :: setSelected
       !> Deferred routine for setting all vector values with scalar
       PROCEDURE(vector_setRange_scalar_absintfc),DEFERRED,PASS :: setRange_scalar
       !> Deferred routine for setting all vector values with array
       PROCEDURE(vector_setRange_array_absintfc),DEFERRED,PASS :: setRange_array
-      GENERIC :: set => setOne,setAll_scalar,setAll_array,setRange_scalar,setRange_array
+      GENERIC :: set => setOne,setAll_scalar,setAll_array,setRange_scalar,setRange_array,setSelected
       !> Deferred routine for getting vector value
       PROCEDURE(vector_getOne_absintfc),DEFERRED,PASS :: getOne
       !> Deferred routine for getting all vector values
@@ -131,6 +133,18 @@ MODULE VectorTypes_Base
       REAL(SRK),INTENT(IN) :: setval
       INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
     ENDSUBROUTINE vector_setAll_scalar_absintfc
+  ENDINTERFACE
+
+  !> Explicitly defines the interface for the set selected (array) routine of all
+  !> vector types
+  ABSTRACT INTERFACE
+    SUBROUTINE vector_setSelected_absintfc(thisVector,indices,setval,ierr)
+      IMPORT :: SIK,SRK,VectorType
+      CLASS(VectorType),INTENT(INOUT) :: thisVector
+      INTEGER(SIK),INTENT(IN) :: indices(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+      INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+    ENDSUBROUTINE vector_setSelected_absintfc
   ENDINTERFACE
 
   !> Explicitly defines the interface for the set all (array) routine of all

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -22,6 +22,8 @@
 MODULE VectorTypes_Native
   USE IntrType
   USE ExceptionHandler
+#include "Futility_DBC.h"
+  USE Futility_DBC
   USE ParameterLists
   USE Allocs
   USE VectorTypes_Base
@@ -74,6 +76,9 @@ MODULE VectorTypes_Native
       !> @copybrief VectorTypes::getAll_RealVectorType
       !> @copydetails VectorTypes::getAll_RealVectorType
       PROCEDURE,PASS :: getAll => getAll_RealVectorType
+      !> @copybrief VectorTypes::getSelected_RealVectorType
+      !> @copydetails VectorTypes::getSelected_RealVectorType
+      PROCEDURE,PASS :: getSelected => getSelected_RealVectorType
       !> @copybrief VectorTypes::getRange_RealVectorType
       !> @copydetails VectorTypes::getRange_RealVectorType
       PROCEDURE,PASS :: getRange => getRange_RealVectorType
@@ -272,8 +277,10 @@ MODULE VectorTypes_Native
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets all values in the real vector
+!> Works on serial vectors only, meaning the indices used to extract data from the vector
+!> are 1->N, where N is the size of the vector.
 !> @param declares the vector type to act on
-!>
+!> @param getval Correctly sized array that will be filled with contents of this vector
     SUBROUTINE getAll_RealVectorType(thisVector,getval,ierr)
       CLASS(RealVectorType),INTENT(INOUT) :: thisVector
       REAL(SRK),INTENT(INOUT) :: getval(:)
@@ -288,6 +295,28 @@ MODULE VectorTypes_Native
       ENDIF
       IF(PRESENT(ierr)) ierr=ierrc
     ENDSUBROUTINE getAll_RealVectorType
+!
+!-------------------------------------------------------------------------------
+!> @brief Gets a list of selected values from the vector
+!> @param declares the vector type to act on
+!> @param indices A list of the indices in the vector
+!> @param getval Correctly sized array that will be filled with contents of this vector
+    SUBROUTINE getSelected_RealVectorType(thisVector,indices,getval,ierr)
+      CLASS(RealVectorType),INTENT(INOUT) :: thisVector
+      INTEGER(SIK),INTENT(IN) :: indices(:)
+      REAL(SRK),INTENT(INOUT) :: getval(:)
+      INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+      ierrc=-1
+      IF(thisVector%isInit) THEN
+        ierrc=-3
+        IF(SIZE(indices) == SIZE(getval) .AND. SIZE(indices) <= thisVector%n) THEN
+          ierrc=0
+          getval=thisVector%b(indices)
+        ENDIF
+      ENDIF
+      IF(PRESENT(ierr)) ierr=ierrc
+    ENDSUBROUTINE getSelected_RealVectorType
+
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets a range of values in the real vector

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -64,6 +64,9 @@ MODULE VectorTypes_Native
       !> @copybrief VectorTypes::setAll_array_RealVectorType
       !> @copydetails VectorTypes::setAll_array_RealVectorType
       PROCEDURE,PASS :: setAll_array => setAll_array_RealVectorType
+      !> @copybrief VectorTypes::setSelected_RealVectorType
+      !> @copydetails VectorTypes::setSelected_RealVectorType
+      PROCEDURE,PASS :: setSelected => setSelected_RealVectorType
       !> @copybrief VectorTypes::setRange_scalar_RealVectorType
       !> @copydetails VectorTypes::setRange_scalar_RealVectorType
       PROCEDURE,PASS :: setRange_scalar => setRange_scalar_RealVectorType
@@ -202,6 +205,25 @@ MODULE VectorTypes_Native
       ENDIF
       IF(PRESENT(ierr)) ierr=ierrc
     ENDSUBROUTINE setAll_array_RealVectorType
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets selected values in the real vector
+!> @param declare the vector type to act on
+!> @param indices a list of indices in the vector to set
+!> @param setval the array of values to be set (must be same size as indices)
+!>
+    SUBROUTINE setSelected_RealVectorType(thisVector,indices,setval,ierr)
+      CLASS(RealVectorType),INTENT(INOUT) :: thisVector
+      INTEGER(SIK),INTENT(IN) :: indices(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+      INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+      REQUIRE(thisVector%isInit)
+      REQUIRE(SIZE(setval) == SIZE(indices))
+      ierrc=0
+      thisVector%b(indices)=setval
+      IF(PRESENT(ierr)) ierr=ierrc
+    ENDSUBROUTINE setSelected_RealVectorType
+
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets a range of values in the real vector with a scalar value

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -306,14 +306,11 @@ MODULE VectorTypes_Native
       INTEGER(SIK),INTENT(IN) :: indices(:)
       REAL(SRK),INTENT(INOUT) :: getval(:)
       INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
-      ierrc=-1
-      IF(thisVector%isInit) THEN
-        ierrc=-3
-        IF(SIZE(indices) == SIZE(getval) .AND. SIZE(indices) <= thisVector%n) THEN
-          ierrc=0
-          getval=thisVector%b(indices)
-        ENDIF
-      ENDIF
+      REQUIRE(thisVector%isInit)
+      REQUIRE(SIZE(indices) == SIZE(getval))
+      REQUIRE(SIZE(indices) <= thisVector%n)
+      ierrc=0
+      getval=thisVector%b(indices)
       IF(PRESENT(ierr)) ierr=ierrc
     ENDSUBROUTINE getSelected_RealVectorType
 

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -65,6 +65,9 @@ MODULE VectorTypes_PETSc
       !> @copybrief VectorTypes::setAll_array_PETScVectorType
       !> @copydetails VectorTypes::setAll_array_PETScVectorType
       PROCEDURE,PASS :: setAll_array => setAll_array_PETScVectorType
+      !> @copybrief VectorTypes::setSelected_PETScVectorType
+      !> @copydetails VectorTypes::setSelected_PETScVectorType
+      PROCEDURE,PASS :: setSelected => setSelected_PETScVectorType
       !> @copybrief VectorTypes::setRange_scalar_PETScVectorType
       !> @copydetails VectorTypes::setRange_scalar_PETScVectorType
       PROCEDURE,PASS :: setRange_scalar => setRange_scalar_PETScVectorType
@@ -239,6 +242,29 @@ MODULE VectorTypes_PETSc
       ENDIF
       IF(PRESENT(ierr)) ierr=ierrc
     ENDSUBROUTINE setAll_array_PETScVectorType
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets selected values in the PETSc vector with an array of values
+!> @param declare the vector type to act on
+!> @param indices a list of indices (global if parallel) for which data is being set
+!> @param setval the array of values to be set (same size as indices)
+!>
+    SUBROUTINE setSelected_PETScVectorType(thisVector,indices,setval,ierr)
+      CLASS(PETScVectorType),INTENT(INOUT) :: thisVector
+      INTEGER(SIK),INTENT(IN) :: indices(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+      INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+      !
+      INTEGER(SIK) :: ierrc
+
+      REQUIRE(thisVector%isInit)
+      REQUIRE(SIZE(setval) == SIZE(indices))
+      CALL VecSetValues(thisVector%b,SIZE(indices),indices-1,setval,INSERT_VALUES,iperr)
+      ierrc=0
+      thisVector%isAssembled=.FALSE.
+      IF(PRESENT(ierr)) ierr=ierrc
+    ENDSUBROUTINE setSelected_PETScVectorType
+
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets a range of values in the PETSc vector with a scalar value

--- a/unit_tests/testVectorTypes/CMakeLists.txt
+++ b/unit_tests/testVectorTypes/CMakeLists.txt
@@ -8,3 +8,4 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 INCLUDE(Futility_CreateUnitTest)
 Futility_CreateUnitTest(testVectorTypes)
+Futility_CreateParUnitTest(testVectorTypesParallel 2)

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -542,6 +542,21 @@ PROGRAM testVectorTypes
           DEALLOCATE(testvec)
           ALLOCATE(testvec(7))
       ENDSELECT
+
+      ! Set and get a few selected elements
+      CALL thisVector%set(0._SRK)
+      CALL thisVector%set([1, 5], [1._SRK, 2._SRK])
+      CALL thisVector%get(1, dummy)
+      ASSERT(dummy==1._SRK, 'set/getSelected')
+      CALL thisVector%get(2, dummy)
+      ASSERT(dummy==0._SRK, 'set/getSelected')
+      CALL thisVector%get(3, dummy)
+      ASSERT(dummy==0._SRK, 'set/getSelected')
+      CALL thisVector%get(4, dummy)
+      ASSERT(dummy==0._SRK, 'set/getSelected')
+      CALL thisVector%get(5, dummy)
+      ASSERT(dummy==2._SRK, 'set/getSelected')
+
       !test get with uninit, make sure no crash.
       CALL thisVector%clear()
       testvec=0._SRK
@@ -814,6 +829,22 @@ PROGRAM testVectorTypes
             ASSERT(bool, 'petscvec%setAll_array(...)')
           ENDDO
       ENDSELECT
+      
+      ! Will overrwrite elements 1, 3, and 5
+      ! The rest will remain the same
+      CALL thisVector%set([1, 3, 5], [1._SRK, 3._SRK, 5._SRK])
+      CALL thisVector%get(1, dummy)
+      ASSERT(dummy==1._SRK, "setSelected")
+      CALL thisVector%get(2, dummy)
+      ASSERT(dummy==4._SRK, "setSelected")
+      CALL thisVector%get(3, dummy)
+      ASSERT(dummy==3._SRK, "setSelected")
+      CALL thisVector%get(4, dummy)
+      ASSERT(dummy==8._SRK, "setSelected")
+      CALL thisVector%get(5, dummy)
+      ASSERT(dummy==5._SRK, "setSelected")
+      CALL thisVector%get(6, dummy)
+      ASSERT(dummy==12._SRK, "setSelected")
 
       !set uninit matrix.
       CALL thisVector%clear()
@@ -840,6 +871,7 @@ PROGRAM testVectorTypes
       testvec2(6)=11._SRK
       CALL thisVector%set(testvec2,iverr) !since isInit=.FALSE. expect no change
       ASSERT(iverr == -3, 'petscvec%setAll_array(...)')
+
 
       CALL thisVector%clear()
       CALL pList%clear()

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -531,6 +531,16 @@ PROGRAM testVectorTypes
                        (testvec(7) /= 2._SRK) .OR. &
                        iverr /= 0)
           ASSERT(bool, 'realvec%getAll(...)')
+          DEALLOCATE(testvec)
+          ALLOCATE(testvec(4))
+          CALL thisVector%get([1,3,5,7],testvec)
+          bool = testvec(1) == 1._SRK .AND. &
+                 testvec(2) == 8._SRK .AND. &
+                 testvec(3) == 3._SRK .AND. &
+                 testvec(4) == 2._SRK
+          ASSERT(bool, 'realvec%getSelected(...)')
+          DEALLOCATE(testvec)
+          ALLOCATE(testvec(7))
       ENDSELECT
       !test get with uninit, make sure no crash.
       CALL thisVector%clear()
@@ -1057,6 +1067,16 @@ PROGRAM testVectorTypes
                        (testvec(6) /= 7._SRK) .OR. &
                        (testvec(7) /= 2._SRK))
           ASSERT(bool, 'petscvec%getAll(...)')
+          DEALLOCATE(testvec)
+          ALLOCATE(testvec(4))
+          CALL thisVector%get([1,3,5,7],testvec)
+          bool = testvec(1) == 1._SRK .AND. &
+                 testvec(2) == 8._SRK .AND. &
+                 testvec(3) == 3._SRK .AND. &
+                 testvec(4) == 2._SRK
+          ASSERT(bool, 'petscvec%getSelected(...)')
+          DEALLOCATE(testvec)
+          ALLOCATE(testvec(7))
       ENDSELECT
       !test get with uninit, make sure no crash.
       CALL thisVector%clear()

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -1,0 +1,151 @@
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+!                          Futility Development Group                          !
+!                             All rights reserved.                             !
+!                                                                              !
+! Futility is a jointly-maintained, open-source project between the University !
+! of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
+! can be found in LICENSE.txt in the head directory of this repository.        !
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+PROGRAM testVectorTypesParallel
+#include "UnitTest.h"
+  USE ISO_C_BINDING
+  USE ISO_FORTRAN_ENV
+  USE UnitTest
+  USE IntrType
+  USE ExceptionHandler
+  USE trilinos_interfaces
+  USE ParameterLists
+  USE ParallelEnv
+  USE VectorTypes
+
+  IMPLICIT NONE
+
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
+#undef IS
+  PetscErrorCode  :: ierr
+#else
+#ifdef HAVE_MPI
+#include <mpif.h>
+  INTEGER :: ierr
+#endif
+#endif
+  INTEGER(SIK) :: iverr
+  TYPE(ExceptionHandlerType),POINTER :: e
+
+  CREATE_TEST('Test Vector Types Parallel')
+
+  !Configure exception handler for test
+  ALLOCATE(e)
+  CALL e%setStopOnError(.FALSE.)
+  CALL e%setQuietMode(.TRUE.)
+  CALL eVectorType%addSurrogate(e)
+
+#ifdef HAVE_MPI
+  CALL MPI_Init(ierr)
+#endif
+#ifdef FUTILITY_HAVE_PETSC
+  CALL PetscInitialize(PETSC_NULL_CHARACTER,ierr)
+#endif
+
+  REGISTER_SUBTEST("Vector Types",testVector)
+
+#ifdef FUTILITY_HAVE_PETSC
+  CALL PetscFinalize(ierr)
+#endif
+#ifdef HAVE_MPI
+  CALL MPI_Finalize(ierr)
+#endif
+  FINALIZE_TEST()
+
+CONTAINS
+!
+!-------------------------------------------------------------------------------
+    SUBROUTINE testVector()
+      CLASS(VectorType),ALLOCATABLE :: thisVector
+      TYPE(ParamType) :: pList
+      LOGICAL(SBK) :: bool
+      INTEGER(SIK) :: rank, nproc, mpierr, i
+      REAL(SRK) :: val
+      REAL(SRK),ALLOCATABLE :: getval(:)
+#if defined(FUTILITY_HAVE_PETSC) && defined(HAVE_MPI)
+      CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
+      CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+      ASSERT(nproc==2, 'nproc valid')
+      !Perform test of init function
+      !first check intended init path (m provided)
+      CALL pList%clear()
+      CALL pList%add('VectorType->n',20)
+      CALL pList%add('VectorType->MPI_Comm_ID',MPI_COMM_WORLD)
+      CALL pList%add('VectorType->nlocal',10)
+      ALLOCATE(PETScVectorType :: thisVector)
+      CALL thisVector%init(pList)
+      SELECTTYPE(thisVector)
+        TYPE IS(PETScVectorType)
+          !check for success
+          bool = thisVector%isInit.AND.thisVector%n == 20
+          ASSERT(bool, 'petscvec%init(...)')
+          CALL VecGetSize(thisVector%b,i,ierr)
+          ASSERT(i == 20, 'petscvec%init(...)')
+      ENDSELECT
+
+      ! Test setting/getting single elements at a time
+      CALL thisVector%set(1,1._SRK)
+      CALL thisVector%set(2,2._SRK)
+      CALL thisVector%set(3,3._SRK)
+      CALL thisVector%set(18,18._SRK)
+      CALL thisVector%set(19,19._SRK)
+      CALL thisVector%set(20,20._SRK)
+
+      IF(rank==0) THEN
+        CALL thisVector%get(1,val)
+        ASSERT(val==1._SRK, "getOne")
+        CALL thisVector%get(2,val)
+        ASSERT(val==2._SRK, "getOne")
+        CALL thisVector%get(3,val)
+        ASSERT(val==3._SRK, "getOne")
+      ELSE
+        CALL thisVector%get(18,val)
+        ASSERT(val==18._SRK, "getOne")
+        CALL thisVector%get(19,val)
+        ASSERT(val==19._SRK, "getOne")
+        CALL thisVector%get(20,val)
+        ASSERT(val==20._SRK, "getOne")
+      ENDIF
+
+      ! Test setting/getting all elements at a time
+      ! Need to use getSelected because getAll does not work for parallel vectors
+      CALL thisVector%set([(REAL(i, SRK), i=1, 20)])
+      ALLOCATE(getval(10))
+      IF(rank==0) THEN
+         CALL thisVector%get([(i, i=1, 10)], getval)
+         ASSERT(ALL(getval==[(REAL(i, SRK), i=1, 10)]), 'getAll')
+      ELSE
+         CALL thisVector%get([(i, i=11, 20)], getval)
+         ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
+      ENDIF
+
+      ! Test setting/getting elemnts by range
+      CALL thisVector%set(1, 3, [1._SRK, 2._SRK, 3._SRK])
+      CALL thisVector%set(18, 20, [18._SRK, 19._SRK, 20._SRK])
+      DEALLOCATE(getval)
+      ALLOCATE(getval(3))
+      IF(rank==0) THEN
+         CALL thisVector%get(1, 3, getval)
+         ASSERT(ALL(getval==[1._SRK, 2._SRK, 3._SRK]), 'getRange')
+      ELSE
+         CALL thisVector%get(18, 20, getval)
+         ASSERT(ALL(getval==[18._SRK, 19._SRK, 20._SRK]), 'getRange')
+      ENDIF
+
+      DEALLOCATE(thisVector)
+      CALL pList%clear()
+
+#endif
+    ENDSUBROUTINE testVector
+ENDPROGRAM testVectorTypesParallel

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -35,7 +35,6 @@ PROGRAM testVectorTypesParallel
   INTEGER :: ierr
 #endif
 #endif
-  INTEGER(SIK) :: iverr
   TYPE(ExceptionHandlerType),POINTER :: e
 
   CREATE_TEST('Test Vector Types Parallel')

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -67,13 +67,13 @@ CONTAINS
 !
 !-------------------------------------------------------------------------------
     SUBROUTINE testVector()
+#if defined(FUTILITY_HAVE_PETSC) && defined(HAVE_MPI)
       CLASS(VectorType),ALLOCATABLE :: thisVector
       TYPE(ParamType) :: pList
       LOGICAL(SBK) :: bool
       INTEGER(SIK) :: rank, nproc, mpierr, i
       REAL(SRK) :: val
       REAL(SRK),ALLOCATABLE :: getval(:)
-#if defined(FUTILITY_HAVE_PETSC) && defined(HAVE_MPI)
       CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
       CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
       ASSERT(nproc==2, 'nproc valid')

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -128,6 +128,7 @@ CONTAINS
          ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
       ENDIF
 
+
       ! Use getAll with same data
       CALL thisVector%get(getval)
       IF(rank==0) THEN
@@ -136,6 +137,19 @@ CONTAINS
          ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
       ENDIF
 
+      ! Test setSelected by overwiting a few entries
+      CALL thisVector%set([1, 5, 15, 20], [100._SRK, 105._SRK, 115._SRK, 120._SRK])
+      DEALLOCATE(getval)
+      ALLOCATE(getval(2))
+      IF(rank==0) THEN
+         CALL thisVector%get([1, 5], getval)
+         ASSERT(getval(1)==100._SRK, 'set/getSelected')
+         ASSERT(getval(2)==105._SRK, 'set/getSelected')
+      ELSE
+         CALL thisVector%get([15, 20], getval)
+         ASSERT(getval(1)==115._SRK, 'set/getSelected')
+         ASSERT(getval(2)==120._SRK, 'set/getSelected')
+      ENDIF
 
       ! Test setting/getting elemnts by range
       CALL thisVector%set(1, 3, [1._SRK, 2._SRK, 3._SRK])

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -118,8 +118,7 @@ CONTAINS
         ASSERT(val==20._SRK, "getOne")
       ENDIF
 
-      ! Test setting/getting all elements at a time
-      ! Need to use getSelected because getAll does not work for parallel vectors
+      ! Test setting/getting selected elements all at once
       CALL thisVector%set([(REAL(i, SRK), i=1, 20)])
       ALLOCATE(getval(10))
       IF(rank==0) THEN
@@ -129,6 +128,15 @@ CONTAINS
          CALL thisVector%get([(i, i=11, 20)], getval)
          ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
       ENDIF
+
+      ! Use getAll with same data
+      CALL thisVector%get(getval)
+      IF(rank==0) THEN
+         ASSERT(ALL(getval==[(REAL(i, SRK), i=1, 10)]), 'getAll')
+      ELSE
+         ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
+      ENDIF
+
 
       ! Test setting/getting elemnts by range
       CALL thisVector%set(1, 3, [1._SRK, 2._SRK, 3._SRK])


### PR DESCRIPTION
Description:
The original getAll procedure will not work for a parallel vector because it
will cause an out of bounds error in PETSc.  To get all values at once, the user
needs to pass in the global indices of the values to get and they can only
pass  in indices that belong to the proc.  I added a new procedure, 'getSelected',
which can be used to do this, clarified that getAll should not be used for parallel
vectors, added tests for getSelected, and then added a new set of parallel vector
tests.