### PR TITLE
Add FINAL procedures for ParameterLists type

### DIFF
--- a/src/ParameterLists.f90
+++ b/src/ParameterLists.f90
@@ -494,6 +494,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType
       !> @copydoc ParameterLists::clear_ParamType
       PROCEDURE,PASS :: clear => clear_ParamType
+      !> @copybrief ParameterLists::clear_ParamType
+      !> @copydoc ParameterLists::clear_ParamType
+      FINAL :: clearFinal_ParamType
 #ifdef FUTILITY_HAVE_Trilinos
       PROCEDURE,PASS :: toTeuchosPlist
 #endif
@@ -513,6 +516,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_List
       !> @copydoc ParameterLists::clear_ParamType_List
       PROCEDURE,PASS :: clear => clear_ParamType_List
+      !> @copybrief ParameterLists::clearFinal_ParamType_List
+      !> @copydoc ParameterLists::clearFinal_ParamType_List
+      FINAL :: clearFinal_ParamType_List
   ENDTYPE ParamType_List
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -529,6 +535,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SSK
       !> @copydoc ParameterLists::clear_ParamType_SSK
       PROCEDURE,PASS :: clear => clear_ParamType_SSK
+      !> @copybrief ParameterLists::clearFinal_ParamType_SSK
+      !> @copydoc ParameterLists::clearFinal_ParamType_SSK
+      FINAL :: clearFinal_ParamType_SSK
   ENDTYPE ParamType_SSK
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -545,6 +554,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SDK
       !> @copydoc ParameterLists::clear_ParamType_SDK
       PROCEDURE,PASS :: clear => clear_ParamType_SDK
+      !> @copybrief ParameterLists::clearFinal_ParamType_SDK
+      !> @copydoc ParameterLists::clearFinal_ParamType_SDK
+      FINAL :: clearFinal_ParamType_SDK
   ENDTYPE ParamType_SDK
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -561,6 +573,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SNK
       !> @copydoc ParameterLists::clear_ParamType_SNK
       PROCEDURE,PASS :: clear => clear_ParamType_SNK
+      !> @copybrief ParameterLists::clearFinal_ParamType_SNK
+      !> @copydoc ParameterLists::clearFinal_ParamType_SNK
+      FINAL :: clearFinal_ParamType_SNK
   ENDTYPE ParamType_SNK
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -577,6 +592,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SLK
       !> @copydoc ParameterLists::clear_ParamType_SLK
       PROCEDURE,PASS :: clear => clear_ParamType_SLK
+      !> @copybrief ParameterLists::clearFinal_ParamType_SLK
+      !> @copydoc ParameterLists::clearFinal_ParamType_SLK
+      FINAL :: clearFinal_ParamType_SLK
   ENDTYPE ParamType_SLK
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -593,6 +611,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SBK
       !> @copydoc ParameterLists::clear_ParamType_SBK
       PROCEDURE,PASS :: clear => clear_ParamType_SBK
+      !> @copybrief ParameterLists::clearFinal_ParamType_SBK
+      !> @copydoc ParameterLists::clearFinal_ParamType_SBK
+      FINAL :: clearFinal_ParamType_SBK
   ENDTYPE ParamType_SBK
 
   !> @brief Extended type of a ParamType for defining a parameter that
@@ -609,6 +630,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_STR
       !> @copydoc ParameterLists::clear_ParamType_STR
       PROCEDURE,PASS :: clear => clear_ParamType_STR
+      !> @copybrief ParameterLists::clearFinal_ParamType_STR
+      !> @copydoc ParameterLists::clearFinal_ParamType_STR
+      FINAL :: clearFinal_ParamType_STR
   ENDTYPE ParamType_STR
 !----------------------------------------------------------------------
 !     One-Dimensional Arrays
@@ -627,6 +651,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SSK_a1
       !> @copydoc ParameterLists::clear_ParamType_SSK_a1
       PROCEDURE,PASS :: clear => clear_ParamType_SSK_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_SSK_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_SSK_a1
+      FINAL :: clearFinal_ParamType_SSK_a1
   ENDTYPE ParamType_SSK_a1
 
   !> @brief Extended type of a ParamType for defining a one dimensional
