### PR TITLE
Hotfix: GMRES restarting

### DIFF
--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -1254,7 +1254,7 @@ MODULE LinearSolverTypes
 !>
     SUBROUTINE setX0_LinearSolverType_Iterative(solver,X0)
       CLASS(LinearSolverType_Iterative),INTENT(INOUT) :: solver
-      REAL(SRK),POINTER,INTENT(IN) :: X0(:)
+      REAL(SRK),INTENT(IN) :: X0(:)
       INTEGER(SIK) :: i
 
       IF(solver%isInit) THEN
@@ -1575,7 +1575,6 @@ MODULE LinearSolverTypes
 
       REAL(SRK)  :: beta,h,t,phibar,temp,tol
       REAL(SRK),ALLOCATABLE :: v(:,:),R(:,:),w(:),c(:),s(:),g(:),y(:)
-      REAL(SRK),POINTER :: newGuess(:)
       TYPE(RealVectorType) :: u
       INTEGER(SIK) :: j,k,m,n,it,itOuter
       TYPE(ParamType) :: pList
@@ -1658,8 +1657,8 @@ MODULE LinearSolverTypes
           ! If we've converged, exit and report
           IF (ABS(phibar) <= tol) EXIT
           ! If not, set up the restart:
-          newGuess => u%b
-          CALL solver%setX0(newGuess)
+          !newGuess => u%b
+          CALL solver%setX0(u%b)
           CALL solver%getResidual(u)
           CALL LNorm(u%b,2,beta)
         ENDDO

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -1254,7 +1254,7 @@ MODULE LinearSolverTypes
 !>
     SUBROUTINE setX0_LinearSolverType_Iterative(solver,X0)
       CLASS(LinearSolverType_Iterative),INTENT(INOUT) :: solver
-      REAL(SRK),INTENT(IN) :: X0(:)
+      REAL(SRK),INTENT(IN),POINTER :: X0(:)
       INTEGER(SIK) :: i
 
       IF(solver%isInit) THEN
@@ -1659,7 +1659,9 @@ MODULE LinearSolverTypes
           IF (ABS(phibar) <= tol) EXIT
 
           ! If not, set up the restart:
-          CALL solver%setX0(u%b)
+          ! Set solver%x to u%b
+          CALL BLAS_axpy(u,solver%x)
+          ! Recalculate the residual and residual norm
           CALL solver%getResidual(u)
           CALL LNorm(u%b,2,beta)
         ENDDO
@@ -1785,7 +1787,9 @@ MODULE LinearSolverTypes
           IF (ABS(phibar) <= tol) EXIT
 
           ! If not, set up the restart:
-          CALL solver%setX0(u%b)
+          ! Set solver%x to u%b
+          CALL BLAS_axpy(u,solver%x)
+          ! Recalculate the residual and residual norm
           CALL solver%getResidual(u)
           CALL LNorm(u%b,2,beta)
         ENDDO

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -1579,7 +1579,6 @@ MODULE LinearSolverTypes
       INTEGER(SIK) :: k,m,n,it,itOuter
       TYPE(ParamType) :: pList
 
-      WRITE(*,*) "GMRES NOPC"
       n=0
       !Set parameter list for vector
       CALL pList%add('VectorType -> n',solver%A%n)
@@ -1601,7 +1600,6 @@ MODULE LinearSolverTypes
         ALLOCATE(y(m+1))
 
         tol=solver%absConvTol*beta ! Is this correct?
-        phibar=beta
 
         DO itOuter=1,solver%maxIters
           v(:,:)=0._SRK
@@ -1613,6 +1611,7 @@ MODULE LinearSolverTypes
           y(:)=0._SRK
           v(:,1)=-u%b/beta
           h=beta
+          phibar=beta
 #ifdef FUTILITY_DEBUG_MSG
             WRITE(668,*) '         GMRES-NOPC',0,ABS(phibar)
 #endif
@@ -1724,7 +1723,6 @@ MODULE LinearSolverTypes
         ALLOCATE(y(m+1))
 
         tol=solver%absConvTol*beta ! Is this correct?
-        phibar=beta
 
         DO itOuter=1,solver%maxIters
           v(:,:)=0._SRK
@@ -1735,6 +1733,7 @@ MODULE LinearSolverTypes
           g(:)=0._SRK
           y(:)=0._SRK
           v(:,1)=-u%b/beta
+          phibar=beta
           h=beta
 #ifdef FUTILITY_DEBUG_MSG
             WRITE(668,*) '         GMRES-NOPC',0,ABS(phibar)

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -2780,9 +2780,12 @@ CONTAINS
           CALL A%setShape(9,9, 4.0_SRK)
       ENDSELECT
 
