### PR TITLE
Move associate statement

### DIFF
--- a/src/MemProf.f90
+++ b/src/MemProf.f90
@@ -98,8 +98,8 @@ MODULE MemProf
       INTEGER(C_LONG_LONG) :: tmpL1, tmpL2
       CHARACTER(LEN=16) :: filename
 
+      thisMP%pe=>pe
       IF(ASSOCIATED(myLog)) THEN
-        thisMP%pe=>pe
         thisMP%myLog=>myLog
 
         CALL getProcMemInfo(tmpL1,tmpL2)


### PR DESCRIPTION
Description:
Always associate the parallel env object in MemProf, even if the log file
is not associated.  This will prevent seg faults when the log file is not
associated.