### PR TITLE
Changing .travis.yml to use && instead of ;

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
  - docker pull dalg24/vera_tpls
 
 script:
- - docker run -v $PWD:/mnt/Futility dalg24/vera_tpls /bin/bash -c "mkdir /build; cd /build; cmake /mnt/Futility; make -j2 |& tee /mnt/Futility/make.out; ctest -j2"
+ - docker run -v $PWD:/mnt/Futility dalg24/vera_tpls /bin/bash -c "mkdir /build && cd /build && cmake /mnt/Futility && make -j2 |& tee /mnt/Futility/make.out && ctest -j2"
  - ls
  - (exit `grep -i -B 4 'Unused variable' make.out | grep 'f90' | wc -l`)
  - git clone https://github.com/trilinos/Trilinos.git; cd Trilinos; git checkout 6c776f530a29eb; cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
  - ls
  - (exit `grep -i -B 4 'Unused variable' make.out | grep 'f90' | wc -l`)
  - git clone https://github.com/trilinos/Trilinos.git; cd Trilinos; git checkout 6c776f530a29eb; cd ..
- - docker run -v $PWD:/mnt/Futility dalg24/vera_tpls /bin/bash -c "mkdir /build; cd /build; /bin/bash /mnt/Futility/build_scripts/build_on_docker.sh /mnt/Futility -DFutility_ENABLE_Stratimikos=OFF; make -j2; ctest -j2"
+ - docker run -v $PWD:/mnt/Futility dalg24/vera_tpls /bin/bash -c "mkdir /build && cd /build && /bin/bash /mnt/Futility/build_scripts/build_on_docker.sh /mnt/Futility -DFutility_ENABLE_Stratimikos=OFF && make -j2 && ctest -j2"
 
 branches:
   only:

--- a/build_scripts/build_on_docker.sh
+++ b/build_scripts/build_on_docker.sh
@@ -4,8 +4,8 @@ TPL_DIR=/tools/vera/gcc-5.4.0/tpls/opt
 BLAS_LIBRARY_DIRS=${TPL_DIR}/lapack-3.3.1/lib
 LAPACK_LIBRARY_DIRS=${TPL_DIR}/lapack-3.3.1/lib
 
-PETSC_DIR=${TPL_DIR}/petsc-3.5.4
-SLEPC_DIR=${TPL_DIR}/slepc-3.5.4
+PETSC_DIR=${TPL_DIR}/petsc-3.6.4
+SLEPC_DIR=${TPL_DIR}/slepc-3.6.3
 HYPRE_DIR=${TPL_DIR}/hypre-2.9.1a
 SUNDIALS_DIR=${TPL_DIR}/sundials-2.9.0
 PETSC_INCLUDE_DIRS="${PETSC_DIR}/include;${HYPRE_DIR}/include"
@@ -16,8 +16,8 @@ SLEPC_LIBRARY_DIRS="${SLEPC_DIR}/lib"
 SUNDIALS_INCLUDE_DIRS="${SUNDIALS_DIR}/include"
 SUNDIALS_LIBRARY_DIRS="${SUNDIALS_DIR}/lib"
 HDF5_LIBRARY_NAMES="hdf5_hl;hdf5;hdf5_cpp;hdf5_fortran"
-HDF5_INCLUDE_DIRS=${TPL_DIR}/hdf5-1.8.10/include
-HDF5_LIBRARY_DIRS=${TPL_DIR}/hdf5-1.8.10/lib
+HDF5_INCLUDE_DIRS=${TPL_DIR}/hdf5-1.10.1/include
+HDF5_LIBRARY_DIRS=${TPL_DIR}/hdf5-1.10.1/lib
 
 cmake -Wno-dev                                  \
  -DCMAKE_BUILD_TYPE:STRING="RELEASE"            \


### PR DESCRIPTION
Description:
In bash when chaining commands, the && will only execute the next
command if the previous command had a return value of 0. When using
; it will execute the next command regardless of the return code.

Not sure how TravisCI treats the error code in reporting errors,
so I'm hoping this reveals the issue.

Github Issue - #132