### PR TITLE
Adding setRow for distributed and sparse matrix types

### DIFF
--- a/src/MatrixTypes_Base.f90
+++ b/src/MatrixTypes_Base.f90
@@ -97,6 +97,7 @@ MODULE MatrixTypes_Base
     ENDSUBROUTINE matrix_set_sub_absintfc
   ENDINTERFACE
 
+
   !> Explicitly defines the interface for the get routine of all matrix types
   ABSTRACT INTERFACE
     SUBROUTINE matrix_get_sub_absintfc(matrix,i,j,getval)
@@ -144,6 +145,8 @@ MODULE MatrixTypes_Base
     CONTAINS
       !> Deferred routine for assembling a matrix
       PROCEDURE(distmatrix_assemble_absintfc),DEFERRED,PASS :: assemble
+      !> Deferred routine for setting a row at a time
+      PROCEDURE(distmatrix_setRow_absintfc),DEFERRED,PASS :: setRow
   ENDTYPE DistributedMatrixType
 
   !> Explicitly defines the interface for assembling a distributed matrix
@@ -153,6 +156,16 @@ MODULE MatrixTypes_Base
       CLASS(DistributedMatrixType),INTENT(INOUT) :: thisMatrix
       INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
     ENDSUBROUTINE distmatrix_assemble_absintfc
