### PR TITLE
Adding an optional tolerance argument to the getUnion subroutine.

### DIFF
--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -606,8 +606,9 @@ MODULE ArrayUtils
 !> @param delta1 The optional flag if the first array is an incremental array
 !> @param delta2 The optional flag if the second array is an incremental array
 !> @param deltaout The optional flag if the output array is an incremental array
+!> @param tol The optional value used to perform the SOFTEQ check
 !>
-    SUBROUTINE getUnion_1DReal(r1,r2,rout,xi1,xi2,delta1,delta2,deltaout)
+    SUBROUTINE getUnion_1DReal(r1,r2,rout,xi1,xi2,delta1,delta2,deltaout,tol)
       REAL(SRK),INTENT(IN) :: r1(:)
       REAL(SRK),INTENT(IN) :: r2(:)
       REAL(SRK),ALLOCATABLE,INTENT(INOUT) :: rout(:)
@@ -616,10 +617,14 @@ MODULE ArrayUtils
       LOGICAL(SBK),INTENT(IN),OPTIONAL :: delta1
       LOGICAL(SBK),INTENT(IN),OPTIONAL :: delta2
       LOGICAL(SBK),INTENT(IN),OPTIONAL :: deltaout
+      REAL(SRK),INTENT(IN),OPTIONAL :: tol
       LOGICAL(SBK) :: bool1,bool2
       INTEGER(SIK) :: i,j,sr1,sr2,sout,tmpsout
+      REAL(SRK) :: localtol
       REAL(SRK),ALLOCATABLE :: tmpout(:),tmpout2(:),tmp1(:),tmp2(:)
 
+      localtol=EPSREAL
+      IF(PRESENT(tol)) localtol=tol
       IF(ALLOCATED(rout)) DEALLOCATE(rout)
       !Process the first array if it is a delta
       IF(SIZE(r1) > 0 .AND. SIZE(r2) == 0) THEN
@@ -676,7 +681,7 @@ MODULE ArrayUtils
         sout=tmpsout
         !Find the number of repeated values
         DO i=2,tmpsout
-          IF(tmpout(i-1) .APPROXEQ. tmpout(i)) sout=sout-1
+          IF(SOFTEQ(tmpout(i-1),tmpout(i),localtol)) sout=sout-1
         ENDDO
         ALLOCATE(tmpout2(sout))
         tmpout2=0.0_SRK
@@ -684,7 +689,7 @@ MODULE ArrayUtils
         j=2
         !Assign the non-repeated values
         DO i=2,tmpsout
-          IF(.NOT.(tmpout(i-1) .APPROXEQ. tmpout(i))) THEN
+          IF(.NOT.SOFTEQ(tmpout(i-1),tmpout(i),localtol)) THEN
             tmpout2(j)=tmpout(i)
             j=j+1
           ENDIF

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -101,6 +101,18 @@ PROGRAM testArrayUtils
                     (/6.0_SRK,40.0_SRK,15.0_SRK,60.0_SRK,20.0_SRK,100.0_SRK,6.0_SRK/),tmpr,DELTAOUT=.TRUE.)
       bool=ALL(tmpr .APPROXEQA. (/2.0_SRK,4.0_SRK,4.0_SRK,5.0_SRK,5.0_SRK,20.0_SRK,20.0_SRK,5.0_SRK,35.0_SRK/))
       ASSERT(bool,'getUnion deltaout=.TRUE.')
+      CALL getUnion((/65.0_SRK,2.0_SRK,10.0_SRK,0.0_SRK,0.0000000000000001_SRK,2.0_SRK/), &
+                    (/6.0_SRK,40.0_SRK,15.0_SRK,60.0_SRK,20.0_SRK,100.0_SRK,6.0_SRK/),tmpr,DELTAOUT=.TRUE.,TOL=1.0E-15_SRK)
+      bool=ALL(tmpr .APPROXEQA. (/2.0_SRK,4.0_SRK,4.0_SRK,5.0_SRK,5.0_SRK,20.0_SRK,20.0_SRK,5.0_SRK,35.0_SRK/))
+      ASSERT(bool,'getUnion deltaout=.TRUE.')
+      CALL getUnion((/65.0_SRK,2.0_SRK,10.0_SRK,0.0_SRK,0.0000000000000001_SRK,2.0_SRK/), &
+                    (/6.0_SRK,40.0_SRK,15.0_SRK,60.0_SRK,20.0_SRK,100.0_SRK,6.0_SRK/),tmpr,DELTAOUT=.TRUE.,TOL=1.0E-08_SRK)
+      bool=ALL(tmpr .APPROXEQA. (/2.0_SRK,4.0_SRK,4.0_SRK,5.0_SRK,5.0_SRK,20.0_SRK,20.0_SRK,5.0_SRK,35.0_SRK/))
+      ASSERT(bool,'getUnion deltaout=.TRUE.')
+      CALL getUnion((/65.0_SRK,2.0_SRK,10.0_SRK,0.0_SRK,0.0000000000000001_SRK,0.0000000001_SRK,2.0_SRK/), &
+                    (/6.0_SRK,40.0_SRK,15.0_SRK,60.0_SRK,20.0_SRK,100.0_SRK,6.0_SRK/),tmpr,DELTAOUT=.TRUE.,TOL=1.0E-08_SRK)
+      bool=ALL(tmpr .APPROXEQA. (/2.0_SRK,4.0_SRK,4.0_SRK,5.0_SRK,5.0_SRK,20.0_SRK,20.0_SRK,5.0_SRK,35.0_SRK/))
+      ASSERT(bool,'getUnion deltaout=.TRUE.')
       !
       COMPONENT_TEST('findNUnique 1-D Array')
       tmprealarray(1)=1.0_SRK


### PR DESCRIPTION
Description:
The default behavior of this routine used the .APPROXEQ. comparison,
which can be too fine in some circumstances.  Default tolerance is
EPSREAL.

Added unit tests for optional input.

CASL Ticket # - N/A