### PR TITLE
Adds scalar interfaces for allReduce, allReduceMax, allReduceMin

### DIFF
--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -265,49 +265,40 @@ MODULE ParallelEnv
                           bcast_SDK4_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceR_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceR_scalar_MPI_Env_type
-      PROCEDURE,PASS,PRIVATE :: allReduceR_scalar => allReduceR_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduce_scalar => allReduceR_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceR_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceR_array_MPI_Env_type
-      PROCEDURE,PASS,PRIVATE :: allReduceR_array => allReduceR_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduce => allReduceR_array_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceI_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceI_scalar_MPI_Env_type
-      PROCEDURE,PASS,PRIVATE :: allReduceI_scalar => allReduceI_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceI_scalar => allReduceI_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceI_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceI_array_MPI_Env_type
-      PROCEDURE,PASS,PRIVATE :: allReduceI_array => allReduceI_array_MPI_Env_type
-      GENERIC :: allReduceI => allReduceI_scalar,allReduceI_array
-      GENERIC :: allReduce => allReduceR_scalar,allReduceR_array, &
-                              allReduceI_scalar,allReduceI_array
+      PROCEDURE,PASS :: allReduceI => allReduceI_array_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMaxR_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMaxR_scalar_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMaxR_scalar => allReduceMaxR_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMax_scalar => allReduceMaxR_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMaxR_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMaxR_array_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMaxR_array => allReduceMaxR_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMax => allReduceMaxR_array_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMaxI_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMaxI_scalar_MPI_Env_type
       PROCEDURE,PASS :: allReduceMaxI_scalar => allReduceMaxI_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMaxI_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMaxI_array_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMaxI_array => allReduceMaxI_array_MPI_Env_type
-      GENERIC :: allReduceMaxI => allReduceMaxI_scalar,allReduceMaxI_array
-      GENERIC :: allReduceMax => allReduceMaxR_scalar,allReduceMaxR_array, &
-                                 allReduceMaxI_scalar,allReduceMaxI_array
+      PROCEDURE,PASS :: allReduceMaxI => allReduceMaxI_array_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMinR_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMinR_scalar_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMinR_scalar => allReduceMinR_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMin_scalar => allReduceMinR_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMinR_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMinR_array_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMinR_array => allReduceMinR_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMin => allReduceMinR_array_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMinI_scalar_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMinI_scalar_MPI_Env_type
       PROCEDURE,PASS :: allReduceMinI_scalar => allReduceMinI_scalar_MPI_Env_type
       !> @copybrief ParallelEnv::allReduceMinI_array_MPI_Env_type
       !> @copydetails  ParallelEnv::allReduceMinI_array_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMinI_array => allReduceMinI_array_MPI_Env_type
-      GENERIC :: allReduceMinI => allReduceMinI_scalar,allReduceMinI_array
-      GENERIC :: allReduceMin => allReduceMinR_scalar,allReduceMinR_array, &
-                                 allReduceMinI_scalar,allReduceMinI_array
+      PROCEDURE,PASS :: allReduceMinI => allReduceMinI_array_MPI_Env_type
       !> @copybrief ParallelEnv::reduceMaxLoc_MPI_Env_type
       !> @copydetails  ParallelEnv::reduceMaxLoc_MPI_Env_type
       PROCEDURE,PASS :: reduceMaxLoc => reduceMaxLocR_MPI_Env_type

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -263,24 +263,51 @@ MODULE ParallelEnv
                           bcast_SDK2_MPI_Env_type, &
                           bcast_SDK3_MPI_Env_type, &
                           bcast_SDK4_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceR_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceR_MPI_Env_type