@@ -643,6 +670,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SDK_a1
       !> @copydoc ParameterLists::clear_ParamType_SDK_a1
       PROCEDURE,PASS :: clear => clear_ParamType_SDK_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_SDK_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_SDK_a1
+      FINAL :: clearFinal_ParamType_SDK_a1
   ENDTYPE ParamType_SDK_a1
 
   !> @brief Extended type of a ParamType for defining a one dimensional
@@ -659,6 +689,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SNK_a1
       !> @copydoc ParameterLists::clear_ParamType_SNK_a1
       PROCEDURE,PASS :: clear => clear_ParamType_SNK_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_SNK_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_SNK_a1
+      FINAL :: clearFinal_ParamType_SNK_a1
   ENDTYPE ParamType_SNK_a1
 
   !> @brief Extended type of a ParamType for defining a one dimensional
@@ -675,6 +708,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SLK_a1
       !> @copydoc ParameterLists::clear_ParamType_SLK_a1
       PROCEDURE,PASS :: clear => clear_ParamType_SLK_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_SLK_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_SLK_a1
+      FINAL :: clearFinal_ParamType_SLK_a1
   ENDTYPE ParamType_SLK_a1
 
   !> @brief Extended type of a ParamType for defining a one dimensional
@@ -691,6 +727,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SBK_a1
       !> @copydoc ParameterLists::clear_ParamType_SBK_a1
       PROCEDURE,PASS :: clear => clear_ParamType_SBK_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_SBK_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_SBK_a1
+      FINAL :: clearFinal_ParamType_SBK_a1
   ENDTYPE ParamType_SBK_a1
 
   !> @brief Extended type of a ParamType for defining a one dimensional
@@ -707,6 +746,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_STR_a1
       !> @copydoc ParameterLists::clear_ParamType_STR_a1
       PROCEDURE,PASS :: clear => clear_ParamType_STR_a1
+      !> @copybrief ParameterLists::clearFinal_ParamType_STR_a1
+      !> @copydoc ParameterLists::clearFinal_ParamType_STR_a1
+      FINAL :: clearFinal_ParamType_STR_a1
   ENDTYPE ParamType_STR_a1
 
 !----------------------------------------------------------------------
@@ -726,6 +768,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SSK_a2
       !> @copydoc ParameterLists::clear_ParamType_SSK_a2
       PROCEDURE,PASS :: clear => clear_ParamType_SSK_a2
+      !> @copybrief ParameterLists::clearFinal_ParamType_SSK_a2
+      !> @copydoc ParameterLists::clearFinal_ParamType_SSK_a2
+      FINAL :: clearFinal_ParamType_SSK_a2
   ENDTYPE ParamType_SSK_a2
 
   !> @brief Extended type of a ParamType for defining a two dimensional
@@ -742,6 +787,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SDK_a2
       !> @copydoc ParameterLists::clear_ParamType_SDK_a2
       PROCEDURE,PASS :: clear => clear_ParamType_SDK_a2
+      !> @copybrief ParameterLists::clearFinal_ParamType_SDK_a2
+      !> @copydoc ParameterLists::clearFinal_ParamType_SDK_a2
+      FINAL :: clearFinal_ParamType_SDK_a2
   ENDTYPE ParamType_SDK_a2
 
   !> @brief Extended type of a ParamType for defining a two dimensional
@@ -758,6 +806,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SNK_a2
       !> @copydoc ParameterLists::clear_ParamType_SNK_a2
       PROCEDURE,PASS :: clear => clear_ParamType_SNK_a2
+      !> @copybrief ParameterLists::clearFinal_ParamType_SNK_a2
+      !> @copydoc ParameterLists::clearFinal_ParamType_SNK_a2
+      FINAL :: clearFinal_ParamType_SNK_a2
   ENDTYPE ParamType_SNK_a2
 
   !> @brief Extended type of a ParamType for defining a two dimensional
@@ -774,6 +825,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SLK_a2
       !> @copydoc ParameterLists::clear_ParamType_SLK_a2
       PROCEDURE,PASS :: clear => clear_ParamType_SLK_a2
+      !> @copybrief ParameterLists::clearFinal_ParamType_SLK_a2
+      !> @copydoc ParameterLists::clearFinal_ParamType_SLK_a2
+      FINAL :: clearFinal_ParamType_SLK_a2
   ENDTYPE ParamType_SLK_a2
 
   !> @brief Extended type of a ParamType for defining a two dimensional
