### PR TITLE
Fixed compilation issue with FutilityComputingEnvironment for gcc 4.8.5

### DIFF
--- a/src/FutilityComputingEnvironment.f90
+++ b/src/FutilityComputingEnvironment.f90
@@ -132,7 +132,7 @@ ENDSUBROUTINE clear
 FUNCTION addTimer(this,name) RESULT(timer)
   CLASS(FutilityComputingEnvironment),INTENT(INOUT) :: this
   CHARACTER(LEN=*),INTENT(IN) :: name
-  TYPE(TimerType),POINTER :: timer
+  CLASS(TimerType),POINTER :: timer
   !
   INTEGER(SIK) :: iTimer
   TYPE(TimerPtrArray),ALLOCATABLE :: oldTimers(:)
@@ -185,7 +185,7 @@ SUBROUTINE removeTimer(this,name)
   CHARACTER(LEN=*),INTENT(IN) :: name
   !
   INTEGER(SIK) :: iTimer
-  TYPE(TimerType),POINTER :: timer
+  CLASS(TimerType),POINTER :: timer
   TYPE(TimerPtrArray),ALLOCATABLE :: oldTimers(:)
 
   timer => this%getTimer(name)
@@ -224,7 +224,7 @@ ENDSUBROUTINE removeTimer
 FUNCTION getTimer(this,name) RESULT(timer)
   CLASS(FutilityComputingEnvironment),INTENT(INOUT) :: this
   CHARACTER(LEN=*),INTENT(IN) :: name
-  TYPE(TimerType),POINTER :: timer
+  CLASS(TimerType),POINTER :: timer
   !
   INTEGER(SIK) :: iTimer
 

--- a/unit_tests/testFutilityComputingEnvironment/testFutilityComputingEnvironment.f90
+++ b/unit_tests/testFutilityComputingEnvironment/testFutilityComputingEnvironment.f90
@@ -46,7 +46,7 @@ CONTAINS
 !
 !-------------------------------------------------------------------------------
 SUBROUTINE testTimers()
-  TYPE(TimerType),POINTER :: timer
+  CLASS(TimerType),POINTER :: timer
 
   COMPONENT_TEST('addTimer')
   ASSERT_EQ(testCompEnv%nTimers,0,'%nTimers')


### PR DESCRIPTION
In routines adding or removing timers, changed
TYPE(TimerType) to CLASS(TimerType) in order to match the TimerPtrArray
specification.

When compiling with gcc 4.8.5 the following error was found, along with similar errors in other routines.
```
/home/apfitzge/MPACT/Futility/src/FutilityComputingEnvironment.f90:143.2:

  timer => this%getTimer(name)
  1
Error: Different types in pointer assignment at (1); attempted assignment of CLASS(timertype) to TYPE(timertype)
```
this change allows compilation to succeed and all unit-tests pass.