### PR TITLE
Fix potential infinite memory allocation in str(...) interface

### DIFF
--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -1473,8 +1473,12 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
-      IF(i < 0) length=length+1
+      IF(i == 0) THEN
+        length=1
+      ELSE
+        length=FLOOR(LOG10(ABS(REAL(i))))+1
+        IF(i < 0) length=length+1
+      ENDIF
       ALLOCATE(CHARACTER(length) :: string)
       WRITE(string,'(i0)') i
 
@@ -1497,7 +1501,11 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      IF(i == 0) THEN
+        length=1
+      ELSE
+        length=FLOOR(LOG10(ABS(REAL(i))))+1
+      ENDIF
       REQUIRE(nPadZero >= length)
 
       length=nPadZero
@@ -1523,8 +1531,12 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
-      IF(i < 0) length=length+1
+      IF(i == 0) THEN
+        length=1
+      ELSE
+        length=FLOOR(LOG10(ABS(REAL(i))))+1
+        IF(i < 0) length=length+1
+      ENDIF
       ALLOCATE(CHARACTER(length) :: string)
       WRITE(string,'(i0)') i
 
@@ -1547,7 +1559,11 @@ MODULE IO_Strings
       !
       INTEGER(SIK) :: length
 
-      length=FLOOR(ABS(LOG10(ABS(REAL(i)))))+1
+      IF(i == 0) THEN
+        length=1
+      ELSE
+        length=FLOOR(LOG10(ABS(REAL(i))))+1
+      ENDIF
       REQUIRE(nPadZero >= length)
 
       length=nPadZero

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -526,15 +526,19 @@ PROGRAM testIOutil
 
       COMPONENT_TEST('str')
       !SNK
+      ASSERT_EQ(str(0_SNK),'0','str(SNK)')
       ASSERT_EQ(str(2_SNK),'2','str(SNK)')
       ASSERT_EQ(str(-2_SNK),'-2','str(SNK)')
+      ASSERT_EQ(str(0_SNK,4),'0000','str(SNK,pad)')
       ASSERT_EQ(str(375_SNK,9),'000000375','str(SNK,pad)')
       ASSERT_EQ(str(3_SNK,3),'003','str(SNK,pad)')
       ASSERT_EQ(str(-3_SNK,3),'-003','str(SNK,pad)')
       ASSERT_EQ(str(-375_SNK,9),'-000000375','str(SNK,pad)')
       !SLK
+      ASSERT_EQ(str(0_SLK),'0','str(SLK)')
       ASSERT_EQ(str(3_SLK),'3','str(SLK)')
       ASSERT_EQ(str(-3_SLK),'-3','str(SLK)')
+      ASSERT_EQ(str(0_SLK,4),'0000','str(SLK,pad)')
       ASSERT_EQ(str(375_SLK,9),'000000375','str(SLK,pad)')
       ASSERT_EQ(str(3_SLK,3),'003','str(SLK,pad)')
       ASSERT_EQ(str(-3_SLK,3),'-003','str(SLK,pad)')


### PR DESCRIPTION
When calling str(0), there was a LOG10(0) call to calculate the
length, which caused the runtime error.