### PR TITLE
Fixing SLEPc usage for >= version 3.6

### DIFF
--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -62,11 +62,19 @@ MODULE EigenvalueSolverTypes
 #else
 #include <finclude/petsc.h>
 #endif
-!petscisdef.h defines the keyword IS, and it needs to be reset
+
 #ifdef FUTILITY_HAVE_SLEPC
+!SLEPC version == PETSC version
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <slepc/finclude/slepcsys.h>
+#include <slepc/finclude/slepceps.h>
+#else
 #include <finclude/slepcsys.h>
 #include <finclude/slepceps.h>
 #endif
+#endif
+
+!petscisdef.h defines the keyword IS, and it needs to be reset
 #undef IS
 #endif
 
@@ -720,7 +728,11 @@ MODULE EigenvalueSolverTypes
 
       SELECTTYPE(solver); TYPE IS(EigenvalueSolverType_SLEPc)
 #ifdef FUTILITY_HAVE_SLEPC
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+        CALL EPSComputeError(solver%eps,0,EPS_ERROR_RELATIVE,resid,ierr)
+#else
         CALL EPSComputeRelativeError(solver%eps,0,resid,ierr)
+#endif
         CALL EPSGetIterationNumber(solver%eps,its,ierr)
 #endif
       TYPE IS(EigenvalueSolverType_Anasazi)

--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -56,11 +56,19 @@ MODULE PartitionGraph
 #else
 #include <finclude/petsc.h>
 #endif
-!petscisdef.h defines the keyword IS, and it needs to be reset
+
 #ifdef FUTILITY_HAVE_SLEPC
+!SLEPC version == PETSC version
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <slepc/finclude/slepcsys.h>
+#include <slepc/finclude/slepceps.h>
+#else
 #include <finclude/slepcsys.h>
 #include <finclude/slepceps.h>
 #endif
+#endif
+
+!petscisdef.h defines the keyword IS, and it needs to be reset
 #undef IS
 #endif
 

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -31,7 +31,14 @@ PROGRAM testPartitionGraph
 #else
 #include <finclude/petsc.h>
 #endif
+
+!SLEPC version == PETSC version
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#include <slepc/finclude/slepc.h>
+#else
 #include <finclude/slepc.h>
+#endif
+
 #undef IS
   PetscErrorCode  :: ierr
 #endif

--- a/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
+++ b/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
@@ -10,12 +10,13 @@ PROGRAM testTPLSLEPC
 
   IMPLICIT NONE
 
-#include <finclude/slepc.h>
 #include <petscversion.h>
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
+#include <slepc/finclude/slepc.h>
 #else
 #include <finclude/petsc.h>
+#include <finclude/slepc.h>
 #endif
 #undef IS
 
@@ -193,7 +194,11 @@ PROGRAM testTPLSLEPC
         CALL EPSGetEigenpair(eps,i,kr,ki,PETSC_NULL_OBJECT,PETSC_NULL_OBJECT,ierr)
 
         ! Compute the relative error associated to each eigenpair
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+        CALL EPSComputeError(eps,i,EPS_ERROR_RELATIVE,error,ierr)
+#else
         CALL EPSComputeRelativeError(eps,i,error,ierr)
+#endif
         IF(rank == 0) THEN
           WRITE(*,'(A,F20.15,A,ES25.15)') '       ',PetscRealPart(kr),'       ',error
           !check eigenvalue


### PR DESCRIPTION
Description:
Like versions >=3.6 of PETSc the location of the Fortran include
directories changed. The ifdefs are modified to work with newer
and older versions of SLEPc like with PETSc.

The usage of EPSComputeError also changed. Therefore, this was
updated.

CASL Ticket # - #5077