-      ! build X0 and set it to 1.0s
+      ! build X0 and set it to a vector orthogonal to the solution
+      ! This forces GMRES to take longer and thus require a restart,
+      ! which tests this portion of the solver
       ALLOCATE(thisX(9))
-      thisX=1.0_SRK
+      thisX(1)=1.0_SRK
+      thisX(9)=-1.0_SRK
 
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
           CALL thisLS%setX0(thisX)
@@ -2794,7 +2797,7 @@ CONTAINS
 
       !set iterations and convergence information and build/set M
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,30_SIK)
+        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,3_SIK)
       ENDSELECT
 
       !solve it
@@ -2860,9 +2863,13 @@ CONTAINS
         ENDSELECT
       ENDDO
 
-      !build X0 and set it to 1.0s
+      ! build X0 and set it to a vector orthogonal to the solution
+      ! This forces GMRES to take longer and thus require a restart,
+      ! which tests this portion of the solver
       ALLOCATE(thisX(9))
-      thisX=1.0_SRK
+      thisX(1)=1.0_SRK
+      thisX(9)=-1.0_SRK
+
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
         CALL thisLS%setX0(thisX)
       ENDSELECT
@@ -2874,7 +2881,7 @@ CONTAINS
 
       !set iterations and convergence information and build/set M
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,30_SIK)
+        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,3_SIK)
       ENDSELECT
 
       !solve
@@ -3084,9 +3091,12 @@ CONTAINS
           CALL A%set(9,9, 4.0_SRK)
       ENDSELECT
 
-      ! build X0 and set it to 1.0s
+      ! build X0 and set it to a vector orthogonal to the solution
+      ! This forces GMRES to take longer and thus require a restart,
+      ! which tests this portion of the solver
       ALLOCATE(thisX(9))
-      thisX=1.0_SRK
+      thisX(1)=1.0_SRK
+      thisX(9)=-1.0_SRK
 
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
           CALL thisLS%setX0(thisX)
@@ -3098,7 +3108,7 @@ CONTAINS
 
       !set iterations and convergence information and build/set M
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,30_SIK)
+        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,3_SIK)
       ENDSELECT
 
       !solve it
@@ -3165,9 +3175,12 @@ CONTAINS
         ENDSELECT
       ENDDO
 
-      !build X0 and set it to 1.0s
+      ! build X0 and set it to a vector orthogonal to the solution
+      ! This forces GMRES to take longer and thus require a restart,
+      ! which tests this portion of the solver
       ALLOCATE(thisX(9))
-      thisX=1.0_SRK
+      thisX(1)=1.0_SRK
+      thisX(9)=-1.0_SRK
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
         CALL thisLS%setX0(thisX)
       ENDSELECT
@@ -3178,7 +3191,7 @@ CONTAINS
 
       !set iterations and convergence information and build/set M
       SELECTTYPE(thisLS); TYPE IS(LinearSolverType_Iterative)
-        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,30_SIK)
+        CALL thisLS%setConv(2_SIK,1.0E-9_SRK,1.0E-9_SRK,1000_SIK,3_SIK)
       ENDSELECT
 
       !solve

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -2856,11 +2856,9 @@ CONTAINS
           CALL A%set(i,i,4.0_SRK)
           IF((i < 9).AND.((i /= 3).AND.(i /= 6))) THEN
             CALL A%set(i,i+1,-1.0_SRK)
-            CALL A%set(i+1,i,-1.0_SRK)
           ENDIF
           IF(i < 7) THEN
             CALL A%set(i,i+3,-1.0_SRK)
-            CALL A%set(i+3,i,-1.0_SRK)
           ENDIF
         ENDSELECT
       ENDDO

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -2856,9 +2856,11 @@ CONTAINS
           CALL A%set(i,i,4.0_SRK)
           IF((i < 9).AND.((i /= 3).AND.(i /= 6))) THEN
             CALL A%set(i,i+1,-1.0_SRK)
+            CALL A%set(i+1,i,-1.0_SRK)
           ENDIF
           IF(i < 7) THEN
             CALL A%set(i,i+3,-1.0_SRK)
+            CALL A%set(i+3,i,-1.0_SRK)
           ENDIF
         ENDSELECT
       ENDDO


### PR DESCRIPTION
While working on a separate branch, we discovered the native GMRES solver does not restart properly. The unit tests did not require a restart and so the issue was never noticed.

This branch updates the unit tests for GMRES, making them require a restart to solve, and also correctly restarts the GMRES algorithm.