-      PROCEDURE,PASS :: allReduce => allReduceR_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceI_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceI_MPI_Env_type
-      PROCEDURE,PASS :: allReduceI => allReduceI_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceMaxR_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceMaxR_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMax => allReduceMaxR_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceMaxI_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceMaxI_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMaxI => allReduceMaxI_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceMinR_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceMinR_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMin => allReduceMinR_MPI_Env_type
-      !> @copybrief ParallelEnv::allReduceMinI_MPI_Env_type
-      !> @copydetails  ParallelEnv::allReduceMinI_MPI_Env_type
-      PROCEDURE,PASS :: allReduceMinI => allReduceMinI_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceR_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceR_scalar_MPI_Env_type
+      PROCEDURE,PASS,PRIVATE :: allReduceR_scalar => allReduceR_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceR_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceR_array_MPI_Env_type
+      PROCEDURE,PASS,PRIVATE :: allReduceR_array => allReduceR_array_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceI_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceI_scalar_MPI_Env_type
+      PROCEDURE,PASS,PRIVATE :: allReduceI_scalar => allReduceI_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceI_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceI_array_MPI_Env_type
+      PROCEDURE,PASS,PRIVATE :: allReduceI_array => allReduceI_array_MPI_Env_type
+      GENERIC :: allReduceI => allReduceI_scalar,allReduceI_array
+      GENERIC :: allReduce => allReduceR_scalar,allReduceR_array, &
+                              allReduceI_scalar,allReduceI_array
+      !> @copybrief ParallelEnv::allReduceMaxR_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMaxR_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMaxR_scalar => allReduceMaxR_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMaxR_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMaxR_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMaxR_array => allReduceMaxR_array_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMaxI_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMaxI_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMaxI_scalar => allReduceMaxI_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMaxI_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMaxI_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMaxI_array => allReduceMaxI_array_MPI_Env_type
+      GENERIC :: allReduceMaxI => allReduceMaxI_scalar,allReduceMaxI_array
+      GENERIC :: allReduceMax => allReduceMaxR_scalar,allReduceMaxR_array, &
+                                 allReduceMaxI_scalar,allReduceMaxI_array
+      !> @copybrief ParallelEnv::allReduceMinR_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMinR_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMinR_scalar => allReduceMinR_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMinR_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMinR_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMinR_array => allReduceMinR_array_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMinI_scalar_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMinI_scalar_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMinI_scalar => allReduceMinI_scalar_MPI_Env_type
+      !> @copybrief ParallelEnv::allReduceMinI_array_MPI_Env_type
+      !> @copydetails  ParallelEnv::allReduceMinI_array_MPI_Env_type
+      PROCEDURE,PASS :: allReduceMinI_array => allReduceMinI_array_MPI_Env_type
+      GENERIC :: allReduceMinI => allReduceMinI_scalar,allReduceMinI_array
+      GENERIC :: allReduceMin => allReduceMinR_scalar,allReduceMinR_array, &
+                                 allReduceMinI_scalar,allReduceMinI_array
       !> @copybrief ParallelEnv::reduceMaxLoc_MPI_Env_type
       !> @copydetails  ParallelEnv::reduceMaxLoc_MPI_Env_type
       PROCEDURE,PASS :: reduceMaxLoc => reduceMaxLocR_MPI_Env_type
