### PR TITLE
Fixing the case where a size 0 array is passed as an input argument.

### DIFF
--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -220,29 +220,32 @@ MODULE ArrayUtils
       REAL(SRK),ALLOCATABLE :: tmpr(:)
 
       n=SIZE(r,DIM=1)
-      IF(PRESENT(delta)) THEN
-        IF(delta) THEN
-          CALL getAbsolute_1DReal(r,tmpr)
-          n=SIZE(tmpr,DIM=1)
+      sout=0
+      IF(n > 0) THEN
+        IF(PRESENT(delta)) THEN
+          IF(delta) THEN
+            CALL getAbsolute_1DReal(r,tmpr)
+            n=SIZE(tmpr,DIM=1)
+          ENDIF
         ENDIF
-      ENDIF
-      IF(.NOT.ALLOCATED(tmpr)) THEN
-        ALLOCATE(tmpr(n))
-        tmpr=r
-      ENDIF
-      loctol=EPSREAL*100.0_SRK
-      IF(PRESENT(tol)) THEN
-        IF((0.0_SRK < tol)) loctol=tol
-      ENDIF
+        IF(.NOT.ALLOCATED(tmpr)) THEN
+          ALLOCATE(tmpr(n))
+          tmpr=r
+        ENDIF
+        loctol=EPSREAL*100.0_SRK
+        IF(PRESENT(tol)) THEN
+          IF((0.0_SRK < tol)) loctol=tol
+        ENDIF
 
-      !Find the number of unique entries
-      CALL sort(tmpr)
-      sout=1
-      DO i=2,n
-        IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) sout=sout+1
-      ENDDO
-      !Deallocate
-      DEALLOCATE(tmpr)
+        !Find the number of unique entries
+        CALL sort(tmpr)
+        sout=1
+        DO i=2,n
+          IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) sout=sout+1
+        ENDDO
+        !Deallocate
+        DEALLOCATE(tmpr)
+      ENDIF
     ENDFUNCTION findNUnique_1DReal
 !
 !-------------------------------------------------------------------------------
@@ -262,25 +265,28 @@ MODULE ArrayUtils
       INTEGER(SIK),ALLOCATABLE :: tmpr(:)
 
       n=SIZE(r,DIM=1)
-      IF(PRESENT(delta)) THEN
-        IF(delta) THEN
-          CALL getAbsolute_1DInt(r,tmpr)
-          n=SIZE(tmpr,DIM=1)
+      sout=0
+      IF(n > 0) THEN
+        IF(PRESENT(delta)) THEN
+          IF(delta) THEN
+            CALL getAbsolute_1DInt(r,tmpr)
+            n=SIZE(tmpr,DIM=1)
+          ENDIF
         ENDIF
-      ENDIF
-      IF(.NOT.ALLOCATED(tmpr)) THEN
-        ALLOCATE(tmpr(n))
-        tmpr=r
-      ENDIF
+        IF(.NOT.ALLOCATED(tmpr)) THEN
+          ALLOCATE(tmpr(n))
+          tmpr=r
+        ENDIF
 
-      !Find the number of unique entries
-      CALL sort(tmpr)
-      sout=1
-      DO i=2,n
-        IF(tmpr(i-1) /= tmpr(i)) sout=sout+1
-      ENDDO
-      !Deallocate
-      DEALLOCATE(tmpr)
+        !Find the number of unique entries
+        CALL sort(tmpr)
+        sout=1
+        DO i=2,n
+          IF(tmpr(i-1) /= tmpr(i)) sout=sout+1
+        ENDDO
+        !Deallocate
+        DEALLOCATE(tmpr)
+      ENDIF
     ENDFUNCTION findNUnique_1DInt
 !
 !-------------------------------------------------------------------------------
@@ -304,21 +310,23 @@ MODULE ArrayUtils
       TYPE(StringType),ALLOCATABLE :: tmpr(:)
 
       n=SIZE(r,DIM=1)
