### PR TITLE
Adds optional plist argument to ProcCmdLineArgs

### DIFF
--- a/src/CommandLineProcessor.f90
+++ b/src/CommandLineProcessor.f90
@@ -117,6 +117,7 @@ MODULE CommandLineProcessor
   USE ISO_FORTRAN_ENV
   USE IntrType
   USE Strings
+  USE ParameterLists
   USE ExceptionHandler
   USE IO_Strings
   USE IOutil
@@ -468,21 +469,24 @@ MODULE CommandLineProcessor
 !> @brief This routine controls execution based on command line arguments
 !> @param clp command line processor object
 !> @param userSubroutine the name of the subroutine defined outside the module
+!> @param plist optional parameter list to process arguments into
 !> that processes the command line arguments.
 !>
-    SUBROUTINE ProcCmdLineArgs(clp,userSubroutine)
+    SUBROUTINE ProcCmdLineArgs(clp,userSubroutine,plist)
       CLASS(CmdLineProcType),INTENT(INOUT) :: clp
+      TYPE(ParamType),INTENT(INOUT),OPTIONAL :: plist
       !> This is the definition of the interface to the user subroutine
       !> defined elsewhere.
       INTERFACE
-        SUBROUTINE userSubroutine(uclp)
-          IMPORT :: CmdLineProcType
+        SUBROUTINE userSubroutine(uclp,plist)
+          IMPORT :: CmdLineProcType,ParamType
           CLASS(CmdLineProcType),INTENT(INOUT) :: uclp
+          TYPE(ParamType),INTENT(INOUT),OPTIONAL :: plist
         ENDSUBROUTINE
       ENDINTERFACE
 
       !Call the other subroutine that was passed in.
-      CALL userSubroutine(clp)
+      CALL userSubroutine(clp,plist)
 
     ENDSUBROUTINE ProcCmdLineArgs
 !


### PR DESCRIPTION
This change was made to support some cleanup in MPACT,
but in general passing a parameter list to the commandline
processor is something that makes sense and could be useful
to other applications down the road.