### PR TITLE
Implement str(...) function to convert integers and reals to strings

### DIFF
--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -1442,7 +1442,8 @@ MODULE IO_Strings
 !> @param nPadZero the number of leading 0s to pad with
 !> @returns string the string
 !>
-!> Prints with no white space and the number of leading 0s specified by @c nPadZero
+!> Prints with no white space and pads with leading 0s so that the string is
+!> @c nPadZero in length (not counting a possible negative sign)
 !>
     FUNCTION str_SNK_pad(i,nPadZero) RESULT(string)
       INTEGER(SNK),INTENT(IN) :: i
@@ -1451,10 +1452,10 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      REQUIRE(nPadZero >= 0)
-
       length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
-      length=length+nPadZero
+      REQUIRE(nPadZero >= length)
+
+      length=nPadZero
       IF(i < 0) THEN
         ALLOCATE(CHARACTER(length+1) :: string)
       ELSE
@@ -1491,7 +1492,8 @@ MODULE IO_Strings
 !> @param nPadZero the number of leading 0s to pad with
 !> @returns string the string
 !>
-!> Prints with no white space and the number of leading 0s specified by @c nPadZero
+!> Prints with no white space and pads with leading 0s so that the string is
+!> @c nPadZero in length (not counting a possible negative sign)
 !>
     FUNCTION str_SLK_pad(i,nPadZero) RESULT(string)
       INTEGER(SLK),INTENT(IN) :: i
@@ -1500,10 +1502,10 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      REQUIRE(nPadZero >= 0)
-
       length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
-      length=length+nPadZero
+      REQUIRE(nPadZero >= length)
+
+      length=nPadZero
       IF(i < 0) THEN
         ALLOCATE(CHARACTER(length+1) :: string)
       ELSE

--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -16,12 +16,6 @@
 !> CodeCoverageReports "Code Coverage Reports" page. An example of how to use
 !> the routines in this module is provided below and in the test.
 !>
-!> @par Module Dependencies
-!>  - ISO_FORTRAN_ENV
-!>  - @ref IntrType "IntrType": @copybrief IntrType
-!>  - @ref Strings "Strings": @copybrief Strings
-!>  - @ref ExceptionHandler "ExceptionHandler": @copybrief Exceptionhandler
-!>
 !> @par EXAMPLES
 !> @code
 !> PROGRAM FileExample
@@ -70,15 +64,11 @@
 !> ENDPROGRAM
 !> @endcode
 !>
-!> @author Brendan Kochunas
-!>   @date 07/05/2011
-!>
-!> @todo
-!>  - Add optional inputs to nFields and getField to specify delimiter symbols
-!>    and repeater symbols.
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 MODULE IO_Strings
   USE ISO_FORTRAN_ENV
+#include "Futility_DBC.h"
+  USE Futility_DBC
   USE IntrType
   USE Strings
   USE ExceptionHandler
@@ -354,15 +344,27 @@ MODULE IO_Strings
     !> @copybrief IO_Strings::str_SNK
     !> @copydetails IO_Strings::str_SNK
     MODULE PROCEDURE str_SNK
+    !> @copybrief IO_Strings::str_SNK_pad
+    !> @copydetails IO_Strings::str_SNK_pad
+    MODULE PROCEDURE str_SNK_pad
     !> @copybrief IO_Strings::str_SLK
     !> @copydetails IO_Strings::str_SLK
     MODULE PROCEDURE str_SLK
+    !> @copybrief IO_Strings::str_SLK_pad
+    !> @copydetails IO_Strings::str_SLK_pad
+    MODULE PROCEDURE str_SLK_pad
     !> @copybrief IO_Strings::str_SSK
     !> @copydetails IO_Strings::str_SSK
     MODULE PROCEDURE str_SSK