-      ALLOCATE(tmpr(n))
-      tmpr=r
-
-      !Find the number of unique entries
-      DO i=1,n
-        DO j=i+1,n
-          IF((TRIM(tmpr(i)) == TRIM(tmpr(j))) .AND. (LEN_TRIM(tmpr(j)) > 0)) tmpr(j)=''
-        ENDDO
-      ENDDO
       sout=0
-      DO i=1,n
-        IF(TRIM(tmpr(i)) /= '') sout=sout+1
-      ENDDO
-      !Deallocate
-      DEALLOCATE(tmpr)
+      IF(n > 0) THEN
+        ALLOCATE(tmpr(n))
+        tmpr=r
+
+        !Find the number of unique entries
+        DO i=1,n
+          DO j=i+1,n
+            IF((TRIM(tmpr(i)) == TRIM(tmpr(j))) .AND. (LEN_TRIM(tmpr(j)) > 0)) tmpr(j)=''
+          ENDDO
+        ENDDO
+        DO i=1,n
+          IF(TRIM(tmpr(i)) /= '') sout=sout+1
+        ENDDO
+        !Deallocate
+        DEALLOCATE(tmpr)
+      ENDIF
     ENDFUNCTION findNUnique_1DString
 !
 !-------------------------------------------------------------------------------
@@ -343,6 +351,8 @@ MODULE ArrayUtils
 
       n=SIZE(r,DIM=1)
       m=SIZE(r,DIM=2)
+      
+      sout=0
       IF(n > 0 .AND. m > 0) THEN
         ALLOCATE(tmpr(n,m))
         tmpr=r
@@ -390,40 +400,43 @@ MODULE ArrayUtils
       REAL(SRK),ALLOCATABLE :: tmpr(:)
 
       n=SIZE(r,DIM=1)
-      IF(PRESENT(delta)) THEN
-        IF(delta) THEN
-          CALL getAbsolute_1DReal(r,tmpr)
-          n=SIZE(tmpr,DIM=1)
+      IF(ALLOCATED(rout)) DEALLOCATE(rout)
+      IF(n > 0) THEN
+        IF(PRESENT(delta)) THEN
+          IF(delta) THEN
+            CALL getAbsolute_1DReal(r,tmpr)
+            n=SIZE(tmpr,DIM=1)
+          ENDIF
         ENDIF
-      ENDIF
-      IF(.NOT.ALLOCATED(tmpr)) THEN
-        ALLOCATE(tmpr(n))
-        tmpr=r
-      ENDIF
-      loctol=EPSREAL*100.0_SRK
-      IF(PRESENT(tol)) THEN
-        IF((0.0_SRK < tol)) loctol=tol
-      ENDIF
-
-      !Find the number of unique entries
-      CALL sort(tmpr)
-      sout=1
-      DO i=2,n
-        IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) sout=sout+1
-      ENDDO
-      ALLOCATE(rout(sout))
-      rout=0.0_SRK
-      rout(1)=tmpr(1)
-      sout=2
-      DO i=2,n
-        IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) THEN
-          rout(sout)=tmpr(i)
-          sout=sout+1
+        IF(.NOT.ALLOCATED(tmpr)) THEN
+          ALLOCATE(tmpr(n))
+          tmpr=r
         ENDIF
-      ENDDO
+        loctol=EPSREAL*100.0_SRK
+        IF(PRESENT(tol)) THEN
+          IF((0.0_SRK < tol)) loctol=tol
+        ENDIF
 
-      !Deallocate
-      DEALLOCATE(tmpr)
+        !Find the number of unique entries
+        CALL sort(tmpr)
+        sout=1
+        DO i=2,n
+          IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) sout=sout+1
+        ENDDO
+        ALLOCATE(rout(sout))
+        rout=0.0_SRK
+        rout(1)=tmpr(1)
+        sout=2
+        DO i=2,n
+          IF(.NOT. SOFTEQ(tmpr(i-1),tmpr(i),loctol)) THEN
+            rout(sout)=tmpr(i)
+            sout=sout+1
+          ENDIF
+        ENDDO
+
+        !Deallocate
+        DEALLOCATE(tmpr)
+      ENDIF
     ENDSUBROUTINE getUnique_1DReal
 !
 !-------------------------------------------------------------------------------