@@ -790,6 +844,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_STR_a2
       !> @copydoc ParameterLists::clear_ParamType_STR_a2
       PROCEDURE,PASS :: clear => clear_ParamType_STR_a2
+      !> @copybrief ParameterLists::clearFinal_ParamType_STR_a2
+      !> @copydoc ParameterLists::clearFinal_ParamType_STR_a2
+      FINAL :: clearFinal_ParamType_STR_a2
   ENDTYPE ParamType_STR_a2
 !----------------------------------------------------------------------
 !     Three-Dimensional Arrays
@@ -808,6 +865,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SSK_a3
       !> @copydoc ParameterLists::clear_ParamType_SSK_a3
       PROCEDURE,PASS :: clear => clear_ParamType_SSK_a3
+      !> @copybrief ParameterLists::clearFinal_ParamType_SSK_a3
+      !> @copydoc ParameterLists::clearFinal_ParamType_SSK_a3
+      FINAL :: clearFinal_ParamType_SSK_a3
   ENDTYPE ParamType_SSK_a3
 
   !> @brief Extended type of a ParamType for defining a three dimensional
@@ -824,6 +884,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SDK_a3
       !> @copydoc ParameterLists::clear_ParamType_SDK_a3
       PROCEDURE,PASS :: clear => clear_ParamType_SDK_a3
+      !> @copybrief ParameterLists::clearFinal_ParamType_SDK_a3
+      !> @copydoc ParameterLists::clearFinal_ParamType_SDK_a3
+      FINAL :: clearFinal_ParamType_SDK_a3
   ENDTYPE ParamType_SDK_a3
 
   !> @brief Extended type of a ParamType for defining a three dimensional
@@ -840,6 +903,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SNK_a3
       !> @copydoc ParameterLists::clear_ParamType_SNK_a3
       PROCEDURE,PASS :: clear => clear_ParamType_SNK_a3
+      !> @copybrief ParameterLists::clearFinal_ParamType_SNK_a3
+      !> @copydoc ParameterLists::clearFinal_ParamType_SNK_a3
+      FINAL :: clearFinal_ParamType_SNK_a3
   ENDTYPE ParamType_SNK_a3
 
   !> @brief Extended type of a ParamType for defining a three dimensional
@@ -856,6 +922,9 @@ MODULE ParameterLists
       !> @copybrief ParameterLists::clear_ParamType_SLK_a3
       !> @copydoc ParameterLists::clear_ParamType_SLK_a3
       PROCEDURE,PASS :: clear => clear_ParamType_SLK_a3
+      !> @copybrief ParameterLists::clearFinal_ParamType_SLK_a3
+      !> @copydoc ParameterLists::clearFinal_ParamType_SLK_a3
+      FINAL :: clearFinal_ParamType_SLK_a3
   ENDTYPE ParamType_SLK_a3
 !
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2385,6 +2454,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType(thisParam)
+      TYPE(ParamType),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType
+!
+!-------------------------------------------------------------------------------
 !> @brief Searches a parameter (thisParam) for a set of required parameters
 !> (reqParams) and determines if all the required parameters are present and
 !> of the correct type.
@@ -3180,6 +3259,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_List
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_List(thisParam)
+      TYPE(ParamType_List),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_List
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing parameter list to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
 !>        matching @c name will be to set the new value of @c paramlist
