### PR TITLE
Adds -Wno-surprising flag to GNU Fortran_FLAGS

### DIFF
--- a/cmake/Futility_Configurations.cmake
+++ b/cmake/Futility_Configurations.cmake
@@ -282,6 +282,7 @@ ELSEIF(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     SET(Fortran_FLAGS_DEBUG
         ${CSYM}O0
         ${CSYM}Wall
+        ${CSYM}Wno-surprising
         ${CSYM}fcheck=all
         ${CSYM}fbacktrace
         ${CSYM}g


### PR DESCRIPTION
This will remove all the spurious warnings from using FINAL procedures.
The warnings that -W-surprising normally covers are for pretty strange,
unusual situations, so we're not really losing any useful information by
disabling this.