@@ -443,35 +456,38 @@ MODULE ArrayUtils
       INTEGER(SIK),ALLOCATABLE :: tmpr(:)
 
       n=SIZE(r,DIM=1)
-      IF(PRESENT(delta)) THEN
-        IF(delta) THEN
-          CALL getAbsolute_1DInt(r,tmpr)
-          n=SIZE(tmpr,DIM=1)
+      IF(ALLOCATED(rout)) DEALLOCATE(rout)
+      IF(n > 0) THEN
+        IF(PRESENT(delta)) THEN
+          IF(delta) THEN
+            CALL getAbsolute_1DInt(r,tmpr)
+            n=SIZE(tmpr,DIM=1)
+          ENDIF
         ENDIF
-      ENDIF
-      IF(.NOT.ALLOCATED(tmpr)) THEN
-        ALLOCATE(tmpr(n))
-        tmpr=r
-      ENDIF
+        IF(.NOT.ALLOCATED(tmpr)) THEN
+          ALLOCATE(tmpr(n))
+          tmpr=r
+        ENDIF
 
-      !Find the number of unique entries
-      CALL sort(tmpr)
-      sout=1
-      DO i=2,n
-        IF(tmpr(i-1) /= tmpr(i)) sout=sout+1
-      ENDDO
-      ALLOCATE(rout(sout))
-      rout=0
-      rout(1)=tmpr(1)
-      sout=2
-      DO i=2,n
-        IF(tmpr(i-1) /= tmpr(i)) THEN
-          rout(sout)=tmpr(i)
-          sout=sout+1
-        ENDIF
-      ENDDO
-      !Deallocate
-      DEALLOCATE(tmpr)
+        !Find the number of unique entries
+        CALL sort(tmpr)
+        sout=1
+        DO i=2,n
+          IF(tmpr(i-1) /= tmpr(i)) sout=sout+1
+        ENDDO
+        ALLOCATE(rout(sout))
+        rout=0
+        rout(1)=tmpr(1)
+        sout=2
+        DO i=2,n
+          IF(tmpr(i-1) /= tmpr(i)) THEN
+            rout(sout)=tmpr(i)
+            sout=sout+1
+          ENDIF
+        ENDDO
+        !Deallocate
+        DEALLOCATE(tmpr)
+      ENDIF
     ENDSUBROUTINE getUnique_1DInt
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -22,7 +22,7 @@ PROGRAM testArrayUtils
   INTEGER(SIK) :: tmpintarray(10)
   INTEGER(SIK),ALLOCATABLE :: tmpi(:)
   TYPE(StringType) :: tmpstr1a(10),tmpstr2a(2,2),str2a(2,3)
-  TYPE(StringType),ALLOCATABLE :: tmps1(:)
+  TYPE(StringType),ALLOCATABLE :: tmps1(:),tmps2(:,:)
 !
 !Check the timer resolution
   CREATE_TEST('ArrayUtils')
@@ -129,6 +129,56 @@ PROGRAM testArrayUtils
       ASSERT(bool,'findNUnique == 3,tol=EPSREAL*1000.0_SRK')
       bool=findNUnique(tmprealarray,tol=EPSREAL*10000.0_SRK) == 3
       ASSERT(bool,'findNUnique == 3,tol=EPSREAL*10000.0_SRK')