@@ -1459,6 +1486,37 @@ MODULE ParallelEnv
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a sum of operation
+!> for a real scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial sum to be returned as the total sum
+!>
+!> This routine only performs a sum operation and only for reals.
+!>
+    SUBROUTINE allReduceR_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceR_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      REAL(SRK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      REAL(SRK) :: rbuf
+      REQUIRE(myPE%initstat)
+#ifdef DBL
+      CALL MPI_Allreduce(x,rbuf,1,MPI_DOUBLE_PRECISION,MPI_SUM, &
+        myPE%comm,mpierr)
+#else
+      CALL MPI_Allreduce(x,rbuf,1,MPI_SINGLE_PRECISION,MPI_SUM, &
+        myPE%comm,mpierr)
+#endif
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_Allreduce returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceR_scalar_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a sum of operation
 !> for a real array.
 !> @param myPE the MPI parallel environment
 !> @param n the number of data elements to communicate
@@ -1466,8 +1524,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a sum operation and only for reals.
 !>
-    SUBROUTINE allReduceR_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceR_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceR_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       REAL(SRK),INTENT(INOUT) :: x(*)
@@ -1492,7 +1550,36 @@ MODULE ParallelEnv
       ENDIF
       DEALLOCATE(rbuf)
 #endif
-    ENDSUBROUTINE allReduceR_MPI_Env_type
+    ENDSUBROUTINE allReduceR_array_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a max operation
+!> for a real scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial value to be returned as the max
+!>
+!> This routine only performs a max operation and only for reals.
+!>
+    SUBROUTINE allReduceMaxR_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMaxR_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      REAL(SRK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      REAL(SRK) :: rbuf
+      REQUIRE(myPE%initstat)
+#ifdef DBL
+      CALL MPI_Allreduce(x,rbuf,1,MPI_DOUBLE_PRECISION,MPI_MAX,myPE%comm,mpierr)
+#else
+      CALL MPI_Allreduce(x,rbuf,n,MPI_SINGLE_PRECISION,MPI_MAX,myPE%comm,mpierr)
+#endif
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_AllreduceMax returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceMaxR_scalar_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a max operation
@@ -1503,8 +1590,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a max operation and only for reals.
 !>
-    SUBROUTINE allReduceMaxR_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceMaxR_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceR_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       REAL(SRK),INTENT(INOUT) :: x(*)
@@ -1526,7 +1613,36 @@ MODULE ParallelEnv
         CALL BLAS_copy(n,rbuf,1,x,1)
       ENDIF
 #endif
-    ENDSUBROUTINE allReduceMaxR_MPI_Env_type
+    ENDSUBROUTINE allReduceMaxR_array_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a min operation
+!> for a real scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial value to be returned as the min
+!>
+!> This routine only performs a min operation and only for reals.
+!>
+    SUBROUTINE allReduceMinR_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMinR_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      REAL(SRK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      REAL(SRK) :: rbuf
+      REQUIRE(myPE%initstat)
+#ifdef DBL
+      CALL MPI_Allreduce(x,rbuf,1,MPI_DOUBLE_PRECISION,MPI_MIN,myPE%comm,mpierr)
+#else
+      CALL MPI_Allreduce(x,rbuf,n,MPI_SINGLE_PRECISION,MPI_MIN,myPE%comm,mpierr)
+#endif
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_AllreduceMin returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceMinR_scalar_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a min operation
@@ -1537,8 +1653,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a min operation and only for reals.
 !>
-    SUBROUTINE allReduceMinR_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceMinR_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceR_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       REAL(SRK),INTENT(INOUT) :: x(*)
@@ -1560,7 +1676,7 @@ MODULE ParallelEnv
         CALL BLAS_copy(n,rbuf,1,x,1)
       ENDIF
 #endif
-    ENDSUBROUTINE allReduceMinR_MPI_Env_type
+    ENDSUBROUTINE allReduceMinR_array_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_reduce and performs a maxloc operation
@@ -1656,6 +1772,31 @@ MODULE ParallelEnv
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a sum of operation
+!> for an integer scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial sum to be returned as the total sum
+!>
+!> This routine only performs a sum operation and only for integers.
+!>
+    SUBROUTINE allReduceI_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceI_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      INTEGER(SIK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      INTEGER(SIK) :: rbuf
+      REQUIRE(myPE%initstat)
+      CALL MPI_Allreduce(x,rbuf,1,MPI_INTEGER,MPI_SUM,myPE%comm,mpierr)
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_Allreduce returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceI_scalar_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a sum of operation
 !> for an integer array.
 !> @param myPE the MPI parallel environment
 !> @param n the number of data elements to communicate
@@ -1663,8 +1804,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a sum operation and only for integers.
 !>
-    SUBROUTINE allReduceI_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceI_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceI_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       INTEGER(SIK),INTENT(INOUT) :: x(*)
@@ -1682,7 +1823,33 @@ MODULE ParallelEnv
         x(1:n)=rbuf ! No BLAS_copy for integers
       ENDIF
 #endif
-    ENDSUBROUTINE allReduceI_MPI_Env_type
+    ENDSUBROUTINE allReduceI_array_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a max operation
+!> for an integer scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial value to be returned as the max array
+!>
+!> This routine only performs a max operation and only for integers.
+!>
+    SUBROUTINE allReduceMaxI_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMaxI_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      INTEGER(SIK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      INTEGER(SIK) :: rbuf
+      REQUIRE(myPE%initstat)
+      CALL MPI_Allreduce(x,rbuf,1,MPI_INTEGER,MPI_MAX, &
+        myPE%comm,mpierr)
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_AllreduceMax returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceMaxI_scalar_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a max operation
@@ -1693,8 +1860,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a max operation and only for integers.
 !>
-    SUBROUTINE allReduceMaxI_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceMaxI_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMaxI_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       INTEGER(SIK),INTENT(INOUT) :: x(*)
@@ -1712,7 +1879,33 @@ MODULE ParallelEnv
         x(1:n)=rbuf ! No BLAS_copy for integers
       ENDIF
 #endif
-    ENDSUBROUTINE allReduceMaxI_MPI_Env_type
+    ENDSUBROUTINE allReduceMaxI_array_MPI_Env_type
+!
+!-------------------------------------------------------------------------------
+!> @brief Wrapper routine calls MPI_Allreduce and performs a min operation
+!> for an integer scalar.
+!> @param myPE the MPI parallel environment
+!> @param x the partial value to be returned as the min array
+!>
+!> This routine only performs a min operation and only for integers.
+!>
+    SUBROUTINE allReduceMinI_scalar_MPI_Env_type(myPE,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMinI_scalar_MPI_Env_type'
+      CLASS(MPI_EnvType),INTENT(IN) :: myPE
+      INTEGER(SIK),INTENT(INOUT) :: x
+#ifdef HAVE_MPI
+      INTEGER(SIK) :: rbuf
+      REQUIRE(myPE%initstat)
+      CALL MPI_Allreduce(x,rbuf,1,MPI_INTEGER,MPI_MIN, &
+        myPE%comm,mpierr)
+      IF(mpierr /= MPI_SUCCESS) THEN
+        CALL eParEnv%raiseError(modName//'::'// &
+          myName//' - call to MPI_AllreduceMin returned an error!')
+      ELSE
+        x=rbuf
+      ENDIF
+#endif
+    ENDSUBROUTINE allReduceMinI_scalar_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a min operation
@@ -1723,8 +1916,8 @@ MODULE ParallelEnv
 !>
 !> This routine only performs a min operation and only for integers.
 !>
-    SUBROUTINE allReduceMinI_MPI_Env_type(myPE,n,x)
-      CHARACTER(LEN=*),PARAMETER :: myName='allReduce_MPI_Env_type'
+    SUBROUTINE allReduceMinI_array_MPI_Env_type(myPE,n,x)
+      CHARACTER(LEN=*),PARAMETER :: myName='allReduceMinI_array_MPI_Env_type'
       CLASS(MPI_EnvType),INTENT(IN) :: myPE
       INTEGER(SIK),INTENT(IN) :: n
       INTEGER(SIK),INTENT(INOUT) :: x(*)
@@ -1742,7 +1935,7 @@ MODULE ParallelEnv
         x(1:n)=rbuf ! No BLAS_copy for integers
       ENDIF
 #endif
-    ENDSUBROUTINE allReduceMinI_MPI_Env_type
+    ENDSUBROUTINE allReduceMinI_array_MPI_Env_type
 !
 !-------------------------------------------------------------------------------
 !> @brief Wrapper routine calls MPI_Allreduce and performs a logical 'and'

--- a/unit_tests/testParallelEnv/testParallelEnv.f90
+++ b/unit_tests/testParallelEnv/testParallelEnv.f90
@@ -113,8 +113,8 @@ PROGRAM testParallelEnv
     SUBROUTINE testMPIEnv()
       INTEGER(SIK) :: ip,jp,tag
       INTEGER(SLK) :: sbuf(2)
-      INTEGER(SIK) :: sbuf_SIK(2)
-      REAL(SRK) :: sbuf_SRK(2)
+      INTEGER(SIK) :: sbuf_SIK(2),sbuf0_SIK
+      REAL(SRK) :: sbuf_SRK(2),sbuf0_SRK
       INTEGER(SIK),ALLOCATABLE :: ranks_SIK(:),ranks2_SIK(:,:)
       INTEGER(SIK),ALLOCATABLE :: testIDX(:),testWGT(:)
       INTEGER(SLK),ALLOCATABLE :: ranks(:),ranks2(:,:)
@@ -444,6 +444,93 @@ PROGRAM testParallelEnv
         ASSERT(ALL(bool4d(:,:,1:2,:)),'trueForAny, 1D')
       ENDIF
 
+      COMPONENT_TEST('%allReduce')
+      CALL testMPI%clear()
+      CALL testMPI%init()
+      IF(testMPI%nproc > 1) THEN
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduceI(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,3,'allReduceI_scalar')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduceI(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),3,'allreduceI_array')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
+
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduce(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,3,'allReduce scalar integer')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduce(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),3,'allreduce array integer')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
+
+        sbuf0_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduce(sbuf0_SRK)
+        ASSERT_APPROXEQA(sbuf0_SRK,3.0_SRK,'allReduce scalar real')
+        sbuf_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduce(1,sbuf_SRK)
+        ASSERT_APPROXEQA(sbuf_SRK(1),3.0_SRK,'allreduce array real')
+        ASSERT_APPROXEQA(sbuf_SRK(2),REAL(testMPI%rank+1,SRK),'allreduce rray real')
+      ENDIF
+
+      COMPONENT_TEST('%allReduceMax')
+      CALL testMPI%clear()
+      CALL testMPI%init()
+      IF(testMPI%nproc > 1) THEN
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMaxI(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,2,'allReduceI_scalar')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMaxI(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),2,'allreduceI_array')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
+
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMax(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,2,'allReduce scalar integer')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMax(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),2,'allreduce array integer')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
+
+        sbuf0_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduceMax(sbuf0_SRK)
+        ASSERT_APPROXEQA(sbuf0_SRK,2.0_SRK,'allReduce scalar real')
+        sbuf_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduceMax(1,sbuf_SRK)
+        ASSERT_APPROXEQA(sbuf_SRK(1),2.0_SRK,'allreduce array real')
+        ASSERT_APPROXEQA(sbuf_SRK(2),REAL(testMPI%rank+1,SRK),'allreduce rray real')
+      ENDIF
+
+      COMPONENT_TEST('%allReduceMin')
+      CALL testMPI%clear()
+      CALL testMPI%init()
+      IF(testMPI%nproc > 1) THEN
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMinI(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,1,'allReduceI_scalar')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMinI(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),1,'allreduceI_array')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
+
+        sbuf0_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMin(sbuf0_SIK)
+        ASSERT_EQ(sbuf0_SIK,1,'allReduce scalar integer')
+        sbuf_SIK=testMPI%rank+1
+        CALL testMPI%allReduceMin(1,sbuf_SIK)
+        ASSERT_EQ(sbuf_SIK(1),1,'allreduce array integer')
+        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
+
+        sbuf0_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduceMin(sbuf0_SRK)
+        ASSERT_APPROXEQA(sbuf0_SRK,1.0_SRK,'allReduce scalar real')
+        sbuf_SRK=REAL(testMPI%rank+1,SRK)
+        CALL testMPI%allReduceMin(1,sbuf_SRK)
+        ASSERT_APPROXEQA(sbuf_SRK(1),1.0_SRK,'allreduce array real')
+        ASSERT_APPROXEQA(sbuf_SRK(2),REAL(testMPI%rank+1,SRK),'allreduce rray real')
+      ENDIF
+
       CALL testMPI%clear()
     ENDSUBROUTINE testMPIEnv
 !
@@ -523,7 +610,7 @@ PROGRAM testParallelEnv
       ASSERT(testPE%ray%rank == 0,'%ray%rank')
       ASSERT(testPE%ray%master,'%ray%master')
       ASSERT(testPE%ray%isInit(),'%isInit()')
-      
+
       COMPONENT_TEST('deviceID')
       ASSERT_EQ(testPE%getDeviceID(),-1,'%deviceID')
       CALL testPE%setDeviceID(2)

--- a/unit_tests/testParallelEnv/testParallelEnv.f90
+++ b/unit_tests/testParallelEnv/testParallelEnv.f90
@@ -449,23 +449,15 @@ PROGRAM testParallelEnv
       CALL testMPI%init()
       IF(testMPI%nproc > 1) THEN
         sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduceI(sbuf0_SIK)
+        CALL testMPI%allReduceI_scalar(sbuf0_SIK)
         ASSERT_EQ(sbuf0_SIK,3,'allReduceI_scalar')
         sbuf_SIK=testMPI%rank+1
         CALL testMPI%allReduceI(1,sbuf_SIK)
         ASSERT_EQ(sbuf_SIK(1),3,'allreduceI_array')
         ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
 
-        sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduce(sbuf0_SIK)
-        ASSERT_EQ(sbuf0_SIK,3,'allReduce scalar integer')
-        sbuf_SIK=testMPI%rank+1
-        CALL testMPI%allReduce(1,sbuf_SIK)
-        ASSERT_EQ(sbuf_SIK(1),3,'allreduce array integer')
-        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
-
         sbuf0_SRK=REAL(testMPI%rank+1,SRK)
-        CALL testMPI%allReduce(sbuf0_SRK)
+        CALL testMPI%allReduce_scalar(sbuf0_SRK)
         ASSERT_APPROXEQA(sbuf0_SRK,3.0_SRK,'allReduce scalar real')
         sbuf_SRK=REAL(testMPI%rank+1,SRK)
         CALL testMPI%allReduce(1,sbuf_SRK)
@@ -478,23 +470,15 @@ PROGRAM testParallelEnv
       CALL testMPI%init()
       IF(testMPI%nproc > 1) THEN
         sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMaxI(sbuf0_SIK)
+        CALL testMPI%allReduceMaxI_scalar(sbuf0_SIK)
         ASSERT_EQ(sbuf0_SIK,2,'allReduceI_scalar')
         sbuf_SIK=testMPI%rank+1
         CALL testMPI%allReduceMaxI(1,sbuf_SIK)
         ASSERT_EQ(sbuf_SIK(1),2,'allreduceI_array')
         ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
 
-        sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMax(sbuf0_SIK)
-        ASSERT_EQ(sbuf0_SIK,2,'allReduce scalar integer')
-        sbuf_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMax(1,sbuf_SIK)
-        ASSERT_EQ(sbuf_SIK(1),2,'allreduce array integer')
-        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
-
         sbuf0_SRK=REAL(testMPI%rank+1,SRK)
-        CALL testMPI%allReduceMax(sbuf0_SRK)
+        CALL testMPI%allReduceMax_scalar(sbuf0_SRK)
         ASSERT_APPROXEQA(sbuf0_SRK,2.0_SRK,'allReduce scalar real')
         sbuf_SRK=REAL(testMPI%rank+1,SRK)
         CALL testMPI%allReduceMax(1,sbuf_SRK)
@@ -507,23 +491,15 @@ PROGRAM testParallelEnv
       CALL testMPI%init()
       IF(testMPI%nproc > 1) THEN
         sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMinI(sbuf0_SIK)
+        CALL testMPI%allReduceMinI_scalar(sbuf0_SIK)
         ASSERT_EQ(sbuf0_SIK,1,'allReduceI_scalar')
         sbuf_SIK=testMPI%rank+1
         CALL testMPI%allReduceMinI(1,sbuf_SIK)
         ASSERT_EQ(sbuf_SIK(1),1,'allreduceI_array')
         ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduceI_array')
 
-        sbuf0_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMin(sbuf0_SIK)
-        ASSERT_EQ(sbuf0_SIK,1,'allReduce scalar integer')
-        sbuf_SIK=testMPI%rank+1
-        CALL testMPI%allReduceMin(1,sbuf_SIK)
-        ASSERT_EQ(sbuf_SIK(1),1,'allreduce array integer')
-        ASSERT_EQ(sbuf_SIK(2),testMPI%rank+1,'allreduce array integer')
-
         sbuf0_SRK=REAL(testMPI%rank+1,SRK)
-        CALL testMPI%allReduceMin(sbuf0_SRK)
+        CALL testMPI%allReduceMin_scalar(sbuf0_SRK)
         ASSERT_APPROXEQA(sbuf0_SRK,1.0_SRK,'allReduce scalar real')
         sbuf_SRK=REAL(testMPI%rank+1,SRK)
         CALL testMPI%allReduceMin(1,sbuf_SRK)


### PR DESCRIPTION
The same is true for the integer versions of all those interfaces.
Those interfaces were also turned into generics so that both
integers and reals can be passed through the same allReduce procedure
name.