### PR TITLE
Fix for very long warning messages

### DIFF
--- a/src/ExceptionHandler.f90
+++ b/src/ExceptionHandler.f90
@@ -60,7 +60,7 @@
 !>   CALL e%setLogFileUnit(23)
 !>   OPEN(UNIT=e%getLogFileUnit(),FILE='Exception.log', &
 !>        ACCESS='SEQUENTIAL',FORM='FORMATTED')
-!>   CALL e%setLogFileActive(.TRUE.)
+!>   CALL e%setLogActive(.TRUE.)
 !>
 !>   !Suppress reporting of exceptions to standard error
 !>   CALL e%setQuietMode(.TRUE.)
@@ -1035,7 +1035,8 @@ MODULE ExceptionHandler
       ENDIF
 
       !Set the message to be included as one line back to exception object
-      WRITE(mesg,'(a)') TRIM(prefix)//' - '//TRIM(mesg)
+      prefix = TRIM(prefix)//' - '
+      WRITE(mesg,'(a)') TRIM(prefix)//TRIM(mesg(1:EXCEPTION_MAX_MESG_LENGTH-LEN(TRIM(prefix))))
     ENDSUBROUTINE exceptionMessage
 !
 !-------------------------------------------------------------------------------

--- a/src/ExceptionHandler.f90
+++ b/src/ExceptionHandler.f90
@@ -986,7 +986,7 @@ MODULE ExceptionHandler
       INTEGER(SIK),INTENT(IN) :: logUnit
       CHARACTER(LEN=EXCEPTION_MAX_MESG_LENGTH),INTENT(INOUT) :: mesg
       CHARACTER(LEN=EXCEPTION_MAX_MESG_LENGTH) :: prefix
-      INTEGER(SIK) :: ioerr1,ioerr2
+      INTEGER(SIK) :: ioerr1,ioerr2,prefixLen
 
       !Set the appropriate prefix and printing options
       SELECT CASE(eCode)
@@ -1035,8 +1035,8 @@ MODULE ExceptionHandler
       ENDIF
 
       !Set the message to be included as one line back to exception object
-      prefix = TRIM(prefix)//' - '
-      WRITE(mesg,'(a)') TRIM(prefix)//TRIM(mesg(1:EXCEPTION_MAX_MESG_LENGTH-LEN(TRIM(prefix))))
+      prefixLen = LEN_TRIM(prefix)+3
+      WRITE(mesg,'(a)') TRIM(prefix)//' - '//TRIM(mesg(1:EXCEPTION_MAX_MESG_LENGTH-prefixLen))
     ENDSUBROUTINE exceptionMessage
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testExceptionHandler/testExceptionHandler.f90
+++ b/unit_tests/testExceptionHandler/testExceptionHandler.f90
@@ -222,7 +222,7 @@ PROGRAM testExceptionHandler
       CALL testE%setLogFileUnit(OUTPUT_UNIT)
       CALL testE%setLogFileUnit(ERROR_UNIT)
       CALL testE%setLogFileUnit(-1)
-      ASSERT(testE%getCounter(EXCEPTION_WARNING) == 3,'%counter(WARN)')
+      ASSERT(testE%getCounter(EXCEPTION_WARNING) == 4,'%counter(WARN)')
       mesg='#### EXCEPTION_WARNING #### - '// &
         'Illegal unit number for log file. Log file unit not set.'
       ASSERT(TRIM(testE%getLastMessage()) == TRIM(mesg),'%getLastMessage')

--- a/unit_tests/testExceptionHandler/testExceptionHandler.f90
+++ b/unit_tests/testExceptionHandler/testExceptionHandler.f90
@@ -197,6 +197,22 @@ PROGRAM testExceptionHandler
       ASSERT(testE%getCounter(EXCEPTION_ERROR) == 0,'%counter(ERROR)')
       ASSERT(testE%getCounter(EXCEPTION_FATAL_ERROR) == 0,'%counter(FATAL)')
       ASSERT(testE%getLastMessage() == '','mesg')
+
+      ! Ensure ExceptionHandler does not crash if the message passed in exceeds
+      ! the length of the message internally, which is 512 characters.  Each line
+      ! of this message is 50 characters, so over 550 in total.
+      COMPONENT_TEST('raiseWarning_exceedCharLen')
+      CALL testE%raiseWarning('Very                                              '//&
+                              'long                                              '//&
+                              'message                                           '//&
+                              'exceeding                                         '//&
+                              'size                                              '//&
+                              'of                                                '//&
+                              'character                                         '//&
+                              'length                                            '//&
+                              'limit                                             '//&
+                              'of                                                '//&
+                              '512.....The remainder of this message will be truncated')
     ENDSUBROUTINE testRaise
 !
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Description:
Prior to this, if a message passed to raiseWarning exceeded 512 characters,
it would crash the code due to a IO error.  This fix will truncate the end
of the message in this case.

CASL Ticket # - 6064