+      ASSERT(findNUnique(tmprealarray(1:0)) == 0,'0 subset size')
+      IF(ALLOCATED(tmpr)) DEALLOCATE(tmpr)
+      ALLOCATE(tmpr(0))
+      ASSERT(findNUnique(tmpr) == 0,'size 0 array')
+
+      COMPONENT_TEST('getUnique 1-D Array')
+      tmprealarray(1)=1.0_SRK
+      tmprealarray(2)=1.0_SRK
+      tmprealarray(3)=1.0000000000000010_SRK
+      tmprealarray(4)=1.0000000000100000_SRK
+      tmprealarray(5)=2.0_SRK
+      tmprealarray(6)=2.0_SRK
+      tmprealarray(7)=2.0_SRK
+      tmprealarray(8)=2.0_SRK
+      tmprealarray(9)=2.0_SRK
+      tmprealarray(10)=2.0_SRK
+      CALL getUnique(tmprealarray,tmpr)
+      bool=ALL(tmpr == (/1.0_SRK,1.0000000000100000_SRK,2.0_SRK/))
+      ASSERT(bool,'getUnique, 3 unique')
+      tmprealarray(3)=1.0000000000000100_SRK
+      CALL getUnique(tmprealarray,tmpr,TOL=1.E-15_SRK)
+      bool=ALL(tmpr == (/1.0_SRK,1.0000000000000100_SRK,1.0000000000100000_SRK,2.0_SRK/))
+      ASSERT(bool,'getUnique, 4 unique with TOL')
+      tmprealarray(3)=1.0000000000100001_SRK
+      CALL getUnique(tmprealarray,tmpr,TOL=1.E-15_SRK)
+      bool=ALL(tmpr == (/1.0_SRK,1.0000000000100000_SRK,2.0_SRK/))
+      ASSERT(bool,'getUnique, 3 unique with TOL')
+      CALL getUnique(tmprealarray(1:0),tmpr)
+      ASSERT(.NOT. ALLOCATED(tmpr),'getUnique, size 0 array')
+
+      !bool=findNUnique(tmprealarray) == 3
+      !ASSERT(bool,'findNUnique == 3')
+      !tmprealarray(4)=1.000000000000100_SRK
+      !bool=findNUnique(tmprealarray,tol=EPSREAL) == 3
+      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL')
+      !tmprealarray(4)=1.000000000001000_SRK
+      !bool=findNUnique(tmprealarray,tol=EPSREAL*10.0_SRK) == 3
+      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*10.0_SRK')
+      !tmprealarray(4)=1.000000000010000_SRK
+      !bool=findNUnique(tmprealarray,tol=EPSREAL*100.0_SRK) == 3
+      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*100.0_SRK')
+      !tmprealarray(4)=1.000000000100000_SRK
+      !bool=findNUnique(tmprealarray,tol=EPSREAL*1000.0_SRK) == 3
+      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*1000.0_SRK')
+      !bool=findNUnique(tmprealarray,tol=EPSREAL*10000.0_SRK) == 3
+      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*10000.0_SRK')
+      !ASSERT(findNUnique(tmprealarray(1:0)) == 0,'0 subset size')
+      !IF(ALLOCATED(tmpr)) DEALLOCATE(tmpr)
+      !ALLOCATE(tmpr(0))
+      !ASSERT(findNUnique(tmpr) == 0,'size 0 array')
 
       !
       COMPONENT_TEST('findIndex 1-D Array')
@@ -401,6 +451,10 @@ PROGRAM testArrayUtils
       tmpintarray(5)=20
       tmpintarray(9)=100
       ASSERT(findNUnique(tmpintarray) == 7,'3 duplicates')
+      ASSERT(findNUnique(tmpintarray(1:0)) == 0,'0 subset size')
+      IF(ALLOCATED(tmpi)) DEALLOCATE(tmpi)
+      ALLOCATE(tmpi(0))
+      ASSERT(findNUnique(tmpi) == 0,'size 0 array')
       !
       COMPONENT_TEST('getUnique 1-D Array')
       tmpintarray(1)=0
