### PR TITLE
Mark unit tests appropriately for build system

### DIFF
--- a/cmake/Futility_CreateUnitTest.cmake
+++ b/cmake/Futility_CreateUnitTest.cmake
@@ -7,13 +7,43 @@
 # can be found in LICENSE.txt in the head directory of this repository.        !
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 
+FUNCTION(Futility_SetTestLabels TESTTMP)
+    # The test shall have one argument in the case Tribits failed to add the test
+    # This results in the test name being empty, which must be guarded against
+    SET(TESTNAME "INVALID")
+    SET(extra_args ${ARGN})
+    LIST(LENGTH extra_args num_args)
+    IF(${num_args} GREATER 0)
+      LIST(GET extra_args 0 TESTCAT)
+      SET(TESTNAME ${TESTTMP})
+    ENDIF()
+
+    IF(NOT "${TESTNAME}" STREQUAL "INVALID")
+      SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS ${TESTCAT})
+      IF("${TESTCAT}" STREQUAL "BASIC")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "CONTINUOUS")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ELSEIF("${TESTCAT}" STREQUAL "CONTINUOUS")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ELSEIF("${TESTCAT}" STREQUAL "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ENDIF()
+      UNSET(TESTNAME)
+      UNSET(TESTTMP)
+    ENDIF()
+ENDFUNCTION()
+
 FUNCTION(Futility_CreateUnitTest TESTNAME)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(${TESTNAME}
         SOURCES ${TESTNAME}.f90
         NUM_MPI_PROCS 1
         LINKER_LANGUAGE Fortran
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -23,7 +53,9 @@ FUNCTION(Futility_CreateParUnitTest TESTNAME NPROC)
         NUM_MPI_PROCS ${NPROC}
         LINKER_LANGUAGE Fortran
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -33,7 +65,9 @@ FUNCTION(Futility_CreateUnitTest_C TESTNAME)
         NUM_MPI_PROCS 1
         LINKER_LANGUAGE C
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -43,7 +77,9 @@ FUNCTION(Futility_CreateParUnitTest_C TESTNAME NPROC)
         NUM_MPI_PROCS ${NPROC}
         LINKER_LANGUAGE C
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -53,7 +89,9 @@ FUNCTION(Futilty_CreateUnitTest_CPP TESTNAME)
         NUM_MPI_PROCS 1
         LINKER_LANGUAGE CXX
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -63,6 +101,8 @@ FUNCTION(Futility_CreateParUnitTest_CPP TESTNAME NPROC)
         NUM_MPI_PROCS ${NPROC}
         LINKER_LANGUAGE CXX
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
+        ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
+    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()

--- a/cmake/Futility_CreateUnitTest.cmake
+++ b/cmake/Futility_CreateUnitTest.cmake
@@ -6,34 +6,7 @@
 # of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
 # can be found in LICENSE.txt in the head directory of this repository.        !
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
-
-FUNCTION(Futility_SetTestLabels TESTTMP)
-    # The test shall have one argument in the case Tribits failed to add the test
-    # This results in the test name being empty, which must be guarded against
-    SET(TESTNAME "INVALID")
-    SET(extra_args ${ARGN})
-    LIST(LENGTH extra_args num_args)
-    IF(${num_args} GREATER 0)
-      LIST(GET extra_args 0 TESTCAT)
-      SET(TESTNAME ${TESTTMP})
-    ENDIF()
-
-    IF(NOT "${TESTNAME}" STREQUAL "INVALID")
-      SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS ${TESTCAT})
-      IF("${TESTCAT}" STREQUAL "BASIC")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "CONTINUOUS")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
-      ELSEIF("${TESTCAT}" STREQUAL "CONTINUOUS")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
-      ELSEIF("${TESTCAT}" STREQUAL "NIGHTLY")
-	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
-      ENDIF()
-      UNSET(TESTNAME)
-      UNSET(TESTTMP)
-    ENDIF()
-ENDFUNCTION()
+INCLUDE(SetTestLabels)
 
 FUNCTION(Futility_CreateUnitTest TESTNAME)
     TRIBITS_ADD_EXECUTABLE_AND_TEST(${TESTNAME}
@@ -43,7 +16,7 @@ FUNCTION(Futility_CreateUnitTest TESTNAME)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -55,7 +28,7 @@ FUNCTION(Futility_CreateParUnitTest TESTNAME NPROC)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -67,7 +40,7 @@ FUNCTION(Futility_CreateUnitTest_C TESTNAME)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -79,7 +52,7 @@ FUNCTION(Futility_CreateParUnitTest_C TESTNAME NPROC)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -91,7 +64,7 @@ FUNCTION(Futilty_CreateUnitTest_CPP TESTNAME)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()
 
@@ -103,6 +76,6 @@ FUNCTION(Futility_CreateParUnitTest_CPP TESTNAME NPROC)
         TIMEOUT ${DART_TESTING_TIMEOUT_IN}
         ADDED_TESTS_NAMES_OUT TESTNAME_OUT
     )