+  ENDINTERFACE
+
+  !> Explicitly defines the interface for setting row of a distributed matrix
+  ABSTRACT INTERFACE
+    SUBROUTINE distmatrix_setRow_absintfc(matrix,i,j,setval)
+      IMPORT :: SIK,SRK,DistributedMatrixType
+      CLASS(DistributedMatrixType),INTENT(INOUT) :: matrix
+      INTEGER(SIK),INTENT(IN) :: i, j(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+    ENDSUBROUTINE distmatrix_setRow_absintfc
   ENDINTERFACE
 
   !> The parameter lists to use when validating a parameter list for

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -157,6 +157,9 @@ MODULE MatrixTypes_Native
       !> @copybrief MatrixTypes::set_SparseMatrixType
       !> @copydetails MatrixTypes::set_SparseMatrixType
       PROCEDURE,PASS :: set => set_SparseMatrixType
+      !> @copybrief MatrixTypes::setRow_SparseMatrixType
+      !> @copydetails MatrixTypes::setRow_SparseMatrixType
+      PROCEDURE,PASS :: setRow => setRow_SparseMatrixType
       !> @copybrief MatrixTypes::set_shape_SparseMatrixType
       !> @copydetails MatrixTypes::set_shape_SparseMatrixType
       PROCEDURE,PASS :: setShape => set_shape_SparseMatrixType
@@ -463,6 +466,44 @@ MODULE MatrixTypes_Native
       ENDDO
       IF(found_ja) matrix%a(ja_index)=setval
     ENDSUBROUTINE set_SparseMatrixtype
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets an entire row of values in the sparse matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j a list of j locations in the matrix
+!> @param setval a list of values to set at the corresponding j locations
+!>
+!> This routine sets the values of an entire row in the sparse matrix.  It can only be used
+!> If setShape has previously been applied to the same sparse matrix.  
+!>
+    SUBROUTINE setRow_SparseMatrixType(matrix,i,j,setval)
+      CHARACTER(LEN=*),PARAMETER :: myName='set_SparseMatrixType'
+      CLASS(SparseMatrixType),INTENT(INOUT) :: matrix
+      INTEGER(SIK),INTENT(IN) :: i
+      INTEGER(SIK),INTENT(IN) :: j(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+      INTEGER(SIK) :: ja_index,ja
+      LOGICAL(SBK) :: found_ja
+
+      REQUIRE(matrix%isInit)
+      REQUIRE(((matrix%jCount > 0).AND.(i <= matrix%n)) .AND. ((ALL(j > 0)) .AND. (i > 0)))
+      REQUIRE(SIZE(j)==SIZE(setval))
+      !currently written assuming no all-zero rows.
+      !pretty safe assumption.
+      DO ja = 1, SIZE(j)
+        found_ja=.FALSE.
+        DO ja_index=matrix%ia(i),matrix%ia(i+1)-1
+          IF(matrix%ja(ja_index) == j(ja)) THEN
+            found_ja=.TRUE.
+            EXIT
+          ENDIF
+        ENDDO
+        REQUIRE(found_ja)
+        matrix%a(ja_index)=setval(ja)
+      ENDDO
+    ENDSUBROUTINE setRow_SparseMatrixtype
+
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the values in the dense square matrix

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -68,6 +68,9 @@ MODULE MatrixTypes_PETSc
       !> @copybrief MatrixTypes::set_PETScMatrixType
       !> @copydetails MatrixTypes::set_PETScMatrixType
       PROCEDURE,PASS :: set => set_PETScMatrixType
+      !> @copybrief MatrixTypes::setRow_PETScMatrixType
+      !> @copydetails MatrixTypes::setRow_PETScMatrixType
+      PROCEDURE,PASS :: setRow => setRow_PETScMatrixType
       !> @copybrief MatrixTypes::set_PETScMatrixType
       !> @copydetails MatrixTypes::set_PETScMatrixType
       PROCEDURE,PASS :: setShape => set_PETScMatrixType
@@ -241,6 +244,30 @@ MODULE MatrixTypes_PETSc
         ENDIF
       ENDIF
     ENDSUBROUTINE set_PETScMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets an entire row of values in the PETSc matrix
+!> Using this procedure can be much more computationally efficient for building the matrix than
+!> setting one value at a time.
+!> @param declares the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j a list of j indices of values to be entered in the matrix
+!> @param setval a list of values corresponding to the j locations (must be same size as j)
+!>
+    SUBROUTINE setRow_PETScMatrixType(matrix,i,j,setval)
+      CHARACTER(LEN=*),PARAMETER :: myName='set_PETScMatrixType'
+      CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
+      INTEGER(SIK),INTENT(IN) :: i
+      INTEGER(SIK),INTENT(IN) :: j(:)
+      REAL(SRK),INTENT(IN) :: setval(:)
+      PetscErrorCode  :: ierr
+
+      REQUIRE(matrix%isInit)
+      REQUIRE(SIZE(j)==SIZE(setval))
+      CALL MatSetValues(matrix%a,1,i-1,SIZE(j),j-1,setval,INSERT_VALUES,ierr)
+      matrix%isAssembled=.FALSE.
+    ENDSUBROUTINE setRow_PETScMatrixType
+
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets the values in the PETSc matrix - presently untested

--- a/unit_tests/testMatrixTypes/CMakeLists.txt
+++ b/unit_tests/testMatrixTypes/CMakeLists.txt
@@ -8,3 +8,4 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 INCLUDE(Futility_CreateUnitTest)
 Futility_CreateUnitTest(testMatrixTypes)
+Futility_CreateParUnitTest(testMatrixTypesParallel 2)

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -1,0 +1,170 @@
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+!                          Futility Development Group                          !
+!                             All rights reserved.                             !
+!                                                                              !
+! Futility is a jointly-maintained, open-source project between the University !
+! of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
+! can be found in LICENSE.txt in the head directory of this repository.        !
+!++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+PROGRAM testMatrixTypesParallel
+#include "UnitTest.h"
+  USE ISO_FORTRAN_ENV
+  USE ISO_C_BINDING
+  USE UnitTest
+  USE IntrType
+  USE ExceptionHandler
+  USE trilinos_interfaces
+  USE ParameterLists
+  USE ParallelEnv
+  USE VectorTypes
+  USE MatrixTypes
+
+
+  IMPLICIT NONE
+
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <petsc/finclude/petsc.h>
+#else
+#include <finclude/petsc.h>
+#endif
+#undef IS
+  PetscErrorCode  :: ierr
+#else
+#ifdef HAVE_MPI
+#include <mpif.h>
+  INTEGER :: ierr
+#endif
+#endif
+  TYPE(ExceptionHandlerType),TARGET :: e
+
+  CREATE_TEST('Test Matrix Types Parallel')
+
+
+#ifdef HAVE_MPI
+  CALL MPI_Init(ierr)
+#endif
+#ifdef FUTILITY_HAVE_PETSC
+  CALL PetscInitialize(PETSC_NULL_CHARACTER,ierr)
+#endif
+
+  !Configure exception handler for test
+  CALL e%setStopOnError(.FALSE.)
+  CALL e%setQuietMode(.TRUE.)
+  CALL eParams%addSurrogate(e)
+  CALL eMatrixType%addSurrogate(e)
+
+  REGISTER_SUBTEST("Matrix Types",testMatrix)
+
+
+#ifdef FUTILITY_HAVE_PETSC
+  CALL PetscFinalize(ierr)
+#endif
+#ifdef HAVE_MPI
+  CALL MPI_Finalize(ierr)
+#endif
+  FINALIZE_TEST()
+
+CONTAINS
+!
+!-------------------------------------------------------------------------------
+    SUBROUTINE testMatrix()
+#ifdef HAVE_MPI
+      TYPE(ParamType) :: pList
+      INTEGER(SIK) :: rank, nproc, mpierr
+#if defined(FUTILITY_HAVE_PETSC) || defined(FUTILITY_HAVE_Trilinos)
+      CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
+      REAL(SRK) :: val
+#endif
+
+      CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
+      CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+
+      ASSERT(nproc==2, 'nproc valid')
+
+      ! Create matrix that looks like this
+      ! 1 0 2 0
+      ! 0 3 0 4
+      ! 0 0 5 0
+      ! 6 7 0 0
+      ! Rank 0 owns rows 1 and 2
+      ! Rank 1 owns rows 3 and 4
+
+      CALL pList%add('MatrixType->n',4_SNK)
+      CALL pList%add('MatrixType->nLocal',2_SNK)
+      CALL pList%add('MatrixType->nnz',2_SNK)
+      CALL pList%add('MatrixType->onz',2_SNK)
+      CALL pList%add('MatrixType->matType',SPARSE)
+      CALL pList%add('MatrixType->isSym',.FALSE.)
+      CALL pList%add('MatrixType->MPI_COMM_ID',MPI_COMM_WORLD)
+
+#ifdef FUTILITY_HAVE_PETSC
+      ALLOCATE(PETScMatrixType::thisMatrix)
+
+      CALL thisMatrix%init(pList)
+
+
+      !Perform test of init function
+      ASSERT(thisMatrix%isInit, "init")
+      ASSERT(thisMatrix%n==4, "global size")
+
+      ! Test setting/getting single elements at a time
+      CALL thisMatrix%set(1,1,1._SRK)
+      CALL thisMatrix%set(1,3,2._SRK)
+      CALL thisMatrix%set(2,2,3._SRK)
+      CALL thisMatrix%set(2,4,4._SRK)
+      CALL thisMatrix%set(3,3,5._SRK)
+      CALL thisMatrix%set(4,1,6._SRK)
+      CALL thisMatrix%set(4,2,7._SRK)
+
+      IF(rank==0) THEN
+        CALL thisMatrix%get(1,1,val)
+        ASSERT(val .APPROXEQ. 1._SRK, "getOne")
+        CALL thisMatrix%get(1,3,val)
+        ASSERT(val .APPROXEQ. 2._SRK, "getOne")
+        CALL thisMatrix%get(2,2,val)
+        ASSERT(val .APPROXEQ. 3._SRK, "getOne")
+        CALL thisMatrix%get(2,4,val)
+        ASSERT(val .APPROXEQ. 4._SRK, "getOne")
+      ELSE
+        CALL thisMatrix%get(3,3,val)
+        ASSERT(val .APPROXEQ. 5._SRK, "getOne")
+        CALL thisMatrix%get(4,1,val)
+        ASSERT(val .APPROXEQ. 6._SRK, "getOne")
+        CALL thisMatrix%get(4,2,val)
+        ASSERT(val .APPROXEQ. 7._SRK, "getOne")
+      ENDIF
+
+      ! Test setting row all at once
+      CALL thisMatrix%setRow(1,[1, 3],[10._SRK, 11._SRK])
+      CALL thisMatrix%setRow(2,[2, 4],[12._SRK, 13._SRK])
+      CALL thisMatrix%setRow(3,[3],[14._SRK])
+      CALL thisMatrix%setRow(4,[1, 2],[15._SRK, 16._SRK])
+
+      IF(rank==0) THEN
+        CALL thisMatrix%get(1,1,val)
+        ASSERT(val .APPROXEQ. 10._SRK, "getOne")
+        CALL thisMatrix%get(1,3,val)
+        ASSERT(val .APPROXEQ. 11._SRK, "getOne")
+        CALL thisMatrix%get(2,2,val)
+        ASSERT(val .APPROXEQ. 12._SRK, "getOne")
+        CALL thisMatrix%get(2,4,val)
+        ASSERT(val .APPROXEQ. 13._SRK, "getOne")
+      ELSE
+        CALL thisMatrix%get(3,3,val)
+        ASSERT(val .APPROXEQ. 14._SRK, "getOne")
+        CALL thisMatrix%get(4,1,val)
+        ASSERT(val .APPROXEQ. 15._SRK, "getOne")
+        CALL thisMatrix%get(4,2,val)
+        ASSERT(val .APPROXEQ. 16._SRK, "getOne")
+      ENDIF
+
+      CALL thisMatrix%clear()
+      DEALLOCATE(thisMatrix)
+#endif
+      CALL pList%clear()
+
+#endif
+    ENDSUBROUTINE testMatrix
+ENDPROGRAM testMatrixTypesParallel


### PR DESCRIPTION
Description:
Allows the user to build a matrix row-by-row instead of one element
at a time, which can be much faster.

CASL Ticket # - N/A