@@ -422,6 +476,8 @@ PROGRAM testArrayUtils
       CALL getUnique(tmpintarray,tmpi)
       bool=ALL(tmpi == (/0,2,5,20,25,40,100/))
       ASSERT(bool,'getUnique, 3 duplicates')
+      CALL getUnique(tmpintarray(1:0),tmpi)
+      ASSERT(.NOT. ALLOCATED(tmpi),'getUnique, size 0 array')
 
       COMPONENT_TEST('boundCheck 1-D Ints')
       ASSERT(boundCheck(tmpintarray,3),'in bounds not-allocatable')
@@ -454,6 +510,10 @@ PROGRAM testArrayUtils
       tmpstr1a(5)='four'
       tmpstr1a(10)='nine'
       ASSERT(findNUnique(tmpstr1a) == 7,'3 duplicates array')
+      ASSERT(findNUnique(tmpstr1a(1:0)) == 0,'0 subset size')
+      IF(ALLOCATED(tmps1)) DEALLOCATE(tmps1)
+      ALLOCATE(tmps1(0))
+      ASSERT(findNUnique(tmps1) == 0,'size 0 array')
 
       !getUnique_1DStrings
       COMPONENT_TEST('getUnique 1-D Array')
@@ -510,6 +570,11 @@ PROGRAM testArrayUtils
 
       str2a='one'; str2a(2,3)='two'
       ASSERT(findNUnique(str2a) == 2,'one unique array')
+
+      ASSERT(findNUnique(tmpstr2a(1:0,1:0)) == 0,'0 subset size')
+      IF(ALLOCATED(tmps2)) DEALLOCATE(tmps2)
+      ALLOCATE(tmps2(0,0))
+      ASSERT(findNUnique(tmps2) == 0,'size 0 array')
 
       !getUnique_1DStrings
       COMPONENT_TEST('getUnique 2-D Array')

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -159,27 +159,6 @@ PROGRAM testArrayUtils
       CALL getUnique(tmprealarray(1:0),tmpr)
       ASSERT(.NOT. ALLOCATED(tmpr),'getUnique, size 0 array')
 
-      !bool=findNUnique(tmprealarray) == 3
-      !ASSERT(bool,'findNUnique == 3')
-      !tmprealarray(4)=1.000000000000100_SRK
-      !bool=findNUnique(tmprealarray,tol=EPSREAL) == 3
-      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL')
-      !tmprealarray(4)=1.000000000001000_SRK
-      !bool=findNUnique(tmprealarray,tol=EPSREAL*10.0_SRK) == 3
-      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*10.0_SRK')
-      !tmprealarray(4)=1.000000000010000_SRK
-      !bool=findNUnique(tmprealarray,tol=EPSREAL*100.0_SRK) == 3
-      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*100.0_SRK')
-      !tmprealarray(4)=1.000000000100000_SRK
-      !bool=findNUnique(tmprealarray,tol=EPSREAL*1000.0_SRK) == 3
-      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*1000.0_SRK')
-      !bool=findNUnique(tmprealarray,tol=EPSREAL*10000.0_SRK) == 3
-      !ASSERT(bool,'findNUnique == 3,tol=EPSREAL*10000.0_SRK')
-      !ASSERT(findNUnique(tmprealarray(1:0)) == 0,'0 subset size')
-      !IF(ALLOCATED(tmpr)) DEALLOCATE(tmpr)
-      !ALLOCATE(tmpr(0))
-      !ASSERT(findNUnique(tmpr) == 0,'size 0 array')
-
       !
       COMPONENT_TEST('findIndex 1-D Array')
       !Test with 0.0 specified


### PR DESCRIPTION
Description:
I encountered a need for this to return zero if I pass in an array
subset making it a size 0 array (e.g. tmparray(1:0)).  Before this fix
it would return a 1, which can't be the case if there are no entries in
the array to be unique.  Added test cases for all of the unit test
types.

Also fixed a similar bug for getUnique.  Added tests for that as well.

CASL Ticket # - N/A