-    Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+    SetTestLabels(${TESTNAME_OUT} "BASIC")
     UNSET(TESTNAME)
 ENDFUNCTION()

--- a/cmake/SetTestLabels.cmake
+++ b/cmake/SetTestLabels.cmake
@@ -1,0 +1,39 @@
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+#                          Futility Development Group                          !
+#                             All rights reserved.                             !
+#                                                                              !
+# Futility is a jointly-maintained, open-source project between the University !
+# of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
+# can be found in LICENSE.txt in the head directory of this repository.        !
+#++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+
+# This function sets the test labels appropriately when passed the desired test
+# name and category
+FUNCTION(SetTestLabels TESTTMP)
+    # The test shall have one argument in the case Tribits failed to add the test
+    # This results in the test name being empty, which must be guarded against
+    SET(TESTNAME "INVALID")
+    SET(extra_args ${ARGN})
+    LIST(LENGTH extra_args num_args)
+    IF(${num_args} GREATER 0)
+      LIST(GET extra_args 0 TESTCAT)
+      SET(TESTNAME ${TESTTMP})
+    ENDIF()
+
+    IF(NOT "${TESTNAME}" STREQUAL "INVALID")
+      SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS ${TESTCAT})
+      IF("${TESTCAT}" STREQUAL "BASIC")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "CONTINUOUS")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ELSEIF("${TESTCAT}" STREQUAL "CONTINUOUS")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ELSEIF("${TESTCAT}" STREQUAL "NIGHTLY")
+	SET_PROPERTY(TEST ${TESTNAME} APPEND PROPERTY LABELS "HEAVY")
+      ENDIF()
+      UNSET(TESTNAME)
+      UNSET(TESTTMP)
+    ENDIF()
+ENDFUNCTION()
+

--- a/unit_tests/testDBC/CMakeLists.txt
+++ b/unit_tests/testDBC/CMakeLists.txt
@@ -7,6 +7,7 @@
 # can be found in LICENSE.txt in the head directory of this repository.        !
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 INCLUDE(Futility_CreateUnitTest)
+INCLUDE(SetTestLabels)
 TRIBITS_ADD_EXECUTABLE(testDBC
      SOURCES testDBC.f90
      NOEXEPREFIX
@@ -81,4 +82,4 @@ ELSE()
     ADDED_TEST_NAME_OUT TESTNAME_OUT
   )
 ENDIF()
-Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")
+SetTestLabels(${TESTNAME_OUT} "BASIC")

--- a/unit_tests/testDBC/CMakeLists.txt
+++ b/unit_tests/testDBC/CMakeLists.txt
@@ -6,13 +6,14 @@
 # of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
 # can be found in LICENSE.txt in the head directory of this repository.        !
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
-
+INCLUDE(Futility_CreateUnitTest)
 TRIBITS_ADD_EXECUTABLE(testDBC
      SOURCES testDBC.f90
      NOEXEPREFIX
      LINKER_LANGUAGE Fortran
 )
 
+UNSET(TESTNAME_OUT)
 IF(${Futility_ENABLE_DBC})
   TRIBITS_ADD_ADVANCED_TEST(testDBC
     TIMEOUT ${DART_TESTING_TIMEOUT_IN}
@@ -47,6 +48,7 @@ IF(${Futility_ENABLE_DBC})
         NUM_MPI_PROCS 1
         ARGS 5
         ALWAYS_FAIL_ON_NONZERO_RETURN
+    ADDED_TEST_NAME_OUT TESTNAME_OUT
   )
 ELSE()
   TRIBITS_ADD_ADVANCED_TEST(testDBC
@@ -76,5 +78,7 @@ ELSE()
         NUM_MPI_PROCS 1
         ARGS 4
         ALWAYS_FAIL_ON_NONZERO_RETURN
+    ADDED_TEST_NAME_OUT TESTNAME_OUT
   )
 ENDIF()
+Futility_SetTestLabels(${TESTNAME_OUT} "BASIC")


### PR DESCRIPTION
In ctest, we can specify categories for unit tests and set which ones get run with a flag (i.e. ctest -L BASIC).
This patch adds all unit tests to the BASIC category so that all configurations (heavy, nightly, continuous, basic) know to run them when passed the -L flag.