### PR TITLE
Fixing the intersection between the line type and circle type.

### DIFF
--- a/src/Geom_CircCyl.f90
+++ b/src/Geom_CircCyl.f90
@@ -233,6 +233,7 @@ MODULE Geom_CircCyl
         w(2)=line%p1%coord(2)-circle%c%coord(2)
         b=w(1)*u(1)+w(2)*u(2)
         c=w(1)*w(1)+w(2)*w(2)-circle%r*circle%r
+
         IF(c > zero .AND. b > zero) THEN
           p1%dim=-2
           p2%dim=-2
@@ -245,13 +246,19 @@ MODULE Geom_CircCyl
             p2%dim=-2
           ELSEIF(discr .APPROXEQA. zero) THEN
             !Tangent
+
             ra=one/a
             t1=-ra*b
-            p1=line%p1
-            p1%coord(1)=p1%coord(1)+u(1)*t1
-            p1%coord(2)=p1%coord(2)+u(2)*t1
-            p1%dim=-3
-            p2%dim=-3
+            IF(t1<ZERO .OR. t1 > ONE ) THEN
+              p1%dim=-2
+              p2%dim=-2
+            ELSE
+              p1=line%p1
+              p1%coord(1)=p1%coord(1)+u(1)*t1
+              p1%coord(2)=p1%coord(2)+u(2)*t1
+              p1%dim=-3
+              p2%dim=-3
+            ENDIF
           ELSE
             p1%dim=0
             p2%dim=0

--- a/unit_tests/testGeom_CircCyl/testGeom_CircCyl.f90
+++ b/unit_tests/testGeom_CircCyl/testGeom_CircCyl.f90
@@ -94,6 +94,14 @@ PROGRAM testGeom_CircCyl
       ASSERT(bool, 'circle1%intersectLine(...) (disjoint 1)')
       CALL line1%clear()
 
+      !Test disjoint although extension tagent
+      CALL line1%p1%init(DIM=2,X=0.4225_SRK,Y=0.4_SRK)
+      CALL line1%p2%init(DIM=2,X=0.4225_SRK,Y=0.6_SRK)
+      CALL circle1%intersectLine(line1,point2,point3)
+      bool = .NOT.(point2%dim /= -2 .OR. point3%dim /= -2)
+      ASSERT(bool, 'circle1%intersectLine(...) (disjoint 2)')
+
+      CALL line1%clear()
       !Test tangent
       CALL line1%p1%init(DIM=2,X=0.4225_SRK,Y=0.4_SRK)
       CALL line1%p2%init(DIM=2,X=0.4225_SRK,Y=-0.5_SRK)
@@ -101,6 +109,7 @@ PROGRAM testGeom_CircCyl
       bool = .NOT.(point2%dim /= -3 .OR. point3%dim /= -3)
       ASSERT(bool, 'circle1%intersectLine(...) (tangent)')
       CALL line1%clear()
+
 
       !Test totally inside
       CALL line1%p1%init(DIM=2,X=0.0_SRK,Y=0.0_SRK)

--- a/unit_tests/testGeom_CircCyl/testGeom_CircCyl.f90
+++ b/unit_tests/testGeom_CircCyl/testGeom_CircCyl.f90
@@ -110,7 +110,6 @@ PROGRAM testGeom_CircCyl
       ASSERT(bool, 'circle1%intersectLine(...) (tangent)')
       CALL line1%clear()
 
-
       !Test totally inside
       CALL line1%p1%init(DIM=2,X=0.0_SRK,Y=0.0_SRK)
       CALL line1%p2%init(DIM=2,X=0.1_SRK,Y=0.1_SRK)


### PR DESCRIPTION
Description:
The bug is when a line segment is near a circle, is non-tangent to the
circle, but if extended would be.  The intersection routine would
produce a point, but ultimately, the intersection point needed more logic
to determine if the intersection point is outside the circle.

CASL Ticket # - PHI 5083