+    !> @copybrief IO_Strings::str_SSK_nDecimal
+    !> @copydetails IO_Strings::str_SSK_nDecimal
+    MODULE PROCEDURE str_SSK_nDecimal
     !> @copybrief IO_Strings::str_SDK
     !> @copydetails IO_Strings::str_SDK
     MODULE PROCEDURE str_SDK
+    !> @copybrief IO_Strings::str_SDK_nDecimal
+    !> @copydetails IO_Strings::str_SDK_nDecimal
+    MODULE PROCEDURE str_SDK_nDecimal
   ENDINTERFACE str
 !
 !===============================================================================
@@ -1417,50 +1419,194 @@ MODULE IO_Strings
 !> @brief Converts an integer to a character
 !> @param i the value to convert
 !> @returns string the string
+!>
+!> Prints with no white space
+!>
     FUNCTION str_SNK(i) RESULT(string)
       INTEGER(SNK),INTENT(IN) :: i
-      CHARACTER(LEN=FLOOR(ABS(LOG10(REAL(i)))+1)) :: string
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
 
+      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      IF(i < 0) length=length+1
+      ALLOCATE(CHARACTER(length) :: string)
       WRITE(string,'(i0)') i
 
     ENDFUNCTION str_SNK
+!
+!
+!-------------------------------------------------------------------------------
+!> @brief Converts an integer to a character and pads with leading 0s
+!> @param i the value to convert
+!> @param nPadZero the number of leading 0s to pad with
+!> @returns string the string
+!>
+!> Prints with no white space and the number of leading 0s specified by @c nPadZero
+!>
+    FUNCTION str_SNK_pad(i,nPadZero) RESULT(string)
+      INTEGER(SNK),INTENT(IN) :: i
+      INTEGER(SIK),INTENT(IN) :: nPadZero
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
+
+      REQUIRE(nPadZero >= 0)
+
+      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      length=length+nPadZero
+      IF(i < 0) THEN
+        ALLOCATE(CHARACTER(length+1) :: string)
+      ELSE
+        ALLOCATE(CHARACTER(length) :: string)
+      ENDIF
+      WRITE(string,'(i0.'//str(length)//')') i
+
+    ENDFUNCTION str_SNK_pad
 !
 !-------------------------------------------------------------------------------
 !> @brief Converts a long integer to a character
 !> @param i the value to convert
 !> @returns string the string
+!>
+!> Prints with no white space
+!>
     FUNCTION str_SLK(i) RESULT(string)
       INTEGER(SLK),INTENT(IN) :: i
-      CHARACTER(LEN=FLOOR(ABS(LOG10(REAL(i)))+1)) :: string
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
 
+      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      IF(i < 0) length=length+1
+      ALLOCATE(CHARACTER(length) :: string)
       WRITE(string,'(i0)') i
 
     ENDFUNCTION str_SLK
+!
+!
+!-------------------------------------------------------------------------------
+!> @brief Converts a long integer to a character and pads with leading 0s
+!> @param i the value to convert
+!> @param nPadZero the number of leading 0s to pad with
+!> @returns string the string
+!>
+!> Prints with no white space and the number of leading 0s specified by @c nPadZero
+!>
+    FUNCTION str_SLK_pad(i,nPadZero) RESULT(string)
+      INTEGER(SLK),INTENT(IN) :: i
+      INTEGER(SIK),INTENT(IN) :: nPadZero
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
+
+      REQUIRE(nPadZero >= 0)
+
+      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      length=length+nPadZero
+      IF(i < 0) THEN
+        ALLOCATE(CHARACTER(length+1) :: string)
+      ELSE
+        ALLOCATE(CHARACTER(length) :: string)
+      ENDIF
+      WRITE(string,'(i0.'//str(length)//')') i
+
+    ENDFUNCTION str_SLK_pad
 !
 !-------------------------------------------------------------------------------
 !> @brief Converts a single precision real to a character
 !> @param r the value to convert
 !> @returns string the string
 !>
-!> Prints in scientific
+!> Prints in scientific notation with no white space.
+!>
     FUNCTION str_SSK(r) RESULT(string)
       REAL(SSK),INTENT(IN) :: r
-      CHARACTER(LEN=14) :: string
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
 
-      WRITE(string,'(es14.7)') r
+      IF(r < 0.0_SSK) THEN
+        length=14
+      ELSE
+        length=13
+      ENDIF
+      ALLOCATE(CHARACTER(length) :: string)
+      WRITE(string,'(es'//str(length)//'.7)') r
 
     ENDFUNCTION str_SSK
+!
+!-------------------------------------------------------------------------------
+!> @brief Converts a single precision real to a character
+!> @param r the value to convert
+!> @param nDecimal the number of decimal places
+!> @returns string the string
+!>
+!> Prints in scientific notation with the number of decimal places specified by
+!> @c nDecimal and no white space.
+!>
+    FUNCTION str_SSK_nDecimal(r,nDecimal) RESULT(string)
+      REAL(SSK),INTENT(IN) :: r
+      INTEGER(SIK),INTENT(IN) :: nDecimal
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
+
+      REQUIRE(nDecimal >= 0)
+
+      length=nDecimal+6
+      IF(r < 0.0_SSK) length=length+1
+      ALLOCATE(CHARACTER(length) :: string)
+      WRITE(string,'(es'//str(length)//'.'//str(nDecimal)//')') r
+
+    ENDFUNCTION str_SSK_nDecimal
 !
 !-------------------------------------------------------------------------------
 !> @brief Converts a double precision real to a character
 !> @param r the value to convert
 !> @returns string the string
+!>
+!> Prints in scientific notation with no white space.
+!>
     FUNCTION str_SDK(r) RESULT(string)
       REAL(SDK),INTENT(IN) :: r
-      CHARACTER(LEN=22) :: string
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
 
-      WRITE(string,'(es22.15)') r
+      IF(r < 0.0_SSK) THEN
+        length=22
+      ELSE
+        length=21
+      ENDIF
+      ALLOCATE(CHARACTER(length) :: string)
+      WRITE(string,'(es'//str(length)//'.15)') r
 
     ENDFUNCTION str_SDK
+!
+!-------------------------------------------------------------------------------
+!> @brief Converts a double precision real to a character
+!> @param r the value to convert
+!> @param nDecimal the number of decimal places
+!> @returns string the string
+!>
+!> Prints in scientific notation with the number of decimal places specified by
+!> @c nDecimal and no white space.
+!>
+    FUNCTION str_SDK_nDecimal(r,nDecimal) RESULT(string)
+      REAL(SDK),INTENT(IN) :: r
+      INTEGER(SIK),INTENT(IN) :: nDecimal
+      CHARACTER(LEN=:),ALLOCATABLE :: string
+      !
+      INTEGER(SIK) :: length
+
+      REQUIRE(nDecimal >= 0)
+
+      length=nDecimal+6
+      IF(r < 0.0_SDK) length=length+1
+      ALLOCATE(CHARACTER(length) :: string)
+      WRITE(string,'(es'//str(length)//'.'//str(nDecimal)//')') r
+
+    ENDFUNCTION str_SDK_nDecimal
 !
 ENDMODULE IO_Strings

--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -112,6 +112,7 @@ MODULE IO_Strings
   PUBLIC :: stripComment
   PUBLIC :: SlashRep
   PUBLIC :: printCentered
+  PUBLIC :: str
   !
   !PUBLIC :: charToStringArray
 
@@ -347,6 +348,22 @@ MODULE IO_Strings
     !> @copydetails IO_Strings::SlashRep_c
     MODULE PROCEDURE SlashRep_c
   ENDINTERFACE SlashRep
+
+  !> @brief Generic interface for converting variables to strings
+  INTERFACE str
+    !> @copybrief IO_Strings::str_SNK
+    !> @copydetails IO_Strings::str_SNK
+    MODULE PROCEDURE str_SNK
+    !> @copybrief IO_Strings::str_SLK
+    !> @copydetails IO_Strings::str_SLK
+    MODULE PROCEDURE str_SLK
+    !> @copybrief IO_Strings::str_SSK
+    !> @copydetails IO_Strings::str_SSK
+    MODULE PROCEDURE str_SSK
+    !> @copybrief IO_Strings::str_SDK
+    !> @copydetails IO_Strings::str_SDK
+    MODULE PROCEDURE str_SDK
+  ENDINTERFACE str
 !
 !===============================================================================
   CONTAINS
@@ -1397,48 +1414,53 @@ MODULE IO_Strings
     ENDSUBROUTINE SlashRep_c
 !
 !-------------------------------------------------------------------------------
-!> @brief Defines the operation for performing an assignment of a character
-!> string to an array of strings
-!> @param dArr the array of strings
-!> @param c the character value
-!    SUBROUTINE charToStringArray(sArr,c)
-!      TYPE(StringType),ALLOCATABLE,INTENT(OUT) :: sArr(:)
-!      TYPE(StringType),INTENT(IN) :: c
-!      CHARACTER(LEN=100) :: tmpStr
-!      TYPE(StringType) :: tmpElt
-!      INTEGER(SIK) :: numElts
-!      INTEGER(SIK) :: i,j,k
+!> @brief Converts an integer to a character
+!> @param i the value to convert
+!> @returns string the string
+    FUNCTION str_SNK(i) RESULT(string)
+      INTEGER(SNK),INTENT(IN) :: i
+      CHARACTER(LEN=FLOOR(ABS(LOG10(REAL(i)))+1)) :: string
+
+      WRITE(string,'(i0)') i
+
+    ENDFUNCTION str_SNK
 !
-!      numElts=0
-!      IF(LEN(c) /= 2) THEN
-!        DO i=2,(c%n-1)
-!          IF(c(i) == ',') THEN
-!            numElts=numElts+1
-!          ENDIF
-!        ENDDO
-!        numElts=numElts+1
-!      ENDIF
+!-------------------------------------------------------------------------------
+!> @brief Converts a long integer to a character
+!> @param i the value to convert
+!> @returns string the string
+    FUNCTION str_SLK(i) RESULT(string)
+      INTEGER(SLK),INTENT(IN) :: i
+      CHARACTER(LEN=FLOOR(ABS(LOG10(REAL(i)))+1)) :: string
+
+      WRITE(string,'(i0)') i
+
+    ENDFUNCTION str_SLK
 !
-!      !Empty array case
-!      IF(numElts == 0) THEN
-!        RETURN
-!      ENDIF
+!-------------------------------------------------------------------------------
+!> @brief Converts a single precision real to a character
+!> @param r the value to convert
+!> @returns string the string
+!>
+!> Prints in scientific
+    FUNCTION str_SSK(r) RESULT(string)
+      REAL(SSK),INTENT(IN) :: r
+      CHARACTER(LEN=14) :: string
+
+      WRITE(string,'(es14.7)') r
+
+    ENDFUNCTION str_SSK
 !
-!      j=0
-!      k=1 !sArr index
-!      ALLOCATE(sArr(numElts))
-!      DO i=2,LEN(c)
-!        IF(c(i) /= ',' .AND. c(i) /= '}') THEN
-!          j=j+1
-!          tmpStr(j:j)=c(i)
-!        ELSE
-!          tmpStr=tmpStr(1:j)
-!          tmpElt=tmpStr
-!          sArr(k:k)=tmpElt
-!          j=0
-!          k=k+1
-!        ENDIF
-!      ENDDO
-!    ENDSUBROUTINE charToStringArray
+!-------------------------------------------------------------------------------
+!> @brief Converts a double precision real to a character
+!> @param r the value to convert
+!> @returns string the string
+    FUNCTION str_SDK(r) RESULT(string)
+      REAL(SDK),INTENT(IN) :: r
+      CHARACTER(LEN=22) :: string
+
+      WRITE(string,'(es22.15)') r
+
+    ENDFUNCTION str_SDK
 !
 ENDMODULE IO_Strings

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -545,13 +545,17 @@ PROGRAM testIOutil
       !SNK
       ASSERT_EQ(str(2_SNK),'2','str(SNK)')
       ASSERT_EQ(str(-2_SNK),'-2','str(SNK)')
+      ASSERT_EQ(str(375_SNK,9),'000000375','str(SNK,pad)')
       ASSERT_EQ(str(3_SNK,3),'003','str(SNK,pad)')
       ASSERT_EQ(str(-3_SNK,3),'-003','str(SNK,pad)')
+      ASSERT_EQ(str(-375_SNK,9),'-000000375','str(SNK,pad)')
       !SLK
       ASSERT_EQ(str(3_SLK),'3','str(SLK)')
       ASSERT_EQ(str(-3_SLK),'-3','str(SLK)')
+      ASSERT_EQ(str(375_SLK,9),'000000375','str(SLK,pad)')
       ASSERT_EQ(str(3_SLK,3),'003','str(SLK,pad)')
       ASSERT_EQ(str(-3_SLK,3),'-003','str(SLK,pad)')
+      ASSERT_EQ(str(-375_SLK,9),'-000000375','str(SLK,pad)')
       !SSK
       ASSERT_EQ(str(2.5_SSK),'2.5000000E+00','str(SSK)')
       ASSERT_EQ(str(2.5_SSK,2),'2.50E+00','str(SSK,nDecimal)')

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -10,6 +10,7 @@ PROGRAM testIOutil
 #include "UnitTest.h"
   USE ISO_FORTRAN_ENV
   USE UnitTest
+  USE IntrType
   USE Strings
   USE ExceptionHandler
   USE IO_Strings
@@ -539,6 +540,17 @@ PROGRAM testIOutil
       CALL getRealFormat(string,string1)
       ASSERT(string1 == '','hello')
       FINFO() '"'//string1//'"'
+
+      COMPONENT_TEST('str')
+      ASSERT_EQ(str(2_SNK),'2','str(SNK)')
+      ASSERT_EQ(str(-2_SNK),'-2','str(SNK)')
+      ASSERT_EQ(str(3_SLK),'3','str(SLK)')
+      ASSERT_EQ(str(-3_SLK),'-3','str(SLK)')
+      ASSERT_EQ(str(2.5_SSK),' 2.5000000E+00','str(SSK)')
+      ASSERT_EQ(str(-0.0025_SSK),'-2.4999999E-03','str(SSK)')
+      ASSERT_EQ(str(0.5_SDK),' 5.000000000000000E-01','str(SDK)')
+      ASSERT_EQ(str(-5000.0_SDK),'-5.000000000000000E+03','str(SDK)')
+
     ENDSUBROUTINE testIO_Strings
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -542,14 +542,26 @@ PROGRAM testIOutil
       FINFO() '"'//string1//'"'
 
       COMPONENT_TEST('str')
+      !SNK
       ASSERT_EQ(str(2_SNK),'2','str(SNK)')
       ASSERT_EQ(str(-2_SNK),'-2','str(SNK)')
+      ASSERT_EQ(str(3_SNK,3),'0003','str(SNK,pad)')
+      ASSERT_EQ(str(-3_SNK,3),'-0003','str(SNK,pad)')
+      !SLK
       ASSERT_EQ(str(3_SLK),'3','str(SLK)')
       ASSERT_EQ(str(-3_SLK),'-3','str(SLK)')
-      ASSERT_EQ(str(2.5_SSK),' 2.5000000E+00','str(SSK)')
+      ASSERT_EQ(str(3_SLK,3),'0003','str(SLK,pad)')
+      ASSERT_EQ(str(-3_SLK,3),'-0003','str(SLK,pad)')
+      !SSK
+      ASSERT_EQ(str(2.5_SSK),'2.5000000E+00','str(SSK)')
+      ASSERT_EQ(str(2.5_SSK,2),'2.50E+00','str(SSK,nDecimal)')
       ASSERT_EQ(str(-0.0025_SSK),'-2.4999999E-03','str(SSK)')
-      ASSERT_EQ(str(0.5_SDK),' 5.000000000000000E-01','str(SDK)')
+      ASSERT_EQ(str(-0.0025_SSK,2),'-2.50E-03','str(SSK,nDecimal)')
+      !SDK
+      ASSERT_EQ(str(0.5_SDK),'5.000000000000000E-01','str(SDK)')
+      ASSERT_EQ(str(0.5_SDK,5),'5.00000E-01','str(SDK,nDecimal)')
       ASSERT_EQ(str(-5000.0_SDK),'-5.000000000000000E+03','str(SDK)')
+      ASSERT_EQ(str(-5000.0_SDK,5),'-5.00000E+03','str(SDK,nDecimal)')
 
     ENDSUBROUTINE testIO_Strings
 !

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -545,13 +545,13 @@ PROGRAM testIOutil
       !SNK
       ASSERT_EQ(str(2_SNK),'2','str(SNK)')
       ASSERT_EQ(str(-2_SNK),'-2','str(SNK)')
-      ASSERT_EQ(str(3_SNK,3),'0003','str(SNK,pad)')
-      ASSERT_EQ(str(-3_SNK,3),'-0003','str(SNK,pad)')
+      ASSERT_EQ(str(3_SNK,3),'003','str(SNK,pad)')
+      ASSERT_EQ(str(-3_SNK,3),'-003','str(SNK,pad)')
       !SLK
       ASSERT_EQ(str(3_SLK),'3','str(SLK)')
       ASSERT_EQ(str(-3_SLK),'-3','str(SLK)')
-      ASSERT_EQ(str(3_SLK,3),'0003','str(SLK,pad)')
-      ASSERT_EQ(str(-3_SLK,3),'-0003','str(SLK,pad)')
+      ASSERT_EQ(str(3_SLK,3),'003','str(SLK,pad)')
+      ASSERT_EQ(str(-3_SLK,3),'-003','str(SLK,pad)')
       !SSK
       ASSERT_EQ(str(2.5_SSK),'2.5000000E+00','str(SSK)')
       ASSERT_EQ(str(2.5_SSK,2),'2.50E+00','str(SSK,nDecimal)')

--- a/unit_tests/testVTUFiles/testVTUFiles.f90
+++ b/unit_tests/testVTUFiles/testVTUFiles.f90
@@ -26,7 +26,7 @@ PROGRAM testVTUFiles
   LOGICAL(SBK) :: bool
   INTEGER(SIK) :: i,dir_status
   CHARACTER(LEN=150) :: sint
-  TYPE(StringType) :: str,str2
+  TYPE(StringType) :: str1,str2
   !
   CREATE_TEST('Test VTU Files')
   !
@@ -185,9 +185,9 @@ PROGRAM testVTUFiles
       !
       !Write pvtu file
       CALL MAKE_DIRECTORY('fsr_test',dir_status)
-      str='test'
+      str1='test'
       str2='testPVTU'
-      CALL testVTUFile%writepvtu(666,TRIM(str),TRIM(str2),2,0)
+      CALL testVTUFile%writepvtu(666,TRIM(str1),TRIM(str2),2,0)
       CALL testVTUFile%hasFile('testPVTU_0.vtu',bool)
       ASSERT(bool,'hasFile(...) testPVTU_0.vtu')
       CALL testVTUFile%hasFile('testPVTU_1.vtu',bool)


### PR DESCRIPTION
This is a common function in other languages and extremely useful for
standard IO, error handling, and parameter list manipulations, among
other things.  By default it uses the minimum number of spaces for
integers and scientific notation for reals, with 7/15 decimal places
for single/double precision, respectively.

It may be useful to add other formatting options at some point, but
this simple implementation will still be useful in the near term.