@@ -3483,6 +3572,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SSK
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK(thisParam)
+      TYPE(ParamType_SSK),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SSK
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing scalar single precision real valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -3736,6 +3835,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK(thisParam)
+      TYPE(ParamType_SDK),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SDK
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing scalar double precision real valued
@@ -3993,6 +4102,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SNK
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK(thisParam)
+      TYPE(ParamType_SNK),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SNK
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing scalar 32-bit integer valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -4242,6 +4361,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SLK
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK(thisParam)
+      TYPE(ParamType_SLK),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SLK
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing scalar 64-bit integer valued
@@ -4495,6 +4624,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SBK
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SBK(thisParam)
+      TYPE(ParamType_SBK),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SBK
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing scalar logical valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -4738,6 +4877,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_STR
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR(thisParam)
+      TYPE(ParamType_STR),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_STR
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing string derived type parameter to a new value.
@@ -5105,6 +5254,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SSK_a1
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a1(thisParam)
+      TYPE(ParamType_SSK_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SSK_a1
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing one dimensional array of single precision real valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -5404,6 +5563,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SDK_a1
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a1(thisParam)
+      TYPE(ParamType_SDK_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SDK_a1
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing one dimensional array of double precision real valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -5699,6 +5868,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SNK_a1
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a1(thisParam)
+      TYPE(ParamType_SNK_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SNK_a1
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing one dimensional array of 32-bit integer valued
@@ -5999,6 +6178,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SLK_a1
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a1(thisParam)
+      TYPE(ParamType_SLK_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SLK_a1
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing one dimensional array of 64-bit integer valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -6292,6 +6481,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SBK_a1
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SBK_a1(thisParam)
+      TYPE(ParamType_SBK_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SBK_a1
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing one dimensional array of logical valued
@@ -6593,6 +6792,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_STR_a1
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR_a1(thisParam)
+      TYPE(ParamType_STR_a1),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_STR_a1
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing string derived type parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
 !>        matching @c name will be to set the new value of @c param
@@ -6882,6 +7091,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SSK_a2
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a2(thisParam)
+      TYPE(ParamType_SSK_a2),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SSK_a2
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing two dimensional array of single precision real valued
@@ -7175,6 +7394,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SDK_a2
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a2(thisParam)
+      TYPE(ParamType_SDK_a2),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SDK_a2
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing two dimensional array of double precision real valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -7466,6 +7695,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SNK_a2
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a2(thisParam)
+      TYPE(ParamType_SNK_a2),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SNK_a2
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing two dimensional array of 32-bit integer valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -7755,6 +7994,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SLK_a2
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a2(thisParam)
+      TYPE(ParamType_SLK_a2),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SLK_a2
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing two dimensional array of 64-bit integer valued
@@ -8059,6 +8308,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_STR_a2
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR_a2(thisParam)
+      TYPE(ParamType_STR_a2),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_STR_a2
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing string derived type parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
 !>        matching @c name will be to set the new value of @c param
@@ -8353,6 +8612,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SSK_a3
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a3(thisParam)
+      TYPE(ParamType_SSK_a3),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SSK_a3
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing three dimensional array of single precision real valued
@@ -8653,6 +8922,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SDK_a3
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a3(thisParam)
+      TYPE(ParamType_SDK_a3),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SDK_a3
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing three dimensional array of double precision real valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -8951,6 +9230,16 @@ MODULE ParameterLists
     ENDSUBROUTINE clear_ParamType_SNK_a3
 !
 !-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a3(thisParam)
+      TYPE(ParamType_SNK_a3),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SNK_a3
+!
+!-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing three dimensional array of 32-bit integer valued
 !> parameter to a new value.
 !> @param thisParam the parameter in which an existing parameter with name
@@ -9247,6 +9536,16 @@ MODULE ParameterLists
       thisParam%dataType=''
       thisParam%description=''
     ENDSUBROUTINE clear_ParamType_SLK_a3
+!
+!-------------------------------------------------------------------------------
+!> @brief FINAL procedure for this type
+!> @param thisParam the parameter to clear
+!>
+!> Called automatically when object goes out of scope.
+   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a3(thisParam)
+      TYPE(ParamType_SLK_a3),INTENT(INOUT) :: thisParam
+      CALL thisParam%clear
+   ENDSUBROUTINE clearFinal_ParamType_SLK_a3
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the value of an existing three dimensional array of 64-bit integer valued

--- a/src/ParameterLists.f90
+++ b/src/ParameterLists.f90
@@ -2458,7 +2458,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType(thisParam)
+   SUBROUTINE clearFinal_ParamType(thisParam)
       TYPE(ParamType),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType
@@ -3263,7 +3263,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_List(thisParam)
+   SUBROUTINE clearFinal_ParamType_List(thisParam)
       TYPE(ParamType_List),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_List
@@ -3576,7 +3576,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK(thisParam)
+   SUBROUTINE clearFinal_ParamType_SSK(thisParam)
       TYPE(ParamType_SSK),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SSK
@@ -3841,7 +3841,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK(thisParam)
+   SUBROUTINE clearFinal_ParamType_SDK(thisParam)
       TYPE(ParamType_SDK),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SDK
@@ -4106,7 +4106,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK(thisParam)
+   SUBROUTINE clearFinal_ParamType_SNK(thisParam)
       TYPE(ParamType_SNK),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SNK
@@ -4367,7 +4367,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK(thisParam)
+   SUBROUTINE clearFinal_ParamType_SLK(thisParam)
       TYPE(ParamType_SLK),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SLK
@@ -4628,7 +4628,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SBK(thisParam)
+   SUBROUTINE clearFinal_ParamType_SBK(thisParam)
       TYPE(ParamType_SBK),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SBK
@@ -4883,7 +4883,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR(thisParam)
+   SUBROUTINE clearFinal_ParamType_STR(thisParam)
       TYPE(ParamType_STR),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_STR
@@ -5258,7 +5258,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_SSK_a1(thisParam)
       TYPE(ParamType_SSK_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SSK_a1
@@ -5567,7 +5567,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_SDK_a1(thisParam)
       TYPE(ParamType_SDK_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SDK_a1
@@ -5874,7 +5874,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_SNK_a1(thisParam)
       TYPE(ParamType_SNK_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SNK_a1
@@ -6182,7 +6182,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_SLK_a1(thisParam)
       TYPE(ParamType_SLK_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SLK_a1
@@ -6487,7 +6487,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SBK_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_SBK_a1(thisParam)
       TYPE(ParamType_SBK_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SBK_a1
@@ -6796,7 +6796,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR_a1(thisParam)
+   SUBROUTINE clearFinal_ParamType_STR_a1(thisParam)
       TYPE(ParamType_STR_a1),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_STR_a1
@@ -7097,7 +7097,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a2(thisParam)
+   SUBROUTINE clearFinal_ParamType_SSK_a2(thisParam)
       TYPE(ParamType_SSK_a2),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SSK_a2
@@ -7398,7 +7398,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a2(thisParam)
+   SUBROUTINE clearFinal_ParamType_SDK_a2(thisParam)
       TYPE(ParamType_SDK_a2),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SDK_a2
@@ -7699,7 +7699,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a2(thisParam)
+   SUBROUTINE clearFinal_ParamType_SNK_a2(thisParam)
       TYPE(ParamType_SNK_a2),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SNK_a2
@@ -8000,7 +8000,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a2(thisParam)
+   SUBROUTINE clearFinal_ParamType_SLK_a2(thisParam)
       TYPE(ParamType_SLK_a2),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SLK_a2
@@ -8312,7 +8312,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_STR_a2(thisParam)
+   SUBROUTINE clearFinal_ParamType_STR_a2(thisParam)
       TYPE(ParamType_STR_a2),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_STR_a2
@@ -8618,7 +8618,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SSK_a3(thisParam)
+   SUBROUTINE clearFinal_ParamType_SSK_a3(thisParam)
       TYPE(ParamType_SSK_a3),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SSK_a3
@@ -8926,7 +8926,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SDK_a3(thisParam)
+   SUBROUTINE clearFinal_ParamType_SDK_a3(thisParam)
       TYPE(ParamType_SDK_a3),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SDK_a3
@@ -9234,7 +9234,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SNK_a3(thisParam)
+   SUBROUTINE clearFinal_ParamType_SNK_a3(thisParam)
       TYPE(ParamType_SNK_a3),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SNK_a3
@@ -9542,7 +9542,7 @@ MODULE ParameterLists
 !> @param thisParam the parameter to clear
 !>
 !> Called automatically when object goes out of scope.
-   IMPURE ELEMENTAL SUBROUTINE clearFinal_ParamType_SLK_a3(thisParam)
+   SUBROUTINE clearFinal_ParamType_SLK_a3(thisParam)
       TYPE(ParamType_SLK_a3),INTENT(INOUT) :: thisParam
       CALL thisParam%clear
    ENDSUBROUTINE clearFinal_ParamType_SLK_a3


### PR DESCRIPTION
Note that I'm getting a ton of build warnings after adding this of the variety:

Warning: Only array FINAL procedures declared for derived type ‘paramtype’ defined at (1), suggest also scalar one [-Wsurprising]

However, as far as I can tell, the procedures *are* scalar ones.  I think it might be related to this compiler bug:

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58175

Which was detected in gcc 4.9 and persists even in 6.0...