### PR TITLE
Adds a set of Native/Parallel Datatypes

### DIFF
--- a/src/BLAS2.f90
+++ b/src/BLAS2.f90
@@ -3733,7 +3733,7 @@ PURE SUBROUTINE dtrsv_all(uplo,trans,diag,a,x,incx_in)
   ENDIF
   IF(n > 0 .AND. incx /= 0 .AND. lda >= MAX(1,N) .AND. &
       (trans == 't' .OR. trans == 'T' .OR. trans == 'c' .OR. trans == 'C' .OR. &
-      trans == 'n' .OR. trans == 'N') .AND. &
+        trans == 'n' .OR. trans == 'N') .AND. &
       (uplo == 'u' .OR. uplo == 'U' .OR. uplo == 'l' .OR. uplo == 'L') .AND. &
       (diag == 'u' .OR. diag == 'U' .OR. diag == 'n' .OR. diag == 'N')) THEN
 
@@ -3747,7 +3747,7 @@ PURE SUBROUTINE dtrsv_all(uplo,trans,diag,a,x,incx_in)
         kx = 1 - (n-1)*incx
     ELSEIF (incx/=1) THEN
         kx = 1
-    END IF
+    ENDIF
 
     IF (trans == 'n' .OR. trans == 'N') THEN  ! Form  x := inv( A )*x.
       IF (uplo == 'u' .OR. uplo == 'U') THEN  ! Upper triangular
@@ -3758,6 +3758,22 @@ PURE SUBROUTINE dtrsv_all(uplo,trans,diag,a,x,incx_in)
               temp=x(j)
               DO i=j-1,1,-1
                 x(i)=x(i)-temp*a(i,j)
+              ENDDO
+            ENDIF
+          ENDDO
+        ELSE
+          jx=kx+(n-1)*incx
+          DO J=n,1,-1
+            IF (x(jx)/=ZERO) THEN
+              IF (nounit) x(jx)=x(jx)/a(j,j)
+              temp=x(jx)
+              ix=jx
+              DO i=j-1,1,-1
+                ix=ix-incx
+                x(ix)=x(ix)-temp*a(i,j)
+              ENDDO
+            ENDIF
+            jx=jx-incx
               ENDDO
             ENDIF
           ENDDO

--- a/src/BLAS2.f90
+++ b/src/BLAS2.f90
@@ -3733,7 +3733,7 @@ PURE SUBROUTINE dtrsv_all(uplo,trans,diag,a,x,incx_in)
   ENDIF
   IF(n > 0 .AND. incx /= 0 .AND. lda >= MAX(1,N) .AND. &
       (trans == 't' .OR. trans == 'T' .OR. trans == 'c' .OR. trans == 'C' .OR. &
-        trans == 'n' .OR. trans == 'N') .AND. &
+      trans == 'n' .OR. trans == 'N') .AND. &
       (uplo == 'u' .OR. uplo == 'U' .OR. uplo == 'l' .OR. uplo == 'L') .AND. &
       (diag == 'u' .OR. diag == 'U' .OR. diag == 'n' .OR. diag == 'N')) THEN
 
@@ -3758,22 +3758,6 @@ PURE SUBROUTINE dtrsv_all(uplo,trans,diag,a,x,incx_in)
               temp=x(j)
               DO i=j-1,1,-1
                 x(i)=x(i)-temp*a(i,j)
-              ENDDO
-            ENDIF
-          ENDDO
-        ELSE
-          jx=kx+(n-1)*incx
-          DO J=n,1,-1
-            IF (x(jx)/=ZERO) THEN
-              IF (nounit) x(jx)=x(jx)/a(j,j)
-              temp=x(jx)
-              ix=jx
-              DO i=j-1,1,-1
-                ix=ix-incx
-                x(ix)=x(ix)-temp*a(i,j)
-              ENDDO
-            ENDIF
-            jx=jx-incx
               ENDDO
             ENDIF
           ENDDO

--- a/src/MatrixTypes.f90
+++ b/src/MatrixTypes.f90
@@ -689,7 +689,6 @@ ENDSUBROUTINE matvec_MatrixTypeVectorType
 !> @param b the scalar used to scale @c y
 !>
 SUBROUTINE matvec_DistrBandedMatrixType(thisMatrix,x,y,t,ul,d,incx,a,b)
-  CHARACTER(LEN=*),PARAMETER :: myName='matvec_DistrBandedMatrixTypeNativeVectorType'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: thisMatrix
   REAL(SRK),INTENT(INOUT) :: x(:)
   CHARACTER(LEN=1),INTENT(IN) :: t

--- a/src/MatrixTypes.f90
+++ b/src/MatrixTypes.f90
@@ -97,7 +97,7 @@ PUBLIC :: RectMatrixType
 PUBLIC :: DistributedMatrixType
 ! Matrix structure enumerations
 PUBLIC :: SPARSE,DENSESQUARE,DENSERECT,TRIDIAG, &
-          BANDED,DISTRIBUTED_BANDED,DISTR_BLOCKBANDED
+    BANDED,DISTRIBUTED_BANDED,DISTR_BLOCKBANDED
 ! Matrix-Vector engine enumerations
 PUBLIC :: VM_PETSC,VM_TRILINOS,VM_NATIVE
 ! Parameter list setup/teardown
@@ -430,37 +430,37 @@ SUBROUTINE matvec_MatrixType(thisMatrix,trans,alpha,x,beta,y,uplo,diag,incx_in)
     IF(PRESENT(diag)) d=diag
     IF(PRESENT(incx_in)) incx=incx_in
 
-    SELECTTYPE(thisMatrix)
+    SELECT TYPE(thisMatrix)
     TYPE IS(DenseSquareMatrixType)
       IF(ul /= 'n') THEN
         y=x
         CALL BLAS2_matvec(ul,t,d,thisMatrix%a,y,incx)
       ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-          alpha,thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
+            alpha,thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
       ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-          alpha,thisMatrix%a,thisMatrix%n,x,1,y,1)
+            alpha,thisMatrix%a,thisMatrix%n,x,1,y,1)
       ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-          thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
+            thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
       ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-          thisMatrix%a,thisMatrix%n,x,1,y,1)
+            thisMatrix%a,thisMatrix%n,x,1,y,1)
       ENDIF
     TYPE IS(DenseRectMatrixType)
       IF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-          alpha,thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
+            alpha,thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
       ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-          alpha,thisMatrix%a,thisMatrix%n,x,1,y,1)
+            alpha,thisMatrix%a,thisMatrix%n,x,1,y,1)
       ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-          thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
+            thisMatrix%a,thisMatrix%n,x,1,beta,y,1)
       ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-          thisMatrix%a,thisMatrix%n,x,1,y,1)
+            thisMatrix%a,thisMatrix%n,x,1,y,1)
       ENDIF
     TYPE IS(SparseMatrixType)
       IF(ul /= 'n') THEN
@@ -468,58 +468,58 @@ SUBROUTINE matvec_MatrixType(thisMatrix,trans,alpha,x,beta,y,uplo,diag,incx_in)
         CALL trsv_sparse(ul,t,d,thisMatrix%a,thisMatrix%ia,thisMatrix%ja,y,incx)
       ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-          thisMatrix%ja,thisMatrix%a,alpha,x,beta,y)
+            thisMatrix%ja,thisMatrix%a,alpha,x,beta,y)
       ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-          thisMatrix%ja,thisMatrix%a,alpha,x,y)
+            thisMatrix%ja,thisMatrix%a,alpha,x,y)
       ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
         CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-          thisMatrix%ja,thisMatrix%a,x,beta,y)
+            thisMatrix%ja,thisMatrix%a,x,beta,y)
       ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
         CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-          thisMatrix%ja,thisMatrix%a,x,y)
+            thisMatrix%ja,thisMatrix%a,x,y)
       ENDIF
     TYPE IS(BandedMatrixType)
       IF(ul /= 'n' .OR. d /= 'n' .OR. t /= 'n' .OR. incx /= 1) THEN
         CALL eMatrixType%raiseError('Incorrect call to '// &
-             modName//'::'//myName//' - This interface is not implemented.')
+            modName//'::'//myName//' - This interface is not implemented.')
       ENDIF
 
-      a = 1.0_SRK
-      b = 1.0_SRK
-      IF (PRESENT(alpha)) a = alpha
-      IF (PRESENT(beta)) b = beta
+      a=1.0_SRK
+      b=1.0_SRK
+      IF (PRESENT(alpha)) a=alpha
+      IF (PRESENT(beta)) b=beta
 
-      IF(b == 0.0_SRK) THEN
-        y = 0.0_SRK
-      ELSE IF (b /= 1.0_SRK) THEN
-        y = y*b
+      IF (b == 0.0_SRK) THEN
+        y=0.0_SRK
+      ELSEIF (b /= 1.0_SRK) THEN
+        y=y*b
       ENDIF
 
       ! This can probably be optimized for the a /= 1 case
-      IF (a==1.0_SRK) THEN
+      IF (a == 1.0_SRK) THEN
         DO bIdx=1,SIZE(thisMatrix%bandIdx)
-          idxMult = thisMatrix%bands(bIdx)%jIdx - thisMatrix%bandIdx(bIdx)
-          y(idxMult) = y(idxMult) + thisMatrix%bands(bIdx)%elem * x(thisMatrix%bands(bIdx)%jIdx)
+          idxMult=thisMatrix%bands(bIdx)%jIdx-thisMatrix%bandIdx(bIdx)
+          y(idxMult)=y(idxMult)+thisMatrix%bands(bIdx)%elem*x(thisMatrix%bands(bIdx)%jIdx)
         ENDDO
-      ELSEIF (a==-1.0_SRK) THEN
+      ELSEIF (a == -1.0_SRK) THEN
         DO bIdx=1,SIZE(thisMatrix%bandIdx)
-          idxMult = thisMatrix%bands(bIdx)%jIdx - thisMatrix%bandIdx(bIdx)
-          y(idxMult) = y(idxMult) - thisMatrix%bands(bIdx)%elem * x(thisMatrix%bands(bIdx)%jIdx)
+          idxMult=thisMatrix%bands(bIdx)%jIdx-thisMatrix%bandIdx(bIdx)
+          y(idxMult)=y(idxMult)-thisMatrix%bands(bIdx)%elem*x(thisMatrix%bands(bIdx)%jIdx)
         ENDDO
-      ELSEIF (a/=0.0_SRK) THEN
+      ELSEIF (a /= 0.0_SRK) THEN
         DO bIdx=1,SIZE(thisMatrix%bandIdx)
-          idxMult = thisMatrix%bands(bIdx)%jIdx - thisMatrix%bandIdx(bIdx)
-          y(idxMult) = y(idxMult) + a * thisMatrix%bands(bIdx)%elem * x(thisMatrix%bands(bIdx)%jIdx)
+          idxMult=thisMatrix%bands(bIdx)%jIdx-thisMatrix%bandIdx(bIdx)
+          y(idxMult)=y(idxMult)+a*thisMatrix%bands(bIdx)%elem*x(thisMatrix%bands(bIdx)%jIdx)
         ENDDO
       ENDIF
 
     CLASS IS(DistributedBandedMatrixType)
       CALL eMatrixType%raiseError('Incorrect call to '// &
-         modName//'::'//myName//' - This interface is not available.')
+          modName//'::'//myName//' - This interface is not available.')
     CLASS DEFAULT
       CALL eMatrixType%raiseError('Incorrect call to '// &
-           modName//'::'//myName//' - This interface is not available.')
+          modName//'::'//myName//' - This interface is not available.')
     ENDSELECT
   ENDIF
 ENDSUBROUTINE matvec_MatrixType
@@ -585,97 +585,94 @@ SUBROUTINE matvec_MatrixTypeVectorType(thisMatrix,trans,alpha,x,beta,y,uplo,diag
     IF(PRESENT(beta))  b=beta
 
     SELECT TYPE(x)
+    TYPE IS(RealVectorType)
+      SELECT TYPE(y)
       TYPE IS(RealVectorType)
-        SELECT TYPE(y)
-          TYPE IS(RealVectorType)
-            SELECT TYPE(thisMatrix)
-              TYPE IS(DenseSquareMatrixType)
-                IF(ul /= 'n') THEN
-                  y%b=x%b
-                  CALL BLAS2_matvec(ul,t,d,thisMatrix%a,y%b,incx)
-                ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-                    alpha,thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
-                ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-                    alpha,thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-                    thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
-                    thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
-                ENDIF
-              TYPE IS(DenseRectMatrixType)
-                IF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-                    alpha,thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
-                ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-                    alpha,thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-                    thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
-                    thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
-                ENDIF
-              TYPE IS(SparseMatrixType)
-                IF(ul /= 'n') THEN
-                  y%b=x%b
-                  CALL trsv_sparse(ul,t,d,thisMatrix%a,thisMatrix%ia,thisMatrix%ja,y%b,incx)
-                ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-                    thisMatrix%ja,thisMatrix%a,alpha,x%b,beta,y%b)
-                ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-                    thisMatrix%ja,thisMatrix%a,alpha,x%b,y%b)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-                    thisMatrix%ja,thisMatrix%a,x%b,beta,y%b)
-                ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
-                  CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
-                    thisMatrix%ja,thisMatrix%a,x%b,y%b)
-                ENDIF
-              TYPE IS(BandedMatrixType)
-                CALL matvec_MatrixType(thisMatrix,trans=t,alpha=a,X=x%b,beta=b, &
-                                       Y=y%b,uplo=ul,diag=d,incx_in=incx)
-              CLASS IS(DistributedBandedMatrixType)
-                CALL matvec_MatrixType(thisMatrix,trans=t,alpha=a,X=x%b,beta=b, &
-                                       Y=y%b,uplo=ul,diag=d,incx_in=incx)
-              CLASS DEFAULT
-                CALL eMatrixType%raiseError('Incorrect call to '// &
-                     modName//'::'//myName//' - This interface is not available.')
-            ENDSELECT
-          CLASS DEFAULT
-            CALL eMatrixType%raiseError('Incorrect call to '// &
-                 modName//'::'//myName//' - This interface is not available.')
+        SELECT TYPE(thisMatrix)
+        TYPE IS(DenseSquareMatrixType)
+          IF(ul /= 'n') THEN
+            y%b=x%b
+            CALL BLAS2_matvec(ul,t,d,thisMatrix%a,y%b,incx)
+          ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
+                alpha,thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
+          ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
+                alpha,thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
+                thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%n, &
+                thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
+          ENDIF
+        TYPE IS(DenseRectMatrixType)
+          IF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
+                alpha,thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
+          ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
+                alpha,thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
+                thisMatrix%a,thisMatrix%n,x%b,1,beta,y%b,1)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(t,thisMatrix%n,thisMatrix%m, &
+                thisMatrix%a,thisMatrix%n,x%b,1,y%b,1)
+          ENDIF
+        TYPE IS(SparseMatrixType)
+          IF(ul /= 'n') THEN
+            y%b=x%b
+            CALL trsv_sparse(ul,t,d,thisMatrix%a,thisMatrix%ia,thisMatrix%ja,y%b,incx)
+          ELSEIF(PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
+                thisMatrix%ja,thisMatrix%a,alpha,x%b,beta,y%b)
+          ELSEIF(PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
+                thisMatrix%ja,thisMatrix%a,alpha,x%b,y%b)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. PRESENT(beta)) THEN
+            CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
+                thisMatrix%ja,thisMatrix%a,x%b,beta,y%b)
+          ELSEIF(.NOT.PRESENT(alpha) .AND. .NOT.PRESENT(beta)) THEN
+            CALL BLAS2_matvec(thisMatrix%n,thisMatrix%nnz,thisMatrix%ia, &
+                thisMatrix%ja,thisMatrix%a,x%b,y%b)
+          ENDIF
+        TYPE IS(BandedMatrixType)
+          CALL matvec_MatrixType(thisMatrix,trans=t,alpha=a,X=x%b,beta=b, &
+              Y=y%b,uplo=ul,diag=d,incx_in=incx)
+        CLASS IS(DistributedBandedMatrixType)
+          CALL matvec_MatrixType(thisMatrix,trans=t,alpha=a,X=x%b,beta=b, &
+              Y=y%b,uplo=ul,diag=d,incx_in=incx)
+        CLASS DEFAULT
+          CALL eMatrixType%raiseError('Incorrect call to '// &
+              modName//'::'//myName//' - This interface is not available.')
         ENDSELECT
-#ifdef HAVE_MPI
-      TYPE IS(NativeDistributedVectorType)
-        SELECT TYPE(y)
-          TYPE IS(NativeDistributedVectorType)
-            SELECT TYPE(thisMatrix)
-              CLASS IS(DistributedBandedMatrixType)
-                CALL matvec_DistrBandedMatrixType(thisMatrix,x%b,y%b,t, &
-                                                  ul,d,incx,a,b)
-              CLASS DEFAULT
-                CALL eMatrixType%raiseError('Incorrect call to '// &
-                     modName//'::'//myName// &
-                     ' - This interface is not available.')
-            ENDSELECT
-          CLASS DEFAULT
-            CALL eMatrixType%raiseError('Incorrect call to '// &
-                 modName//'::'//myName//' - This interface is not available.')
-        ENDSELECT
-#endif
       CLASS DEFAULT
         CALL eMatrixType%raiseError('Incorrect call to '// &
-             modName//'::'//myName//' - This interface is not available.')
+            modName//'::'//myName//' - This interface is not available.')
+      ENDSELECT
+#ifdef HAVE_MPI
+    TYPE IS(NativeDistributedVectorType)
+      SELECT TYPE(y)
+      TYPE IS(NativeDistributedVectorType)
+        SELECT TYPE(thisMatrix)
+        CLASS IS(DistributedBandedMatrixType)
+          CALL matvec_DistrBandedMatrixType(thisMatrix,x%b,y%b,t,ul,d,incx,a,b)
+        CLASS DEFAULT
+          CALL eMatrixType%raiseError('Incorrect call to '//modName//'::'// &
+              myName//' - This interface is not available.')
+        ENDSELECT
+      CLASS DEFAULT
+        CALL eMatrixType%raiseError('Incorrect call to '// &
+            modName//'::'//myName//' - This interface is not available.')
+      ENDSELECT
+#endif
+    CLASS DEFAULT
+      CALL eMatrixType%raiseError('Incorrect call to '// &
+          modName//'::'//myName//' - This interface is not available.')
     ENDSELECT
   ENDIF
 ENDSUBROUTINE matvec_MatrixTypeVectorType
-
 
 !
 !-------------------------------------------------------------------------------
@@ -714,7 +711,7 @@ SUBROUTINE matvec_DistrBandedMatrixType(thisMatrix,x,y,t,ul,d,incx,a,b)
   INTEGER(SIK) :: i,l,idxTmp,cnt,ctDefault,mpierr
   CALL MPI_Comm_rank(thisMatrix%comm,rank,mpierr)
 #else
-  rank = 0
+  rank=0
 #endif
   ! NOTE: incx,ul,d,t are NOT USED
 
@@ -722,12 +719,12 @@ SUBROUTINE matvec_DistrBandedMatrixType(thisMatrix,x,y,t,ul,d,incx,a,b)
   ! This allows one to be used for computation and the rest for
   ! communication.
   ! Which one to write to will be determined by *Counter MOD MATVEC_SLOTS
-  sendCounter = 0
-  recvCounter = 0
-  sendRequests = 0
-  sendIdxRequests = 0
-  recvRequests = 0
-  recvIdxRequests = 0
+  sendCounter=0
+  recvCounter=0
+  sendRequests=0
+  sendIdxRequests=0
+  recvRequests=0
+  recvIdxRequests=0
   ! The recv/sendResult array will sometimes hold it's full length,
   ! and sometimes less.
   ! The variable "cnt" will be used to determine this at
@@ -736,81 +733,67 @@ SUBROUTINE matvec_DistrBandedMatrixType(thisMatrix,x,y,t,ul,d,incx,a,b)
   ALLOCATE(recvResult(thisMatrix%iOffsets(2),MATVEC_SLOTS))
   ALLOCATE(sendIdx(thisMatrix%iOffsets(2),MATVEC_SLOTS))
   ALLOCATE(sendResult(thisMatrix%iOffsets(2),MATVEC_SLOTS))
-  ALLOCATE(tmpProduct(thisMatrix%iOffsets(rank+2) - &
-           thisMatrix%iOffsets(rank+1)))
+  ALLOCATE(tmpProduct(thisMatrix%iOffsets(rank+2)- &
+      thisMatrix%iOffsets(rank+1)))
 
   ! First, take care of locally held data.
-  SELECT TYPE(thisMatrix); TYPE IS(DistributedBlockBandedMatrixType)
+  SELECT TYPE(thisMatrix)
+  TYPE IS(DistributedBlockBandedMatrixType)
     IF (.NOT. thisMatrix%blockMask) THEN
       DO k=1,thisMatrix%nlocalBlocks
-        lowIdx = (k-1)*thisMatrix%blockSize+1
-        highIdx = lowIdx-1 + thisMatrix%blockSize
-        CALL matvec_MatrixType(THISMATRIX=thisMatrix%blocks(k), &
-                               X=x(lowIdx:highIdx), &
-                               Y=tmpProduct(lowIdx:highIdx), &
-                               ALPHA=1.0_SRK,BETA=0.0_SRK)
+        lowIdx=(k-1)*thisMatrix%blockSize+1
+        highIdx=lowIdx-1+thisMatrix%blockSize
+        CALL matvec_MatrixType(THISMATRIX=thisMatrix%blocks(k),X=x(lowIdx:highIdx), &
+            Y=tmpProduct(lowIdx:highIdx),ALPHA=1.0_SRK,BETA=0.0_SRK)
       ENDDO
-    ELSE
-      tmpProduct = 0.0_SRK
     ENDIF
-  END SELECT
+    IF (thisMatrix%chunks(rank+1)%isInit) THEN
+      CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(rank+1),X=x, &
+          y=tmpProduct,ALPHA=1.0_SRK,BETA=1.0_SRK)
+    ENDIF
+  TYPE IS(DistributedBandedMatrixType)
+    IF (thisMatrix%chunks(rank+1)%isInit) THEN
+      CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(rank+1),X=x, &
+          y=tmpProduct,ALPHA=1.0_SRK,BETA=0.0_SRK)
+    ENDIF
+  ENDSELECT
 
 #ifdef HAVE_MPI
   ! On each rank, loop over the chunks held (top to bottom)
   DO i=1,SIZE(thisMatrix%iOffsets)-1
-    ctDefault = thisMatrix%iOffsets(i+1) - thisMatrix%iOffsets(i)
+    ctDefault=thisMatrix%iOffsets(i+1)-thisMatrix%iOffsets(i)
     IF (rank+1 == i) THEN
       ! We will be receiving data from other processes
-      IF (thisMatrix%chunks(i)%isInit) THEN
-        SELECT TYPE(thisMatrix)
-        TYPE IS(DistributedBlockBandedMatrixType)
-          IF (.NOT. thisMatrix%blockMask) THEN
-            CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(i),X=x, &
-                             y=tmpProduct,ALPHA=1.0_SRK,BETA=1.0_SRK)
-          ELSE
-            CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(i),X=x, &
-                             y=tmpProduct,ALPHA=1.0_SRK,BETA=0.0_SRK)
-          ENDIF
-        CLASS DEFAULT
-          CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(i),X=x, &
-                           y=tmpProduct,ALPHA=1.0_SRK,BETA=0.0_SRK)
-        ENDSELECT
-      ENDIF
-
       ! Find which other chunks in this row we need to
       ! communicate with
       DO k=1,SIZE(thisMatrix%bandSizes,1)
         IF (ASSOCIATED(thisMatrix%bandSizes(k)%p)) THEN
           IF (thisMatrix%bandSizes(k)%p(1) < 0) THEN
             ! We are receiving a whole vector at once
-            recvCounter = recvCounter + 1
-            idxTmp = MOD(recvCounter,MATVEC_SLOTS)+1
+            recvCounter=recvCounter+1
+            idxTmp=MOD(recvCounter,MATVEC_SLOTS)+1
             ! If we've filled up the available storage, we need
             ! to wait for communication to finish up
-            CALL pop_recv(tmpProduct, recvResult, recvIdx, ctRecv, idxTmp, &
-                          recvRequests, recvIdxRequests)
-            ctRecv(MOD(recvCounter,MATVEC_SLOTS)+1) = ctDefault
-            CALL MPI_IRecv(recvResult(1:ctDefault,idxTmp), ctDefault,     &
-                           MPI_DOUBLE_PRECISION, k-1, 0, thisMatrix%comm, &
-                           recvRequests(idxTmp), mpierr)
+            CALL pop_recv(tmpProduct,recvResult,recvIdx,ctRecv,idxTmp, &
+                recvRequests, recvIdxRequests)
+            ctRecv(MOD(recvCounter,MATVEC_SLOTS)+1)=ctDefault
+            CALL MPI_IRecv(recvResult(1:ctDefault,idxTmp), ctDefault, &
+                MPI_DOUBLE_PRECISION,k-1,0,thisMatrix%comm, &
+                recvRequests(idxTmp),mpierr)
           ELSE
             ! We are receiving multiple sparse chunks
             DO l=1,SIZE(thisMatrix%bandSizes(k)%p)
-              recvCounter = recvCounter + 1
-              idxTmp = MOD(recvCounter,MATVEC_SLOTS)+1
+              recvCounter=recvCounter+1
+              idxTmp=MOD(recvCounter,MATVEC_SLOTS)+1
               ! If we've filled up the available storage, we need
               ! to wait for communication to finish up
-              CALL pop_recv(tmpProduct, recvResult, recvIdx, ctRecv, &
-                            idxTmp, recvRequests, recvIdxRequests)
-              ctRecv(idxTmp) = -thisMatrix%bandSizes(k)%p(l)
-              CALL MPI_IRecv(recvIdx(1:ctRecv(idxTmp),idxTmp),     &
-                             -ctRecv(idxTmp), MPI_INTEGER, k-1, 0, &
-                             thisMatrix%comm,                      &
-                             recvIdxRequests(idxTmp), mpierr)
-              CALL MPI_IRecv(recvResult(1:ctRecv(idxTmp),idxTmp),   &
-                             -ctRecv(idxTmp), MPI_DOUBLE_PRECISION, &
-                             k-1, 0, thisMatrix%comm,               &
-                             recvRequests(idxTmp), mpierr)
+              CALL pop_recv(tmpProduct,recvResult,recvIdx,ctRecv,idxTmp, &
+                  recvRequests, recvIdxRequests)
+              ctRecv(idxTmp)=-thisMatrix%bandSizes(k)%p(l)
+              CALL MPI_IRecv(recvIdx(1:ctRecv(idxTmp),idxTmp),-ctRecv(idxTmp), &
+                  MPI_INTEGER,k-1,0,thisMatrix%comm,recvIdxRequests(idxTmp), mpierr)
+              CALL MPI_IRecv(recvResult(1:ctRecv(idxTmp),idxTmp),-ctRecv(idxTmp), &
+                  MPI_DOUBLE_PRECISION,k-1,0,thisMatrix%comm,recvRequests(idxTmp), mpierr)
             ENDDO
           ENDIF
         ENDIF
@@ -819,95 +802,89 @@ SUBROUTINE matvec_DistrBandedMatrixType(thisMatrix,x,y,t,ul,d,incx,a,b)
       ! requests to finish:
       DO idxTmp=1,MATVEC_SLOTS
         CALL pop_recv(tmpProduct, recvResult, recvIdx, ctRecv, idxTmp, &
-                      recvRequests, recvIdxRequests)
+            recvRequests, recvIdxRequests)
       ENDDO
     ELSE
       ! We will be sending data to some other process
       IF (thismatrix%chunks(i)%isInit) THEN
         ! Decide whether to send whole vector or multiple sparse
         IF (2*thisMatrix%chunks(i)%nnz/3 >= thisMatrix%chunks(i)%n) THEN
-          sendCounter = sendCounter + 1
-          idxTmp = MOD(sendCounter,MATVEC_SLOTS)+1
+          sendCounter=sendCounter+1
+          idxTmp=MOD(sendCounter,MATVEC_SLOTS)+1
           ! Check if we can safely write to sendRequests
-          CALL pop_send(sendResult, sendIdx, idxTmp, sendRequests, &
-                        sendIdxRequests)
-          CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(i), X=x, &
-                           y=sendResult(1:ctDefault,idxTmp), &
-                           ALPHA=1.0_SRK,BETA=0.0_SRK)
-          CALL MPI_ISend(sendResult(1:ctDefault,idxTmp), ctDefault,    &
-                         MPI_DOUBLE_PRECISION, i-1, 0,thisMatrix%comm, &
-                         sendRequests(idxTmp),mpierr)
+          CALL pop_send(sendResult,sendIdx,idxTmp,sendRequests,sendIdxRequests)
+          CALL BLAS_matvec(THISMATRIX=thisMatrix%chunks(i),X=x,&
+              y=sendResult(1:ctDefault,idxTmp),ALPHA=1.0_SRK,BETA=0.0_SRK)
+          CALL MPI_ISend(sendResult(1:ctDefault,idxTmp),ctDefault, &
+              MPI_DOUBLE_PRECISION,i-1,0,thisMatrix%comm,sendRequests(idxTmp),mpierr)
         ELSE
           ! Send several sparse vectors
           DO l=1,SIZE(thisMatrix%chunks(i)%bandIdx)
-            sendCounter = sendCounter + 1
-            idxTmp = MOD(sendCounter,MATVEC_SLOTS)+1
-            CALL pop_send(sendResult, sendIdx, idxTmp, sendRequests, &
-                          sendIdxRequests)
+            sendCounter=sendCounter+1
+            idxTmp=MOD(sendCounter,MATVEC_SLOTS)+1
+            CALL pop_send(sendResult,sendIdx,idxTmp,sendRequests,sendIdxRequests)
 
             ! compute destination indices
             ! perform special-case multiplication from single band here
-            cnt = SIZE(thisMatrix%chunks(i)%bands(l)%jIdx)
-            sendIdx(1:cnt,idxTmp) = thisMatrix%chunks(i)%bands(l)%jIdx &
-                                      - thisMatrix%chunks(i)%bandIdx(l)
-            CALL MPI_ISend(sendIdx(1:cnt,idxTmp), cnt, MPI_INTEGER,   &
-                           i-1, 0, thisMatrix%comm,                       &
-                           sendIdxRequests(idxTmp), mpierr)
+            cnt=SIZE(thisMatrix%chunks(i)%bands(l)%jIdx)
+            sendIdx(1:cnt,idxTmp)=thisMatrix%chunks(i)%bands(l)%jIdx &
+                -thisMatrix%chunks(i)%bandIdx(l)
+            CALL MPI_ISend(sendIdx(1:cnt,idxTmp),cnt,MPI_INTEGER,i-1,0, &
+                thisMatrix%comm,sendIdxRequests(idxTmp), mpierr)
             sendResult(1:cnt,idxTmp)=thisMatrix%chunks(i)%bands(l)%elem &
-                                      *x(thisMatrix%chunks(i)%bands(l)%jIdx)
-            CALL MPI_ISend(sendResult(1:cnt,idxTmp), cnt, &
-                           MPI_DOUBLE_PRECISION, i-1, 0, thisMatrix%comm, &
-                           sendRequests(idxTmp), mpierr)
+                *x(thisMatrix%chunks(i)%bands(l)%jIdx)
+            CALL MPI_ISend(sendResult(1:cnt,idxTmp),cnt,MPI_DOUBLE_PRECISION, &
+                i-1,0,thisMatrix%comm,sendRequests(idxTmp), mpierr)
           ENDDO
         ENDIF
       ENDIF
     ENDIF
   ENDDO
   DO idxTmp=1,MATVEC_SLOTS
-    CALL pop_send(sendResult, sendIdx, idxTmp, sendRequests, sendIdxRequests)
+    CALL pop_send(sendResult,sendIdx,idxTmp,sendRequests,sendIdxRequests)
   ENDDO
 #endif
 
-  ! do y = alpha * reduce + beta*y
+  ! do y=alpha*reduce+beta*y
   ! We take many special cases in order to effectively use FMA instructions
   ! or reduce the required flops.
   IF (a == 1.0_SRK) THEN
     IF (b == 1.0_SRK) THEN
-      y = tmpProduct + y
+      y=tmpProduct+y
     ELSEIF (b == 0.0_SRK) THEN
-      y = tmpProduct
+      y=tmpProduct
     ELSEIF (b == -1.0_SRK) THEN
-      y = tmpProduct - y
+      y=tmpProduct-y
     ELSE
-      y = tmpProduct + b*y
+      y=tmpProduct+b*y
     ENDIF
   ELSEIF (a == 0.0_SRK) THEN
     IF (b == 0.0_SRK) THEN
-      y = 0.0_SRK
+      y=0.0_SRK
     ELSEIF (b == -1.0_SRK) THEN
-      y = -y
+      y=-y
     ELSEIF (b /= 1.0_SRK) THEN
-      y = b*y
+      y=b*y
     ENDIF
   ELSEIF (a == -1.0_SRK) THEN
     IF (b == 1.0_SRK) THEN
-      y = y - tmpProduct
+      y=y-tmpProduct
     ELSEIF (b == 0.0_SRK) THEN
-      y = -tmpProduct
+      y=-tmpProduct
     ELSEIF (b == -1.0_SRK) THEN
-      y = -tmpProduct - y
+      y=-tmpProduct-y
     ELSE
-      y = b*y - tmpProduct
+      y=b*y-tmpProduct
     ENDIF
   ELSE
     IF (b == 1.0_SRK) THEN
-      y = a*tmpProduct + y
+      y=a*tmpProduct+y
     ELSEIF (b == 0.0_SRK) THEN
-      y = a*tmpProduct
+      y=a*tmpProduct
     ELSEIF (b == -1.0_SRK) THEN
-      y = a*tmpProduct - y
+      y=a*tmpProduct-y
     ELSE
-      y = a*tmpProduct + b*y
+      y=a*tmpProduct+b*y
     ENDIF
   ENDIF
 ENDSUBROUTINE matvec_DistrBandedMatrixType
@@ -926,7 +903,7 @@ ENDSUBROUTINE matvec_DistrBandedMatrixType
 !> @param req The array of active requests for data
 !> @param idxReq The array of requests for indices
 !>
-SUBROUTINE pop_recv(acc, valBuf, idxBuf, ctBuf, idx, req, idxReq)
+SUBROUTINE pop_recv(acc,valBuf,idxBuf,ctBuf,idx,req,idxReq)
   REAL(SRK), INTENT(INOUT) :: acc(:)
   REAL(SRK), INTENT(INOUT) :: valBuf(:,:)
   INTEGER(SIK), INTENT(INOUT) :: ctBuf(MATVEC_SLOTS)
@@ -940,12 +917,12 @@ SUBROUTINE pop_recv(acc, valBuf, idxBuf, ctBuf, idx, req, idxReq)
 
   CALL MPI_Wait(req(idx),MPI_STATUS_IGNORE,mpierr)
   IF (ctBuf(idx) > 0) THEN
-    acc(1:ctBuf(idx)) = acc(1:ctBuf(idx)) + valBuf(1:ctBuf(idx),idx)
+    acc(1:ctBuf(idx))=acc(1:ctBuf(idx))+valBuf(1:ctBuf(idx),idx)
   ELSE
     CALL MPI_Wait(idxReq(idx),MPI_STATUS_IGNORE,mpierr)
-    idxReq(idx) = 0
-    acc(idxBuf(1:-ctBuf(idx),idx)) = acc(idxBuf(1:-ctBuf(idx),idx)) &
-        + valBuf(1:-ctBuf(idx),idx)
+    idxReq(idx)=0
+    acc(idxBuf(1:-ctBuf(idx),idx))=acc(idxBuf(1:-ctBuf(idx),idx)) &
+        +valBuf(1:-ctBuf(idx),idx)
   ENDIF
 ENDSUBROUTINE pop_recv
 !
@@ -977,7 +954,7 @@ SUBROUTINE pop_send(valBuf, idxBuf, idx, req, idxReq)
   CALL MPI_Wait(req(idx),MPI_STATUS_IGNORE,mpierr)
   IF (idxReq(idx) /= 0) THEN
     CALL MPI_Wait(idxReq(idx),MPI_STATUS_IGNORE,mpierr)
-    idxReq(idx) = 0
+    idxReq(idx)=0
   ENDIF
 ENDSUBROUTINE pop_send
 #endif
@@ -1099,7 +1076,7 @@ PURE SUBROUTINE trsv_sparse(uplo,trans,diag,a,ia,ja,x,incx_in)
       ! Multiply by upper trianbular part of matrix
       IF (uplo == 'u' .OR. uplo == 'U') THEN
         IF(incx == 1) THEN
-          DO j = 1,SIZE(ia)-1
+          DO j=1,SIZE(ia)-1
             IF(.NOT.(x(j) .APPROXEQA. ZERO)) THEN
               IF (nounit) x(j)=x(j)/a(ia(j))
               DO i=ia(j)+1,ia(j+1)-1
@@ -1111,7 +1088,7 @@ PURE SUBROUTINE trsv_sparse(uplo,trans,diag,a,ia,ja,x,incx_in)
         ! Elements are stored in reverse order and/or by increments other than 1
         ELSE
           ix=kx
-          DO j = 1,SIZE(ia)-1
+          DO j=1,SIZE(ia)-1
             IF(.NOT.(x(ix) .APPROXEQA. ZERO)) THEN
               IF(nounit) x(ix)=x(ix)/a(ia(j))
               jx=ix

--- a/src/MatrixTypes_Base.f90
+++ b/src/MatrixTypes_Base.f90
@@ -190,11 +190,13 @@ TYPE(ParamType),PROTECTED,SAVE :: DistributedMatrixType_reqParams, DistributedMa
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for a Banded Matrix Type.
-TYPE(ParamType),PROTECTED,SAVE :: DistributedBandedMatrixType_reqParams, DistributedBandedMatrixType_optParams
+TYPE(ParamType),PROTECTED,SAVE :: DistributedBandedMatrixType_reqParams, &
+                                  DistributedBandedMatrixType_optParams
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for a Banded Matrix Type.
-TYPE(ParamType),PROTECTED,SAVE :: DistributedBlockBandedMatrixType_reqParams, DistributedBlockBandedMatrixType_optParams
+TYPE(ParamType),PROTECTED,SAVE :: DistributedBlockBandedMatrixType_reqParams, &
+                                  DistributedBlockBandedMatrixType_optParams
 
 !> Logical flag to check whether the required and optional parameter lists
 !> have been created yet for the Matrix Types.

--- a/src/MatrixTypes_Base.f90
+++ b/src/MatrixTypes_Base.f90
@@ -27,14 +27,14 @@ PUBLIC :: DistributedMatrixType
 PUBLIC :: MatrixType_Paramsflag
 !> set enumeration scheme for matrix types
 INTEGER(SIK),PARAMETER,PUBLIC :: SPARSE=0,TRIDIAG=1,DENSESQUARE=2,DENSERECT=3, &
-                                 BANDED=4,DISTRIBUTED_BANDED=5,DISTR_BLOCKBANDED=6
+    BANDED=4,DISTRIBUTED_BANDED=5,DISTR_BLOCKBANDED=6
 PUBLIC :: SparseMatrixType_reqParams,SparseMatrixType_optParams
 PUBLIC :: TriDiagMatrixType_reqParams,TriDiagMatrixType_optParams
 PUBLIC :: BandedMatrixType_reqParams,BandedMatrixType_optParams
 PUBLIC :: DistributedBandedMatrixType_reqParams, &
-  DistributedBandedMatrixType_optParams
+    DistributedBandedMatrixType_optParams
 PUBLIC :: DistributedBlockBandedMatrixType_reqParams, &
-  DistributedBlockBandedMatrixType_optParams
+    DistributedBlockBandedMatrixType_optParams
 PUBLIC :: DenseRectMatrixType_reqParams,DenseRectMatrixType_optParams
 PUBLIC :: DenseSquareMatrixType_reqParams,DenseSquareMatrixType_optParams
 PUBLIC :: DistributedMatrixType_reqParams,DistributedMatrixType_optParams
@@ -191,12 +191,12 @@ TYPE(ParamType),PROTECTED,SAVE :: DistributedMatrixType_reqParams, DistributedMa
 !> The parameter lists to use when validating a parameter list for
 !> initialization for a Banded Matrix Type.
 TYPE(ParamType),PROTECTED,SAVE :: DistributedBandedMatrixType_reqParams, &
-                                  DistributedBandedMatrixType_optParams
+    DistributedBandedMatrixType_optParams
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for a Banded Matrix Type.
 TYPE(ParamType),PROTECTED,SAVE :: DistributedBlockBandedMatrixType_reqParams, &
-                                  DistributedBlockBandedMatrixType_optParams
+    DistributedBlockBandedMatrixType_optParams
 
 !> Logical flag to check whether the required and optional parameter lists
 !> have been created yet for the Matrix Types.
@@ -253,7 +253,7 @@ SUBROUTINE MatrixTypes_Declare_ValidParams()
   matType=1
   MPI_COMM_ID=1
   nlocal=-1
-  blockSize = 1
+  blockSize=1
   !Sparse Matrix Type - Required
   CALL SparseMatrixType_reqParams%add('MatrixType->n',n)
   CALL SparseMatrixType_reqParams%add('MatrixType->nnz',nnz)

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -577,9 +577,6 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
         matrix%jOffsets(:) = matrix%iOffsets(:)
       ENDIF
 
-      REQUIRE(MOD(n,blockSize)==0)
-      REQUIRE(MOD(m,blockSize)==0)
-
       matrix%isInit=.TRUE.
       matrix%isAssembled=.FALSE.
       matrix%n=n*blockSize
@@ -587,6 +584,7 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
       matrix%nnz=nnz
       matrix%blockSize = blockSize
       matrix%comm=commID
+      ALLOCATE(matrix%bandSizes(nProc))
     ENDIF
   ELSE
     CALL eMatrixType%raiseError('Incorrect call to '// &
@@ -1964,17 +1962,17 @@ SUBROUTINE binarySearch_BandedMatrixType(matrix, i, j, bandLoc, elemIdx)
     bIdx = -bIdx
     matrix%bandIdx = -matrix%bandIdx
   ENDIF
+
   lo = 1
-  hi = SIZE(matrix%bands(bandLoc)%elem)
-  found = .FALSE.
-  IF (j < matrix%bands(bandLoc)%jIdx(lo) .OR. j > matrix%bands(bandLoc)%jIdx(hi)) THEN
-    elemIdx = -1
+  hi = SIZE(matrix%bandIdx)
+  IF (bIdx < matrix%bandIdx(1) .OR. bIdx > matrix%bandIdx(hi)) THEN
+    bandloc = -1
   ELSE
     DO WHILE (lo <= hi .AND. .NOT. found)
       mid = (hi+lo)/2
-      IF (j < matrix%bands(bandLoc)%jIdx(mid)) THEN
+      IF (bIdx < matrix%bandIdx(mid)) THEN
         hi = mid-1
-      ELSE IF (j > matrix%bands(bandLoc)%jIdx(mid)) THEN
+      ELSE IF (bIdx > matrix%bandIdx(mid)) THEN
         lo = mid+1
       ELSE
         found = .TRUE.

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -103,105 +103,107 @@ TYPE,EXTENDS(SquareMatrixType) :: TriDiagMatrixType
   REAL(SRK),ALLOCATABLE :: a(:,:)
 !
 !List of Type Bound Procedures
-CONTAINS
-  !> @copybrief MatrixTypes::clear_TriDiagMatrixType
-  !> @copydetails MatrixTypes::clear_TriDiagMatrixType
-  PROCEDURE,PASS :: clear => clear_TriDiagMatrixType
-  !> @copybrief MatrixTypes::init_TriDiagMatrixType
-  !> @copydetails MatrixTypes::init_TriDiagMatrixType
-  PROCEDURE,PASS :: init => init_TriDiagMatrixParam
-  !> @copybrief MatrixTypes::set_TriDiagMatrixType
-  !> @copydetails MatrixTypes::set_TriDiagMatrixType
-  PROCEDURE,PASS :: set => set_TriDiagMatrixType
-  !> @copybrief MatrixTypes::get_TriDiagMatrixType
-  !> @copydetails MatrixTypes::get_TriDiagMatrixType
-  PROCEDURE,PASS :: get => get_TriDiagMatrixType
-  !> @copybrief MatrixTypes::transpose_TriDiagMatrixType
-  !> @copydetails MatrixTypes::transpose_TriDiagMatrixType
-  PROCEDURE,PASS :: transpose => transpose_TriDiagMatrixType
-  !> @copybrief MatrixTypes::zeroentries_TriDiagMatrixType
-  !> @copydetails MatrixTypes::zeroentries_TriDiagMatrixType
-  PROCEDURE,PASS :: zeroentries => zeroentries_TriDiagMatrixType
+  CONTAINS
+    !> @copybrief MatrixTypes::clear_TriDiagMatrixType
+    !> @copydetails MatrixTypes::clear_TriDiagMatrixType
+    PROCEDURE,PASS :: clear => clear_TriDiagMatrixType
+    !> @copybrief MatrixTypes::init_TriDiagMatrixType
+    !> @copydetails MatrixTypes::init_TriDiagMatrixType
+    PROCEDURE,PASS :: init => init_TriDiagMatrixParam
+    !> @copybrief MatrixTypes::set_TriDiagMatrixType
+    !> @copydetails MatrixTypes::set_TriDiagMatrixType
+    PROCEDURE,PASS :: set => set_TriDiagMatrixType
+    !> @copybrief MatrixTypes::get_TriDiagMatrixType
+    !> @copydetails MatrixTypes::get_TriDiagMatrixType
+    PROCEDURE,PASS :: get => get_TriDiagMatrixType
+    !> @copybrief MatrixTypes::transpose_TriDiagMatrixType
+    !> @copydetails MatrixTypes::transpose_TriDiagMatrixType
+    PROCEDURE,PASS :: transpose => transpose_TriDiagMatrixType
+    !> @copybrief MatrixTypes::zeroentries_TriDiagMatrixType
+    !> @copydetails MatrixTypes::zeroentries_TriDiagMatrixType
+    PROCEDURE,PASS :: zeroentries => zeroentries_TriDiagMatrixType
 ENDTYPE TriDiagMatrixType
 
 !> @brief Type used to hold the bands in the banded type
 TYPE Band
-! jIdx stores j index of each element in band
-INTEGER(SIK), ALLOCATABLE :: jIdx(:)
-REAL(SRK), ALLOCATABLE :: elem(:)
+  ! jIdx stores j index of each element in band
+  INTEGER(SIK), ALLOCATABLE :: jIdx(:)
+  ! elem stores the data in the band (compressed)
+  REAL(SRK), ALLOCATABLE :: elem(:)
 ENDTYPE Band
 
+!> @brief Integer array pointer used for 'ragged' storage of band contents
 TYPE IntPtr
-INTEGER(SIK),POINTER :: p(:) => NULL()
+  INTEGER(SIK),POINTER :: p(:) => NULL()
 ENDTYPE IntPtr
 
 !> @brief The basic banded matrix type
 TYPE,EXTENDS(MatrixType) :: BandedMatrixType
-!> Map of band indices stored (-m to n)
-INTEGER(SIK),ALLOCATABLE :: bandIdx(:)
-!> The bands stored in the matrix
-TYPE(Band),ALLOCATABLE :: bands(:)
-!> Number of nonzero elements
-INTEGER(SIK) :: nnz
-!> Number of columns
-INTEGER(SIK) :: m
-!> Counter to keep track of added elements before assembly
-INTEGER(SIK) :: counter
-!> Temporary containers used before (and deallocated after) assembly
-INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
-REAL(SRK),ALLOCATABLE :: elemTmp(:)
-!> Logical flag for whether the matrix is assembled
-LOGICAL(SBK) :: isAssembled
-!> Logical flag for whether bands are stored in ascending or desending
-!> order by index
-LOGICAL(SBK) :: isReversed
+  !> Map of band indices stored (-m to n)
+  INTEGER(SIK),ALLOCATABLE :: bandIdx(:)
+  !> The bands stored in the matrix
+  TYPE(Band),ALLOCATABLE :: bands(:)
+  !> Number of nonzero elements
+  INTEGER(SIK) :: nnz
+  !> Number of columns
+  INTEGER(SIK) :: m
+  !> Counter to keep track of added elements before assembly
+  INTEGER(SIK) :: counter
+  !> Temporary containers used before (and deallocated after) assembly
+  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+  REAL(SRK),ALLOCATABLE :: elemTmp(:)
+  !> Logical flag for whether the matrix is assembled
+  LOGICAL(SBK) :: isAssembled
+  !> Logical flag for whether bands are stored in ascending or desending
+  !> order by index
+  LOGICAL(SBK) :: isReversed
 
 !
 !List of Type Bound Procedures
-CONTAINS
-  !> @copybrief MatrixTypes::clear_BandedMatrixType
-  !> @copydetails MatrixTypes::clear_BandedMatrixType
-  PROCEDURE,PASS :: clear => clear_BandedMatrixType
-  !> @copybrief MatrixTypes::init_BandedMatrixType
-  !> @copydetails MatrixTypes::init_BandedMatrixType
-  PROCEDURE,PASS :: init => init_BandedMatrixParam
-  !> @copybrief MatrixTypes::assemble_BandedMatrixType
-  !> @copydetails MatrixTypes::assemble_BandedMatrixType
-  PROCEDURE,PASS :: assemble => assemble_BandedMatrixType
-  !> @copybrief MatrixTypes::set_BandedMatrixType
-  !> @copydetails MatrixTypes::set_BandedMatrixType
-  PROCEDURE,PASS :: set => set_BandedMatrixType
-  !> @copybrief MatrixTypes::get_BandedMatrixType
-  !> @copydetails MatrixTypes::get_BandedMatrixType
-  PROCEDURE,PASS :: get => get_BandedMatrixType
-  !> @copybrief MatrixTypes::transpose_BandedMatrixType
-  !> @copydetails MatrixTypes::transpose_BandedMatrixType
-  PROCEDURE,PASS :: transpose => transpose_BandedMatrixType
-  !> @copybrief MatrixTypes::zeroentries_BandedMatrixType
-  !> @copydetails MatrixTypes::zeroentries_BandedMatrixType
-  PROCEDURE,PASS :: zeroentries => zeroentries_BandedMatrixType
-  !> @copybrief MatrixTypes::binarySearch_BandedMatrixType
-  !> @copydetails MatrixTypes::binarySearch_BandedMatrixType
-  PROCEDURE,PASS,PRIVATE :: binarySearch => binarySearch_BandedMatrixType
+  CONTAINS
+    !> @copybrief MatrixTypes::clear_BandedMatrixType
+    !> @copydetails MatrixTypes::clear_BandedMatrixType
+    PROCEDURE,PASS :: clear => clear_BandedMatrixType
+    !> @copybrief MatrixTypes::init_BandedMatrixType
+    !> @copydetails MatrixTypes::init_BandedMatrixType
+    PROCEDURE,PASS :: init => init_BandedMatrixParam
+    !> @copybrief MatrixTypes::assemble_BandedMatrixType
+    !> @copydetails MatrixTypes::assemble_BandedMatrixType
+    PROCEDURE,PASS :: assemble => assemble_BandedMatrixType
+    !> @copybrief MatrixTypes::set_BandedMatrixType
+    !> @copydetails MatrixTypes::set_BandedMatrixType
+    PROCEDURE,PASS :: set => set_BandedMatrixType
+    !> @copybrief MatrixTypes::get_BandedMatrixType
+    !> @copydetails MatrixTypes::get_BandedMatrixType
+    PROCEDURE,PASS :: get => get_BandedMatrixType
+    !> @copybrief MatrixTypes::transpose_BandedMatrixType
+    !> @copydetails MatrixTypes::transpose_BandedMatrixType
+    PROCEDURE,PASS :: transpose => transpose_BandedMatrixType
+    !> @copybrief MatrixTypes::zeroentries_BandedMatrixType
+    !> @copydetails MatrixTypes::zeroentries_BandedMatrixType
+    PROCEDURE,PASS :: zeroentries => zeroentries_BandedMatrixType
+    !> @copybrief MatrixTypes::binarySearch_BandedMatrixType
+    !> @copydetails MatrixTypes::binarySearch_BandedMatrixType
+    PROCEDURE,PASS,PRIVATE :: binarySearch => binarySearch_BandedMatrixType
 ENDTYPE BandedMatrixType
 
 !> @brief The distributed banded matrix type
 TYPE,EXTENDS(DistributedMatrixType) :: DistributedBandedMatrixType
-!> Map of band indices stored (-m to n)
-INTEGER(SIK),ALLOCATABLE :: iOffsets(:),jOffsets(:)
-!> The column of banded matrix 'chunks' stored locally
-TYPE(BandedMatrixType),ALLOCATABLE :: chunks(:)
-!> Number of nonzero elements
-INTEGER(SIK) :: nnz
-!> Number of columns
-INTEGER(SIK) :: m
-!> Block size (smallest indivisble unit)
-INTEGER(SIK) :: blockSize
-!> Array of band sizes used to determine optimal communication
-TYPE(IntPtr), ALLOCATABLE :: bandSizes(:)
-!> Temporary containers used before (and deallocated after) assembly
-INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
-REAL(SRK),ALLOCATABLE :: elemTmp(:)
+  !> Map of band indices stored (-m to n)
+  INTEGER(SIK),ALLOCATABLE :: iOffsets(:),jOffsets(:)
+  !> The column of banded matrix 'chunks' stored locally
+  TYPE(BandedMatrixType),ALLOCATABLE :: chunks(:)
+  !> Number of nonzero elements
+  INTEGER(SIK) :: nnz
+  !> Number of columns
+  INTEGER(SIK) :: m
+  !> Block size (smallest indivisble unit)
+  INTEGER(SIK) :: blockSize
+  !> Array of band sizes used to determine optimal communication
+  TYPE(IntPtr), ALLOCATABLE :: bandSizes(:)
+  !> Temporary containers used before (and deallocated after) assembly
+  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+  REAL(SRK),ALLOCATABLE :: elemTmp(:)
 !
 !List of Type Bound Procedures
   CONTAINS
@@ -448,17 +450,14 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
 
   IF(.NOT. matrix%isInit) THEN
     IF(n <= 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of rows (n) must'// &
-           ' be greater than 1!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of rows (n) must be greater than 1!')
     ELSEIF(m <= 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of columns (m) must'// &
-           ' be greater than 1!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of columns (m) must be greater than 1!')
     ELSEIF(nnz < 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of nonzero elements (nnz)'// &
-           ' must be greater than 0!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of nonzero elements (nnz) must be greater than 0!')
     ELSE
       ALLOCATE(matrix%iTmp(nnz))
       ALLOCATE(matrix%jTmp(nnz))
@@ -474,7 +473,7 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
     ENDIF
   ELSE
     CALL eMatrixType%raiseError('Incorrect call to '// &
-         modName//'::'//myName//' - MatrixType already initialized')
+        modName//'::'//myName//' - MatrixType already initialized')
   ENDIF
 ENDSUBROUTINE init_BandedMatrixParam
 !
@@ -496,7 +495,8 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
 
   !Validate against the reqParams and OptParams
   validParams=Params
-  CALL validParams%validate(DistributedBandedMatrixType_reqParams,DistributedBandedMatrixType_optParams)
+  CALL validParams%validate(DistributedBandedMatrixType_reqParams, &
+      DistributedBandedMatrixType_optParams)
 
   ! Pull Data From Parameter List
   CALL validParams%get('MatrixType->n',n)
@@ -509,21 +509,17 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
 
   IF(.NOT. matrix%isInit) THEN
     IF(n <= 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of rows (n) must'// &
-           ' be greater than 1!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of rows (n) must be greater than 1!')
     ELSEIF(m <= 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of columns (m) must'// &
-           ' be greater than 1!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of columns (m) must be greater than 1!')
     ELSEIF(nnz <= 1) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - Number of nonzero entries (nnz)'// &
-           ' must be greater than 0!')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - Number of nonzero entries (nnz) must be greater than 0!')
     ELSEIF(commID == MPI_COMM_NULL) THEN
-      CALL eMatrixType%raiseError('Incorrect input to '// &
-           modName//'::'//myName//' - MPI communicator cannot have the same'// &
-           ' value as MPI_COMM_NULL')
+      CALL eMatrixType%raiseError('Incorrect input to '//modName//'::'//myName// &
+          ' - MPI communicator cannot have the same value as MPI_COMM_NULL')
     ELSE
       CALL MPI_Comm_rank(commID,rank,mpierr)
       CALL MPI_Comm_size(commID,nproc,mpierr)
@@ -537,8 +533,8 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
       matrix%iOffsets(1) = 0
 
       matrix%nlocal = 0
-      n = n/blockSize
-      m = m/blockSize
+      n=n/blockSize
+      m=m/blockSize
       ! We assume that the matrix is somewhat evenly balanced
       ! among its columns; that is, no one chunk of columns contains
       ! more than twice the average nonzero entries
@@ -548,33 +544,34 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
       IF (nlocal < 0) THEN
         ! Automatic division of matrix by greedy partitioning of blocks
         DO i=2,nproc+1
-          matrix%jOffsets(i) = matrix%jOffsets(i-1) + m/nproc
+          matrix%jOffsets(i)=matrix%jOffsets(i-1)+m/nproc
           IF (MOD(m,nproc) > i-2) THEN
-            matrix%jOffsets(i) = matrix%jOffsets(i) + 1
+            matrix%jOffsets(i)=matrix%jOffsets(i)+1
           ENDIF
         ENDDO
 
         DO i=2,nproc+1
-          matrix%iOffsets(i) = matrix%iOffsets(i-1) + n/nproc
+          matrix%iOffsets(i)=matrix%iOffsets(i-1)+n/nproc
           IF (MOD(n,nproc) > i-2) THEN
-            matrix%iOffsets(i) = matrix%iOffsets(i) + 1
+            matrix%iOffsets(i)=matrix%iOffsets(i)+1
           ENDIF
         ENDDO
         ! Separate i/jOffsets are maintained in the case of a rectangular
         ! matrix
-        matrix%iOffsets = matrix%iOffsets*blockSize
-        matrix%jOffsets = matrix%jOffsets*blockSize
+        matrix%iOffsets=matrix%iOffsets*blockSize
+        matrix%jOffsets=matrix%jOffsets*blockSize
       ELSE
         ! Partitioning explicitly specified (square only)
-        REQUIRE(MOD(nlocal,blockSize)==0)
+        REQUIRE(MOD(nlocal,blockSize) == 0)
         REQUIRE(m == n)
         ! Gather all nlocal and sum going forward
-        CALL MPI_AllGather(nlocal,1,MPI_INTEGER,matrix%iOffsets(2),1,MPI_INTEGER,commID,mpierr)
+        CALL MPI_AllGather(nlocal,1,MPI_INTEGER,matrix%iOffsets(2),1, &
+            MPI_INTEGER,commID,mpierr)
         DO i=2,nproc+1
-          matrix%iOffsets(i) = matrix%iOffsets(i) + matrix%iOffsets(i-1)
+          matrix%iOffsets(i)=matrix%iOffsets(i)+matrix%iOffsets(i-1)
         ENDDO
         REQUIRE(matrix%iOffsets(SIZE(matrix%iOffsets)) == n*blockSize)
-        matrix%jOffsets(:) = matrix%iOffsets(:)
+        matrix%jOffsets(:)=matrix%iOffsets(:)
       ENDIF
 
       matrix%isInit=.TRUE.
@@ -609,11 +606,12 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
   INTEGER(SIK),ALLOCATABLE :: blkOffsetTmp(:)
 
   !Check to set up required and optional param lists.
-  IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
+  IF (.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
 
   !Validate against the reqParams and OptParams
   validParams=Params
-  CALL validParams%validate(DistributedBlockBandedMatrixType_reqParams,DistributedBlockBandedMatrixType_optParams)
+  CALL validParams%validate(DistributedBlockBandedMatrixType_reqParams, &
+      DistributedBlockBandedMatrixType_optParams)
 
   ! Pull Data From Parameter List
   CALL validParams%get('MatrixType->n',n)
@@ -623,9 +621,9 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
 
   REQUIRE(.NOT. matrix%isInit)
   REQUIRE(blockSize > 0)
-  REQUIRE(MOD(n,blockSize)==0)
+  REQUIRE(MOD(n,blockSize) == 0)
 
-  matrix%blockMask = .FALSE.
+  matrix%blockMask=.FALSE.
 
   ! Allocate the blocks, then adjust the parameter list and proceed to
   ! %parent%
@@ -635,23 +633,23 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
   CALL MPI_Comm_size(commID,nproc,mpierr)
   REQUIRE(n/blockSize >= nproc)
 
-
-  n = n/blockSize
+  n=n/blockSize
   ! If nlocal < 0, default to greedy partitioning
   IF (nlocal < 0) THEN
-    IF(rank < MOD(n,nproc)) THEN
-      matrix%nlocalBlocks = n/nproc + 1
-      matrix%blockOffset = (rank)*(n/nproc + 1)
+    IF (rank < MOD(n,nproc)) THEN
+      matrix%nlocalBlocks=n/nproc+1
+      matrix%blockOffset=(rank)*(n/nproc+1)
     ELSE
-      matrix%nlocalBlocks = n/nproc
-      matrix%blockOffset = (rank)*(n/nproc) + MOD(n,nproc)
+      matrix%nlocalBlocks=n/nproc
+      matrix%blockOffset=(rank)*(n/nproc)+MOD(n,nproc)
     ENDIF
   ELSE
     ALLOCATE(blkOffsetTmp(nproc))
-    REQUIRE(MOD(nlocal,blockSize)==0)
-    matrix%nlocalBlocks = nlocal/blockSize
-    CALL MPI_AllGather(matrix%nlocalBlocks,1,MPI_INTEGER,blkOffsetTmp,1,MPI_INTEGER,commID,mpierr)
-    matrix%blockOffset = SUM(blkOffsetTmp(1:rank))
+    REQUIRE(MOD(nlocal,blockSize) == 0)
+    matrix%nlocalBlocks=nlocal/blockSize
+    CALL MPI_AllGather(matrix%nlocalBlocks,1,MPI_INTEGER,blkOffsetTmp,1, &
+        MPI_INTEGER,commID,mpierr)
+    matrix%blockOffset=SUM(blkOffsetTmp(1:rank))
     DEALLOCATE(blkOffsetTmp)
   ENDIF
 
@@ -668,7 +666,6 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
   CALL matrix%DistributedBandedMatrixType%init(validParams)
 #endif
 ENDSUBROUTINE init_DistributedBlockBandedMatrixParam
-
 
 !
 !-------------------------------------------------------------------------------
@@ -692,23 +689,19 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
   ALLOCATE(diagRank(SIZE(thisMatrix%iTmp)))
   ALLOCATE(idxOrig(SIZE(thisMatrix%iTmp)))
   DO i=1,SIZE(thisMatrix%iTmp)
-    iLong = INT(thisMatrix%iTmp(i),kind=SLK)
-    jLong = INT(thisMatrix%jTmp(i),kind=SLK)
-    nLong = INT(thisMatrix%n,kind=SLK)
-    mLong = INT(thisMatrix%m,kind=SLK)
-    idxOrig(i) = i
+    iLong=INT(thisMatrix%iTmp(i),kind=SLK)
+    jLong=INT(thisMatrix%jTmp(i),kind=SLK)
+    nLong=INT(thisMatrix%n,kind=SLK)
+    mLong=INT(thisMatrix%m,kind=SLK)
+    idxOrig(i)=i
     ! The diagonal rank counts upwards as one moves southeast in the matrix,
     ! starting at a large negative number in the bottom left, and reaching
     ! zero near the middle
-    IF (thisMatrix%n - thisMatrix%iTmp(i) + 1 + thisMatrix%jTmp(i) &
+    IF (thisMatrix%n-thisMatrix%iTmp(i)+1+thisMatrix%jTmp(i) &
         <= MAX(thisMatrix%m,thisMatrix%n)) THEN
-      diagRank(i) = -mLong*nLong/2
-      diagRank(i) = diagRank(i) + jLong - 1 + ((nLong - iLong + jLong - 1) &
-                    *(nLong - iLong + jLong))/2
+      diagRank(i)=-mLong*nLong/2+jLong-1+((nLong-iLong+jLong-1)*(nLong-iLong+jLong))/2
     ELSE
-      diagRank(i) = nLong*mLong/2
-      diagRank(i) = diagRank(i) - (mLong - jLong + ((iLong + mLong - jLong &
-                    - 1)*(iLong + mLong - jLong))/2)
+      diagRank(i) = nLong*mLong/2-(mLong-jLong+((iLong+mLong-jLong-1)*(iLong+mLong-jLong))/2)
     ENDIF
   ENDDO
 
@@ -724,40 +717,39 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
 
   ! Find number of elements in each band
   ALLOCATE(numOnDiag(thisMatrix%m+thisMatrix%n-1))
-  numOnDiag = 0_SIK
+  numOnDiag=0_SIK
   DO i=1,SIZE(iSort)
-    numOnDiag(jSort(i)-iSort(i)+thisMatrix%n) = 1 + numOnDiag(jSort(i)-iSort(i)+thisMatrix%n)
+    numOnDiag(jSort(i)-iSort(i)+thisMatrix%n)=1+numOnDiag(jSort(i)-iSort(i)+thisMatrix%n)
   ENDDO
   ! Now count up the number of bands necessary
-  nBands = 0
+  nBands=0
   DO i=1,SIZE(numOnDiag)
     IF (numOnDiag(i)/=0) THEN
-      nBands = nBands + 1
+      nBands=nBands+1
     ENDIF
   ENDDO
   ALLOCATE(thisMatrix%bandIdx(nBands))
   ALLOCATE(thisMatrix%bands(nBands))
-  counter = 1
+  counter=1
   ! Allocate the bands
   DO i=1,SIZE(numOnDiag)
     IF (numOnDiag(i)/=0) THEN
       ALLOCATE(thisMatrix%bands(counter)%jIdx(numOnDiag(i)))
       ALLOCATE(thisMatrix%bands(counter)%elem(numOnDiag(i)))
-      thisMatrix%bandIdx(counter) = i - thisMatrix%n
-      counter = counter + 1
+      thisMatrix%bandIdx(counter)=i-thisMatrix%n
+      counter=counter+1
     ENDIF
   ENDDO
-  counter = 1
+  counter=1
   ! Set the bands
   DO i=1,SIZE(thisMatrix%bandIdx)
     DO j=1,SIZE(thisMatrix%bands(i)%jIdx)
-      thisMatrix%bands(i)%jIdx(j) = jSort(counter)
-      thisMatrix%bands(i)%elem(j) = valSort(counter)
-      counter = counter + 1
+      thisMatrix%bands(i)%jIdx(j)=jSort(counter)
+      thisMatrix%bands(i)%elem(j)=valSort(counter)
+      counter=counter+1
     ENDDO
   ENDDO
-
-  thisMatrix%isAssembled = .TRUE.
+  thisMatrix%isAssembled=.TRUE.
 ENDSUBROUTINE assemble_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -774,19 +766,18 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
   TYPE(ParamType) :: bandedPList
   INTEGER(SIK) :: mpierr, rank, nproc, i, j, nBandLocal
   INTEGER(SIK),ALLOCATABLE :: nnzPerChunk(:),nband(:),bandSizeTmp(:)
-  LOGICAL(SBK) :: blockNonzero
 
   REQUIRE(thisMatrix%isInit)
   CALL MPI_Comm_rank(thisMatrix%comm,rank,mpierr)
   CALL MPI_Comm_size(thisMatrix%comm,nproc,mpierr)
   ALLOCATE(nnzPerChunk(nProc))
   ALLOCATE(nBand(nProc))
-  nnzPerChunk = 0_SIK
+  nnzPerChunk=0
   DO i=1,thisMatrix%nLocal
     DO j=1,nproc
       IF (thisMatrix%iTmp(i) > thisMatrix%iOffsets(j) .AND. &
           thisMatrix%iTmp(i) <= thisMatrix%iOffsets(j+1)) THEN
-        nnzPerChunk(j) = nnzPerChunk(j) + 1
+        nnzPerChunk(j)=nnzPerChunk(j)+1
         EXIT
       ENDIF
     ENDDO
@@ -795,22 +786,19 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
 
   ALLOCATE(thisMatrix%chunks(nProc))
   DO i=1,nProc
-    blockNonzero = nnzPerChunk(i) > 0
-    IF (blockNonzero) THEN
+    IF (nnzPerChunk(i) > 0) THEN
       CALL bandedPList%add('MatrixType->nnz',nnzPerChunk(i))
-      CALL bandedPList%add('MatrixType->n',thisMatrix%iOffsets(i+1) - &
-                           thisMatrix%iOffsets(i))
-      CALL bandedPList%add('MatrixType->m',thisMatrix%jOffsets(rank+2) - &
-                           thisMatrix%jOffsets(rank+1))
+      CALL bandedPList%add('MatrixType->n',thisMatrix%iOffsets(i+1) &
+          -thisMatrix%iOffsets(i))
+      CALL bandedPList%add('MatrixType->m',thisMatrix%jOffsets(rank+2) &
+          -thisMatrix%jOffsets(rank+1))
       CALL thisMatrix%chunks(i)%init(bandedPList)
 
       DO j=1,thisMatrix%nLocal
         IF (thisMatrix%iTmp(j) > thisMatrix%iOffsets(i) .AND. &
             thisMatrix%iTmp(j) <= thisMatrix%iOffsets(i+1)) THEN
-          CALL thisMatrix%chunks(i)%set(thisMatrix%iTmp(j) - &
-               thisMatrix%iOffsets(i), &
-               thisMatrix%jTmp(j)-thisMatrix%jOffsets(rank+1), &
-               thisMatrix%elemTmp(j))
+          CALL thisMatrix%chunks(i)%set(thisMatrix%iTmp(j)-thisMatrix%iOffsets(i), &
+              thisMatrix%jTmp(j)-thisMatrix%jOffsets(rank+1),thisMatrix%elemTmp(j))
         ENDIF
       ENDDO
       CALL thisMatrix%chunks(i)%assemble()
@@ -819,16 +807,17 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
     ! Set nbandlocal (to be gathered into nband
     IF (thisMatrix%chunks(i)%isInit) THEN
       IF (2*thisMatrix%chunks(i)%nnz/3 < thisMatrix%chunks(i)%n) THEN
-        nBandLocal = SIZE(thisMatrix%chunks(i)%bandIdx)
+        nBandLocal=SIZE(thisMatrix%chunks(i)%bandIdx)
       ELSE
-        nBandLocal = -1
+        nBandLocal=-1
       ENDIF
     ELSE
-      nBandLocal = 0
+      nBandLocal=0
     ENDIF
 
     ! Gather to rank i-1 into nBand(:)
-    CALL MPI_Gather(nBandLocal, 1, MPI_INTEGER, nband(1), 1, MPI_INTEGER, i-1, thisMatrix%comm, mpierr)
+    CALL MPI_Gather(nBandLocal,1,MPI_INTEGER,nband(1),1,MPI_INTEGER,i-1, &
+        thisMatrix%comm,mpierr)
     ! Have rank i-1 allocate
     IF (rank == i-1) THEN
       DO j=1,nProc
@@ -837,15 +826,14 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
         ELSE
           IF (nBand(j) > 0) THEN
             ALLOCATE(thisMatrix%bandSizes(j)%p(nBand(j)))
-            CALL MPI_Recv(thisMatrix%bandSizes(j)%p(1), nBand(j), &
-                          MPI_INTEGER, j-1, 0, thisMatrix%comm, &
-                          MPI_STATUS_IGNORE, mpierr)
+            CALL MPI_Recv(thisMatrix%bandSizes(j)%p(1),nBand(j),MPI_INTEGER, &
+                j-1, 0, thisMatrix%comm,MPI_STATUS_IGNORE, mpierr)
           ELSE
             IF (nBand(j) == 0) THEN
               NULLIFY(thisMatrix%bandSizes(j)%p)
             ELSE
               ALLOCATE(thisMatrix%bandSizes(j)%p(1))
-              thisMatrix%bandSizes(j)%p(1) = -1
+              thisMatrix%bandSizes(j)%p(1)=-1
             ENDIF
           ENDIF
         ENDIF
@@ -854,10 +842,10 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
       IF (nBandLocal > 0) THEN
         ALLOCATE(bandSizeTmp(nBandLocal))
         DO j=1,nBandLocal
-          bandSizeTmp(j) = SIZE(thisMatrix%chunks(i)%bands(j)%elem)
+          bandSizeTmp(j)=SIZE(thisMatrix%chunks(i)%bands(j)%elem)
         ENDDO
-        CALL MPI_Send(bandSizeTmp(:), nBandLocal, MPI_INTEGER, i-1, 0, &
-                      thisMatrix%comm, mpierr)
+        CALL MPI_Send(bandSizeTmp(:),nBandLocal,MPI_INTEGER,i-1,0, &
+            thisMatrix%comm,mpierr)
         DEALLOCATE(bandSizeTmp)
       ENDIF
     ENDIF
@@ -1013,23 +1001,24 @@ SUBROUTINE clear_BandedMatrixType(matrix)
   CHARACTER(LEN=*),PARAMETER :: myName='clear_BandedMatrixType'
   CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK) :: i
+
   matrix%isInit=.FALSE.
   matrix%isAssembled=.FALSE.
   matrix%n=0
   matrix%m=0
   matrix%counter=0
-  IF(ALLOCATED(matrix%bands)) THEN
+  IF (ALLOCATED(matrix%bands)) THEN
     DO i=1,SIZE(matrix%bandIdx)
-      IF(ALLOCATED(matrix%bands(i)%elem)) DEALLOCATE(matrix%bands(i)%elem)
+      IF (ALLOCATED(matrix%bands(i)%elem)) DEALLOCATE(matrix%bands(i)%elem)
     ENDDO
     DEALLOCATE(matrix%bands)
   ENDIF
-  IF(ALLOCATED(matrix%bandIdx)) DEALLOCATE(matrix%bandIdx)
-  IF(ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
-  IF(ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
-  IF(ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
-  matrix%nnz = 0
-  IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
+  IF (ALLOCATED(matrix%bandIdx)) DEALLOCATE(matrix%bandIdx)
+  IF (ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
+  IF (ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
+  IF (ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
+  matrix%nnz=0
+  IF (MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
  ENDSUBROUTINE clear_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1050,19 +1039,19 @@ SUBROUTINE clear_DistributedBandedMatrixType(matrix)
   matrix%m=0
   matrix%nnz=0
   matrix%nLocal=0
-  IF(ALLOCATED(matrix%chunks)) THEN
+  IF (ALLOCATED(matrix%chunks)) THEN
     DO i=1,SIZE(matrix%chunks)
       CALL matrix%chunks(i)%clear()
     ENDDO
     DEALLOCATE(matrix%chunks)
   ENDIF
-  IF(ALLOCATED(matrix%iOffsets)) DEALLOCATE(matrix%iOffsets)
-  IF(ALLOCATED(matrix%jOffsets)) DEALLOCATE(matrix%jOffsets)
-  IF(ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
-  IF(ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
-  IF(ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
-  IF(ALLOCATED(matrix%bandSizes)) DEALLOCATE(matrix%bandSizes)
-  IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
+  IF (ALLOCATED(matrix%iOffsets)) DEALLOCATE(matrix%iOffsets)
+  IF (ALLOCATED(matrix%jOffsets)) DEALLOCATE(matrix%jOffsets)
+  IF (ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
+  IF (ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
+  IF (ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
+  IF (ALLOCATED(matrix%bandSizes)) DEALLOCATE(matrix%bandSizes)
+  IF (MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
 #endif
  ENDSUBROUTINE clear_DistributedBandedMatrixType
 
@@ -1076,13 +1065,13 @@ SUBROUTINE clear_DistributedBlockBandedMatrixType(matrix)
   CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
 #ifdef HAVE_MPI
   INTEGER(SIK) :: i
-  matrix%blockMask = .FALSE.
-  matrix%blockSize = 0
-  matrix%nLocalBlocks = 0
-  matrix%blockOffset = 0
-  matrix%isInit = .FALSE.
+  matrix%blockMask=.FALSE.
+  matrix%blockSize=0
+  matrix%nLocalBlocks=0
+  matrix%blockOffset=0
+  matrix%isInit=.FALSE.
   matrix%isCreated=.FALSE.
-  matrix%isAssembled = .FALSE.
+  matrix%isAssembled=.FALSE.
 
   DO i=1,SIZE(matrix%blocks)
     CALL matrix%blocks(i)%clear()
@@ -1249,27 +1238,25 @@ SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
   LOGICAL(SBK) :: flag
   CHARACTER(LEN=64) :: msg
 
-  flag = .FALSE.
+  flag=.FALSE.
   REQUIRE(matrix%isInit)
-  IF(.NOT. matrix%isAssembled) THEN
+  IF (.NOT. matrix%isAssembled) THEN
     ! If the matrix is not yet assembled, we are adding to the temporary
     ! containers i/j/elemTmp
-    IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
-        .AND. (i>=1) .AND. (j >= 1)) THEN
-
+    IF ((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i >= 1) .AND. (j >= 1)) THEN
       CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
       CALL MPI_Comm_size(matrix%comm,nproc,mpierr)
 
       IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
-        matrix%nLocal = matrix%nLocal + 1
+        matrix%nLocal=matrix%nLocal+1
         IF (matrix%nLocal > 2*matrix%nnz/nproc) THEN
           CALL eMatrixType%raiseError('Matrix Element imbalance '// &
-               modName//'::'//myName//' - Check nnz or use a different type')
+              modName//'::'//myName//' - Check nnz or use a different type')
         ENDIF
-        matrix%iTmp(matrix%nLocal) = i
-        matrix%jTmp(matrix%nLocal) = j
-        matrix%elemTmp(matrix%nLocal) = setval
-        flag = .TRUE.
+        matrix%iTmp(matrix%nLocal)=i
+        matrix%jTmp(matrix%nLocal)=j
+        matrix%elemTmp(matrix%nLocal)=setval
+        flag=.TRUE.
       ENDIF
     ENDIF
   ELSE
@@ -1281,8 +1268,8 @@ SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
         IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
           IF (matrix%chunks(k)%isInit) THEN
             CALL matrix%chunks(k)%set(i-matrix%iOffsets(k), &
-                                      j-matrix%jOffsets(rank+1),setval)
-            flag = .TRUE.
+                j-matrix%jOffsets(rank+1),setval)
+            flag=.TRUE.
             EXIT
           ENDIF
         ENDIF
@@ -1292,9 +1279,8 @@ SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
   IF (.NOT. flag) THEN
     WRITE(msg,'(I2,A,I9,A,I9)') rank," at ",i,',',j
     CALL eMatrixType%raiseWarning('Invalid matrix set in '// &
-         modName//'::'//myname//' for rank '//msg)
+        modName//'::'//myname//' for rank '//msg)
   ENDIF
-
 #endif
 ENDSUBROUTINE set_DistributedBandedMatrixType
 
@@ -1318,20 +1304,20 @@ SUBROUTINE set_DistributedBlockBandedMatrixType(matrix,i,j,setval)
   CHARACTER(LEN=64) :: msg
   REQUIRE(matrix%isInit)
 
-  flag = .FALSE.
+  flag=.FALSE.
   CALL MPI_Comm_Rank(matrix%comm,rank,mpierr)
   ! Check if element is in a block; if not call parent
   IF ((i-1)/matrix%blockSize /= (j-1)/matrix%blockSize) THEN
     CALL matrix%DistributedBandedMatrixType%set(i,j,setval)
     flag = .TRUE.
   ELSE
-    IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
-      .AND. (i>=1) .AND. (j >= 1)) THEN
+    IF ((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i >= 1) .AND. (j >= 1)) THEN
       IF (.NOT. matrix%blockMask) THEN
-        offset = ((i-1)/matrix%blockSize)*matrix%blockSize
-        IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
-          CALL matrix%blocks((j-1)/matrix%blockSize - matrix%blockOffset+1)%set(i-offset,j-offset,setval)
-          flag = .TRUE.
+        offset=((i-1)/matrix%blockSize)*matrix%blockSize
+        IF (j > matrix%jOffsets(rank+1) .AND. (j <= matrix%jOffsets(rank+2))) THEN
+          CALL matrix%blocks((j-1)/matrix%blockSize-matrix%blockOffset+1)%set( &
+              i-offset,j-offset,setval)
+          flag=.TRUE.
         ENDIF
       ENDIF
     ENDIF
@@ -1339,7 +1325,7 @@ SUBROUTINE set_DistributedBlockBandedMatrixType(matrix,i,j,setval)
   IF (.NOT. flag) THEN
     WRITE(msg,'(I2,A,I9,A,I9)') rank," at ",i,',',j
     CALL eMatrixType%raiseWarning('Invalid matrix set in '// &
-         modName//'::'//myname//' for rank '//msg)
+        modName//'::'//myname//' for rank '//msg)
   ENDIF
 #endif
 ENDSUBROUTINE set_DistributedBlockBandedMatrixType
@@ -1359,7 +1345,7 @@ SUBROUTINE setrow_DistributedBandedMatrixType(matrix,i,j,setval)
   INTEGER(SIK),INTENT(IN) :: j(:)
   REAL(SRK),INTENT(IN) :: setval(:)
   CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
-       ' - routine is not implemented!')
+      ' - routine is not implemented!')
 ENDSUBROUTINE setrow_DistributedBandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1378,19 +1364,18 @@ SUBROUTINE set_BandedMatrixType(matrix,i,j,setval)
   INTEGER(SIK) :: bandLoc, elemIdx
 
   REQUIRE(matrix%isInit)
-  IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
-     .AND. (i>=1) .AND. (j >= 1)) THEN
+  IF((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i >= 1) .AND. (j >= 1)) THEN
     IF(.NOT. matrix%isAssembled) THEN
       ! If it is not assembled, add to tmp variables
-      matrix%counter = matrix%counter + 1
-      matrix%iTmp(matrix%counter) = i
-      matrix%jTmp(matrix%counter) = j
-      matrix%elemTmp(matrix%counter) = setval
+      matrix%counter=matrix%counter+1
+      matrix%iTmp(matrix%counter)=i
+      matrix%jTmp(matrix%counter)=j
+      matrix%elemTmp(matrix%counter)=setval
     ELSE
       ! Otherwise, perform binary search to set in existing structure
       CALL binarySearch_BandedMatrixType(matrix,i,j,bandLoc,elemIdx)
       IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
-        matrix%bands(bandLoc)%elem(elemIdx) = setVal
+        matrix%bands(bandLoc)%elem(elemIdx)=setVal
       ENDIF
     ENDIF
   ENDIF
@@ -1492,16 +1477,16 @@ SUBROUTINE get_DistributedBandedMatrixType(matrix,i,j,getval)
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(INOUT) :: getval
 #ifdef HAVE_MPI
-  INTEGER(SIK) :: k, mpierr, rank
+  INTEGER(SIK) :: k,mpierr,rank
 
-  getval = 0.0_SRK
+  getval=0.0_SRK
   CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
   IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
     DO k=1,SIZE(matrix%jOffsets)-1
       IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
         IF (matrix%chunks(k)%isInit) THEN
           CALL matrix%chunks(k)%get(i-matrix%iOffsets(k), &
-                                    j-matrix%jOffsets(rank+1),getval)
+              j-matrix%jOffsets(rank+1),getval)
           EXIT
         ENDIF
       ENDIF
@@ -1526,16 +1511,18 @@ SUBROUTINE get_DistributedBlockBandedMatrixType(matrix,i,j,getval)
   REAL(SRK),INTENT(INOUT) :: getval
 #ifdef HAVE_MPI
   INTEGER(SIK) :: rank,mpierr,offset
+
   CALL MPI_Comm_Rank(matrix%comm,rank,mpierr)
   IF ((i-1)/matrix%blockSize /= (j-1)/matrix%blockSize) THEN
     CALL matrix%DistributedBandedMatrixType%get(i,j,getVal)
-  ELSE IF (.NOT. matrix%blockMask) THEN
-    offset = ((i-1)/matrix%blockSize)*matrix%blockSize
+  ELSEIF (.NOT. matrix%blockMask) THEN
+    offset=((i-1)/matrix%blockSize)*matrix%blockSize
     IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
-      getval = matrix%blocks((i-1)/matrix%blockSize - matrix%blockOffset + 1)%A(i-offset,j-offset)
+      getval=matrix%blocks((i-1)/matrix%blockSize-matrix%blockOffset+1)%A( &
+          i-offset,j-offset)
     ENDIF
   ELSE
-    getval = 0.0_SRK
+    getval=0.0_SRK
   ENDIF
 #endif
 ENDSUBROUTINE get_DistributedBlockBandedMatrixType
@@ -1557,9 +1544,9 @@ SUBROUTINE get_BandedMatrixType(matrix,i,j,getval)
   INTEGER(SIK) :: bandLoc,elemIdx
 
   CALL binarySearch_BandedMatrixType(matrix,i,j,bandLoc,elemIdx)
-  getval = 0.0_SRK
+  getval=0.0_SRK
   IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
-    getval = matrix%bands(bandLoc)%elem(elemIdx)
+    getval=matrix%bands(bandLoc)%elem(elemIdx)
   ENDIF
 
 ENDSUBROUTINE get_BandedMatrixType
@@ -1695,8 +1682,7 @@ SUBROUTINE transpose_DistributedBandedMatrixType(matrix)
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
 
   CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
-       ' - routine is not implemented!')
-
+      ' - routine is not implemented!')
 ENDSUBROUTINE transpose_DistributedBandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1712,15 +1698,15 @@ SUBROUTINE transpose_BandedMatrixType(matrix)
   REQUIRE(matrix%isInit)
   REQUIRE(matrix%isAssembled)
 
-  mTmp = matrix%n
-  matrix%n = matrix%m
-  matrix%m = mTmp
+  mTmp=matrix%n
+  matrix%n=matrix%m
+  matrix%m=mTmp
 
   DO i=1,SIZE(matrix%bandIdx)
-    matrix%bands(i)%jIdx = matrix%bands(i)%jIdx - matrix%bandIdx(i)
+    matrix%bands(i)%jIdx=matrix%bands(i)%jIdx-matrix%bandIdx(i)
   ENDDO
-  matrix%bandIdx = -matrix%bandIdx
-  matrix%isReversed = .NOT. matrix%isReversed
+  matrix%bandIdx=-matrix%bandIdx
+  matrix%isReversed=.NOT.matrix%isReversed
 
 ENDSUBROUTINE transpose_BandedMatrixType
 !
@@ -1850,15 +1836,13 @@ ENDSUBROUTINE zeroentries_TriDiagMatrixType
 !> @param matrix declare the matrix type to act on
 !>
 !>
-SUBROUTINE  zeroentries_DistributedBandedMatrixType(matrix)
-  CHARACTER(LEN=*),PARAMETER :: myName=&
-                  'zeroentries_DistributedBandedMatrixType'
+SUBROUTINE zeroentries_DistributedBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_DistributedBandedMatrixType'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK) :: i
 
   REQUIRE(matrix%isInit)
   REQUIRE(matrix%isAssembled)
-
   DO i=1,SIZE(matrix%iOffsets)-1
     IF (matrix%chunks(i)%isInit) THEN
       CALL matrix%chunks(i)%zeroentries()
@@ -1873,14 +1857,12 @@ ENDSUBROUTINE zeroentries_DistributedBandedMatrixType
 !>
 !>
 SUBROUTINE  zeroentries_DistributedBlockBandedMatrixType(matrix)
-  CHARACTER(LEN=*),PARAMETER :: myName=&
-                  'zeroentries_DistributedBlockBandedMatrixType'
+  CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_DistributedBlockBandedMatrixType'
   CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK) :: i
 
   REQUIRE(matrix%isInit)
   REQUIRE(matrix%isAssembled)
-
   DO i=1,SIZE(matrix%blocks)
     CALL matrix%blocks(i)%zeroEntries()
   ENDDO
@@ -1897,12 +1879,13 @@ SUBROUTINE  zeroentries_BandedMatrixType(matrix)
   CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_BandedMatrixType'
   CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK) :: i
+
   REQUIRE(matrix%isInit)
   REQUIRE(matrix%isAssembled)
   DO i=1,SIZE(matrix%bandIdx)
     IF(ALLOCATED(matrix%bands(i)%elem)) matrix%bands(i)%elem=0.0_SRK
   ENDDO
-  !matrix%bandIdx = 0_SIK
+
 ENDSUBROUTINE zeroentries_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1930,7 +1913,7 @@ SUBROUTINE setBlockMask_DistributedBlockBandedMatrixType(matrix,maskVal)
   LOGICAL(SBK),INTENT(IN) :: maskVal
 
   REQUIRE(matrix%isInit)
-  matrix%blockMask = maskVal
+  matrix%blockMask=maskVal
 ENDSUBROUTINE setBlockMask_DistributedBlockBandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1955,61 +1938,61 @@ SUBROUTINE binarySearch_BandedMatrixType(matrix, i, j, bandLoc, elemIdx)
   REQUIRE((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i>=1) .AND. (j >= 1))
 
   found=.FALSE.
-
   !Check if band is contained (binary search)
-  bIdx = j - i
+  bIdx=j-i
   IF (matrix%isReversed) THEN
-    bIdx = -bIdx
-    matrix%bandIdx = -matrix%bandIdx
+    bIdx=-bIdx
+    matrix%bandIdx=-matrix%bandIdx
   ENDIF
 
-  lo = 1
-  hi = SIZE(matrix%bandIdx)
+  lo=1
+  hi=SIZE(matrix%bandIdx)
   IF (bIdx < matrix%bandIdx(1) .OR. bIdx > matrix%bandIdx(hi)) THEN
-    bandloc = -1
+    bandloc=-1
   ELSE
     DO WHILE (lo <= hi .AND. .NOT. found)
-      mid = (hi+lo)/2
+      mid=(hi+lo)/2
       IF (bIdx < matrix%bandIdx(mid)) THEN
-        hi = mid-1
+        hi=mid-1
       ELSE IF (bIdx > matrix%bandIdx(mid)) THEN
-        lo = mid+1
+        lo=mid+1
       ELSE
-        found = .TRUE.
+        found=.TRUE.
         EXIT
       ENDIF
     ENDDO
     IF (found) THEN
-      bandLoc = mid
-      lo = 1
-      hi = SIZE(matrix%bands(bandLoc)%elem)
-      found = .FALSE.
-      IF (j < matrix%bands(bandLoc)%jIdx(lo) .OR. j > matrix%bands(bandLoc)%jIdx(hi)) THEN
-        elemIdx = -1
+      bandLoc=mid
+      lo=1
+      hi=SIZE(matrix%bands(bandLoc)%elem)
+      found=.FALSE.
+      IF (j < matrix%bands(bandLoc)%jIdx(lo) .OR. &
+          j > matrix%bands(bandLoc)%jIdx(hi)) THEN
+        elemIdx=-1
       ELSE
         DO WHILE (lo <= hi .AND. .NOT. found)
-          mid = (hi+lo)/2
+          mid=(hi+lo)/2
           IF (j < matrix%bands(bandLoc)%jIdx(mid)) THEN
-            hi = mid-1
+            hi=mid-1
           ELSE IF (j > matrix%bands(bandLoc)%jIdx(mid)) THEN
-            lo = mid+1
+            lo=mid+1
           ELSE
-            found = .TRUE.
+            found=.TRUE.
             EXIT
           ENDIF
         ENDDO
       ENDIF
-      elemIdx = -1
+      elemIdx=-1
       IF (found) THEN
-        elemIdx = mid
+        elemIdx=mid
       ENDIF
     ELSE
-      bandLoc = -1
+      bandLoc=-1
     ENDIF
   ENDIF
   IF (matrix%isReversed) THEN
-    matrix%bandIdx = -matrix%bandIdx
+    matrix%bandIdx=-matrix%bandIdx
   ENDIF
-END SUBROUTINE binarySearch_BandedMatrixType
+ENDSUBROUTINE binarySearch_BandedMatrixType
 
 ENDMODULE MatrixTypes_Native

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -16,8 +16,14 @@ USE ExceptionHandler
 USE ParameterLists
 USE Allocs
 USE MatrixTypes_Base
+USE ParallelEnv
+USE Sorting
 
 IMPLICIT NONE
+
+#ifdef HAVE_MPI
+#include <mpif.h>
+#endif
 
 PRIVATE
 !
@@ -25,6 +31,9 @@ PRIVATE
 PUBLIC :: DenseSquareMatrixType
 PUBLIC :: DenseRectMatrixType
 PUBLIC :: TriDiagMatrixType
+PUBLIC :: BandedMatrixType
+PUBLIC :: DistributedBandedMatrixType
+PUBLIC :: DistributedBlockBandedMatrixType
 PUBLIC :: SparseMatrixType
 
 !> @brief The extended type for dense square matrices
@@ -114,6 +123,151 @@ TYPE,EXTENDS(SquareMatrixType) :: TriDiagMatrixType
     !> @copydetails MatrixTypes::zeroentries_TriDiagMatrixType
     PROCEDURE,PASS :: zeroentries => zeroentries_TriDiagMatrixType
 ENDTYPE TriDiagMatrixType
+
+!> @brief Type used to hold the bands in the banded type
+TYPE Band
+  ! jIdx stores j index of each element in band
+  INTEGER(SIK), ALLOCATABLE :: jIdx(:)
+  REAL(SRK), ALLOCATABLE :: elem(:)
+ENDTYPE Band
+
+TYPE IntPtr
+  INTEGER(SIK),POINTER :: p(:) => NULL()
+ENDTYPE IntPtr
+
+!> @brief The basic banded matrix type
+TYPE,EXTENDS(MatrixType) :: BandedMatrixType
+  !> Map of band indices stored (-m to n)
+  INTEGER(SIK),ALLOCATABLE :: bandIdx(:)
+  !> The bands stored in the matrix
+  TYPE(Band),ALLOCATABLE :: bands(:)
+  !> Number of nonzero elements
+  INTEGER(SIK) :: nnz
+  !> Number of columns
+  INTEGER(SIK) :: m
+  !> Counter to keep track of added elements before assembly
+  INTEGER(SIK) :: counter
+  !> Temporary containers used before (and deallocated after) assembly
+  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+  REAL(SRK),ALLOCATABLE :: elemTmp(:)
+  LOGICAL(SBK) :: isAssembled, isReversed
+
+!
+!List of Type Bound Procedures
+  CONTAINS
+    !> @copybrief MatrixTypes::clear_BandedMatrixType
+    !> @copydetails MatrixTypes::clear_BandedMatrixType
+    PROCEDURE,PASS :: clear => clear_BandedMatrixType
+    !> @copybrief MatrixTypes::init_BandedMatrixType
+    !> @copydetails MatrixTypes::init_BandedMatrixType
+    PROCEDURE,PASS :: init => init_BandedMatrixParam
+    !> @copybrief MatrixTypes::assemble_BandedMatrixType
+    !> @copydetails MatrixTypes::assemble_BandedMatrixType
+    PROCEDURE,PASS :: assemble => assemble_BandedMatrixType
+    !> @copybrief MatrixTypes::set_BandedMatrixType
+    !> @copydetails MatrixTypes::set_BandedMatrixType
+    PROCEDURE,PASS :: set => set_BandedMatrixType
+    !> @copybrief MatrixTypes::get_BandedMatrixType
+    !> @copydetails MatrixTypes::get_BandedMatrixType
+    PROCEDURE,PASS :: get => get_BandedMatrixType
+    !> @copybrief MatrixTypes::transpose_BandedMatrixType
+    !> @copydetails MatrixTypes::transpose_BandedMatrixType
+    PROCEDURE,PASS :: transpose => transpose_BandedMatrixType
+    !> @copybrief MatrixTypes::zeroentries_BandedMatrixType
+    !> @copydetails MatrixTypes::zeroentries_BandedMatrixType
+    PROCEDURE,PASS :: zeroentries => zeroentries_BandedMatrixType
+    !> @copybrief MatrixTypes::binarySearch_BandedMatrixType
+    !> @copydetails MatrixTypes::binarySearch_BandedMatrixType
+    PROCEDURE,PASS,PRIVATE :: binarySearch => binarySearch_BandedMatrixType
+ENDTYPE BandedMatrixType
+
+!> @brief The basic banded matrix type
+TYPE,EXTENDS(DistributedMatrixType) :: DistributedBandedMatrixType
+  !> Map of band indices stored (-m to n)
+  INTEGER(SIK),ALLOCATABLE :: iOffsets(:),jOffsets(:)
+  !> The bands stored in the matrix
+  TYPE(BandedMatrixType),ALLOCATABLE :: chunks(:)
+  !> Number of nonzero elements
+  INTEGER(SIK) :: nnz
+  !> Number of columns
+  INTEGER(SIK) :: m
+  !> Block size (smallest indivisble unit)
+  INTEGER(SIK) :: blockSize
+  !> For those ranks that contribute at row = rank, holds array of band sizes
+  !> Used for matvec; if contrib(i,j) is false, bandSizes(i,j) is unassociated
+  !> If size 0, it is unused. Otherwise, it is used for sparse data transfer
+  TYPE(IntPtr), ALLOCATABLE :: bandSizes(:)
+  !> Temporary containers used before (and deallocated after) assembly
+  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+  REAL(SRK),ALLOCATABLE :: elemTmp(:)
+  LOGICAL(SBK) :: isReversed
+!
+!List of Type Bound Procedures
+  CONTAINS
+    !> @copybrief MatrixTypes::clear_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::clear_DistributedBandedMatrixType
+    PROCEDURE,PASS :: clear => clear_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::init_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::init_DistributedBandedMatrixType
+    PROCEDURE,PASS :: init => init_DistributedBandedMatrixParam
+    !> @copybrief MatrixTypes::assemble_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::assemble_DistributedBandedMatrixType
+    PROCEDURE,PASS :: assemble => assemble_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::setrow_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::setrow_DistributedBandedMatrixType
+    PROCEDURE,PASS :: setrow => setrow_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::set_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::set_DistributedBandedMatrixType
+    PROCEDURE,PASS :: set => set_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::get_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::get_DistributedBandedMatrixType
+    PROCEDURE,PASS :: get => get_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::transpose_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::transpose_DistributedBandedMatrixType
+    PROCEDURE,PASS :: transpose => transpose_DistributedBandedMatrixType
+    !> @copybrief MatrixTypes::zeroentries_DistributedBandedMatrixType
+    !> @copydetails MatrixTypes::zeroentries_DistributedBandedMatrixType
+    PROCEDURE,PASS :: zeroentries => zeroentries_DistributedBandedMatrixType
+ENDTYPE DistributedBandedMatrixType
+
+!> @brief The block banded matrix type (designed for CMFD)
+!> for now, the blocks will be assumed to be only on main diag
+TYPE,EXTENDS(DistributedBandedMatrixType) :: DistributedBlockBandedMatrixType
+  !> The block size is set by parent (DistrBanded::blockSize)
+  !> The number of local blocks
+  INTEGER(SIK) :: nlocalBlocks
+  !> Block offset for this processor
+  INTEGER(SIK) :: blockOffset
+  !> Mask to effectively zero out block vals
+  LOGICAL(SBK) :: blockMask
+  !> The dense block container
+  TYPE(DenseSquareMatrixType),ALLOCATABLE :: blocks(:)
+!
+!List of Type Bound Procedures
+  CONTAINS
+    !> @copybrief MatrixTypes::clear_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::clear_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: clear => clear_DistributedBlockBandedMatrixType
+    !> @copybrief MatrixTypes::init_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::init_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: init => init_DistributedBlockBandedMatrixParam
+    ! The assemble routine will remain unchanged
+    ! The setRow routine will remain unchanged (unimplemented)
+    !> @copybrief MatrixTypes::set_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::set_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: set => set_DistributedBlockBandedMatrixType
+    !> @copybrief MatrixTypes::get_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::get_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: get => get_DistributedBlockBandedMatrixType
+    ! the transpose routine will remain unchanged (unimplemented)
+    !> @copybrief MatrixTypes::zeroentries_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::zeroentries_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: zeroentries => zeroentries_DistributedBlockBandedMatrixType
+    !> @copybrief MatrixTypes::setBlockMask_DistributedBlockBandedMatrixType
+    !> @copydetails MatrixTypes::setBlockMask_DistributedBlockBandedMatrixType
+    PROCEDURE,PASS :: setBlockMask => setBlockMask_DistributedBlockBandedMatrixType
+ENDTYPE DistributedBlockBandedMatrixType
+
 
 !> @brief The basic sparse matrix type
 !>
@@ -267,6 +421,438 @@ SUBROUTINE init_TriDiagMatrixParam(matrix,Params)
 ENDSUBROUTINE init_TriDiagMatrixParam
 !
 !-------------------------------------------------------------------------------
+!> @brief Initializes Banded Matrix Type with a Parameter List
+!> @param matrix the matrix type to act on
+!> @param pList the parameter list
+!>
+SUBROUTINE init_BandedMatrixParam(matrix,Params)
+  CHARACTER(LEN=*),PARAMETER :: myName='init_BandedMatrixParam'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  CLASS(ParamType),INTENT(IN) :: Params
+  TYPE(ParamType) :: validParams
+  INTEGER(SIK) :: n,m,nnz
+  LOGICAL(SBK) :: bool
+
+  !Check to set up required and optional param lists.
+  IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
+
+  !Validate against the reqParams and OptParams
+  validParams=Params
+  CALL validParams%validate(BandedMatrixType_reqParams)
+
+  ! Pull Data From Parameter List
+  CALL validParams%get('MatrixType->n',n)
+  CALL validParams%get('MatrixType->m',m)
+  CALL validParams%get('MatrixType->nnz',nnz)
+  CALL validParams%clear()
+
+  ! be greater than 1 and n < 1 are note logically equivalent. is this
+  ! desired behavior?
+  IF(.NOT. matrix%isInit) THEN
+    IF(n < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of rows (n) must'// &
+          ' be greater than 1!')
+    ELSEIF(m < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of columns (m) must'// &
+          ' be greater than 1!')
+    ELSEIF(nnz < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of nonzero elements (nnz)'// &
+          ' must be greater than 0!')
+    ELSE
+      ALLOCATE(matrix%iTmp(nnz))
+      ALLOCATE(matrix%jTmp(nnz))
+      ALLOCATE(matrix%elemTmp(nnz))
+
+      matrix%isInit=.TRUE.
+      matrix%isAssembled=.FaLSE.
+      matrix%isReversed=.FALSE.
+      matrix%counter=0_SRK
+      matrix%n=n
+      matrix%m=m
+      matrix%nnz=nnz
+    ENDIF
+  ELSE
+    CALL eMatrixType%raiseError('Incorrect call to '// &
+      modName//'::'//myName//' - MatrixType already initialized')
+  ENDIF
+ENDSUBROUTINE init_BandedMatrixParam
+!
+!-------------------------------------------------------------------------------
+!> @brief Initializes Distributed Banded Matrix Type with a Parameter List
+!> @param matrix the matrix type to act on
+!> @param pList the parameter list
+!>
+SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
+  CHARACTER(LEN=*),PARAMETER :: myName='init_DistributedBandedMatrixParam'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  CLASS(ParamType),INTENT(IN) :: Params
+  TYPE(ParamType) :: validParams
+  INTEGER(SIK) :: n,m,nnz,MPI_COMM_ID,rank,mpierr,nproc,i,blocksize,nlocal
+  LOGICAL(SBK) :: bool
+
+#ifdef HAVE_MPI
+  !Check to set up required and optional param lists.
+  IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
+
+  !Validate against the reqParams and OptParams
+  validParams=Params
+  CALL validParams%validate(DistributedBandedMatrixType_reqParams,DistributedBandedMatrixType_optParams)
+
+  ! Pull Data From Parameter List
+  CALL validParams%get('MatrixType->n',n)
+  CALL validParams%get('MatrixType->m',m)
+  CALL validParams%get('MatrixType->MPI_Comm_ID',MPI_COMM_ID)
+  CALL validParams%get('MatrixType->nnz',nnz)
+  CALL validParams%get('MatrixType->blockSize',blockSize)
+  CALL validParams%get('MatrixType->nlocal',nlocal)
+  CALL validParams%clear()
+
+  IF(.NOT. matrix%isInit) THEN
+    IF(n < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of rows (n) must'// &
+          ' be greater than 1!')
+    ELSEIF(m < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of columns (m) must'// &
+          ' be greater than 1!')
+    ELSEIF(nnz < 1) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - Number of nonzero entries (nnz)'// &
+          ' must be greater than 0!')
+    ELSEIF(MPI_COMM_ID == MPI_COMM_NULL) THEN
+      CALL eMatrixType%raiseError('Incorrect input to '// &
+        modName//'::'//myName//' - MPI communicator cannot have the same'// &
+          ' value as MPI_COMM_NULL')
+    ELSE
+      CALL MPI_Comm_rank(MPI_COMM_ID,rank,mpierr)
+      CALL MPI_Comm_size(MPI_COMM_ID,nproc,mpierr)
+
+      REQUIRE(MOD(n,blockSize)==0)
+      REQUIRE(MOD(m,blockSize)==0)
+
+      ALLOCATE(matrix%jOffsets(nproc+1))
+      ALLOCATE(matrix%iOffsets(nproc+1))
+      matrix%jOffsets(1) = 0
+      matrix%iOffsets(1) = 0
+
+      matrix%nlocal = 0
+      n = n/blockSize
+      m = m/blockSize
+      ALLOCATE(matrix%iTmp(2*nnz/nProc))
+      ALLOCATE(matrix%jTmp(2*nnz/nProc))
+      ALLOCATE(matrix%elemTmp(2*nnz/nProc))
+      IF (nlocal < 0) THEN
+        DO i=2,nproc+1
+          matrix%jOffsets(i) = matrix%jOffsets(i-1) + m/nproc
+          IF (MOD(m,nproc) > i-2) THEN
+            matrix%jOffsets(i) = matrix%jOffsets(i) + 1
+          END IF
+        END DO
+
+        DO i=2,nproc+1
+          matrix%iOffsets(i) = matrix%iOffsets(i-1) + n/nproc
+          IF (MOD(n,nproc) > i-2) THEN
+            matrix%iOffsets(i) = matrix%iOffsets(i) + 1
+          END IF
+        END DO
+        matrix%iOffsets = matrix%iOffsets*blockSize
+        matrix%jOffsets = matrix%jOffsets*blockSize
+      ELSE
+        REQUIRE(MOD(nlocal,blockSize)==0)
+        REQUIRE(m == n)
+        ! Gather all nlocal and sum going forward
+        CALL MPI_AllGather(nlocal,1,MPI_INTEGER,matrix%iOffsets(2),1,MPI_INTEGER,MPI_Comm_ID,mpierr)
+        DO i=2,nproc+1
+          matrix%iOffsets(i) = matrix%iOffsets(i) + matrix%iOffsets(i-1)
+        ENDDO
+        REQUIRE(matrix%iOffsets(SIZE(matrix%iOffsets)) == n*blockSize)
+        matrix%jOffsets(:) = matrix%iOffsets(:)
+      ENDIF
+
+      ALLOCATE(matrix%bandSizes(nProc))
+
+      matrix%isInit=.TRUE.
+      matrix%isAssembled=.FALSE.
+      matrix%isReversed=.FALSE.
+      matrix%n=n*blockSize
+      matrix%m=m*blockSize
+      matrix%nnz=nnz
+      matrix%blockSize = blockSize
+      matrix%comm=MPI_COMM_ID
+    ENDIF
+  ELSE
+    CALL eMatrixType%raiseError('Incorrect call to '// &
+      modName//'::'//myName//' - MatrixType already initialized')
+  ENDIF
+#endif
+ENDSUBROUTINE init_DistributedBandedMatrixParam
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Initializes Distributed Block-Banded Matrix Type with a Parameter List
+!> @param matrix the matrix type to act on
+!> @param pList the parameter list
+!>
+SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
+  CHARACTER(LEN=*),PARAMETER :: myName='init_DistributedBlockBandedMatrixParam'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  CLASS(ParamType),INTENT(IN) :: Params
+  TYPE(ParamType) :: validParams,blockParams
+  INTEGER(SIK) :: n,m,nnz,MPI_COMM_ID,rank,mpierr,nproc,i,blockSize,nlocal
+  INTEGER(SIK),ALLOCATABLE :: blkOffsetTmp(:)
+  LOGICAL(SBK) :: bool
+
+#ifdef HAVE_MPI
+  !Check to set up required and optional param lists.
+  IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
+
+  !Validate against the reqParams and OptParams
+  validParams=Params
+  CALL validParams%validate(DistributedBlockBandedMatrixType_reqParams,DistributedBlockBandedMatrixType_optParams)
+
+  ! Pull Data From Parameter List
+  CALL validParams%get('MatrixType->n',n)
+  CALL validParams%get('MatrixType->MPI_Comm_ID',MPI_COMM_ID)
+  CALL validParams%get('MatrixType->blockSize',blockSize)
+  CALL validParams%get('MatrixType->nlocal',nlocal)
+
+  REQUIRE(.NOT. matrix%isInit)
+  REQUIRE(blockSize > 0)
+  REQUIRE(MOD(n,blockSize)==0)
+
+  matrix%blockMask = .FALSE.
+
+  ! Allocate the blocks, then adjust the parameter list and proceed to
+  ! %parent%
+
+  ! Default to greedy partitioning, respecting blockSize
+  CALL MPI_Comm_rank(MPI_COMM_ID,rank,mpierr)
+  CALL MPI_Comm_size(MPI_COMM_ID,nproc,mpierr)
+  REQUIRE(n/blockSize >= nproc)
+
+
+  n = n/blockSize
+  ! If nlocal < 0, default to greedy partitioning
+  IF (nlocal < 0) THEN
+    IF(rank < MOD(n,nproc)) THEN
+      matrix%nlocalBlocks = n/nproc + 1
+      matrix%blockOffset = (rank)*(n/nproc + 1)
+    ELSE
+      matrix%nlocalBlocks = n/nproc
+      matrix%blockOffset = (rank)*(n/nproc) + MOD(n,nproc)
+    ENDIF
+  ELSE
+    ALLOCATE(blkOffsetTmp(nproc))
+    REQUIRE(MOD(nlocal,blockSize)==0)
+    matrix%nlocalBlocks = nlocal/blockSize
+    CALL MPI_AllGather(matrix%nlocalBlocks,1,MPI_INTEGER,blkOffsetTmp,1,MPI_INTEGER,MPI_Comm_ID,mpierr)
+    matrix%blockOffset = SUM(blkOffsetTmp(1:rank))
+    DEALLOCATE(blkOffsetTmp)
+  ENDIF
+
+  ALLOCATE(matrix%blocks(matrix%nlocalBlocks))
+  CALL blockParams%clear()
+  CALL blockParams%add('MatrixType->n',blockSize)
+  CALL blockParams%add('MatrixType->isSym',.FALSE.)
+
+  DO i=1,matrix%nlocalblocks
+    CALL matrix%blocks(i)%init(blockParams)
+  ENDDO
+
+  CALL validParams%add('MatrixType->m',n*blockSize)
+  CALL matrix%DistributedBandedMatrixType%init(validParams)
+#endif
+ENDSUBROUTINE init_DistributedBlockBandedMatrixParam
+
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Assembles Serial Banded Matrix Type. This rearranges values set into
+!>        matrix bands, and sets the structure to read-only
+!> @param matrix the matrix type to act on
+!> @param pList the parameter list
+!>
+SUBROUTINE assemble_BandedMatrixType(thisMatrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='assemble_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: thisMatrix
+  INTEGER(SIK),ALLOCATABLE :: numOnDiag(:),idxOrig(:)
+  INTEGER(SIK),ALLOCATABLE :: iSort(:),jSort(:)
+  REAL(SRK),ALLOCATABLE :: valSort(:)
+  INTEGER(SIK) :: counter,currIdx,currBand,nBands,i,j
+  INTEGER(SLK) :: iLong,jLong,nLong,mLong
+  INTEGER(SLK),ALLOCATABLE :: diagRank(:)
+
+  REQUIRE(thisMatrix%isInit)
+  REQUIRE(thisMatrix%nnz == thisMatrix%counter)
+
+  ALLOCATE(diagRank(SIZE(thisMatrix%iTmp)))
+  ALLOCATE(idxOrig(SIZE(thisMatrix%iTmp)))
+  DO i=1,SIZE(thisMatrix%iTmp)
+    iLong = INT(thisMatrix%iTmp(i),kind=SLK)
+    jLong = INT(thisMatrix%jTmp(i),kind=SLK)
+    nLong = INT(thisMatrix%n,kind=SLK)
+    mLong = INT(thisMatrix%m,kind=SLK)
+    idxOrig(i) = i
+    IF (thisMatrix%n - thisMatrix%iTmp(i) + 1 + thisMatrix%jTmp(i) <= MAX(thisMatrix%m,thisMatrix%n)) THEN
+      diagRank(i) = -mLong*nLong/2
+      diagRank(i) = diagRank(i) + jLong - 1 + ((nLong - iLong + jLong - 1)*(nLong - iLong + jLong))/2
+    ELSE
+      diagRank(i) = nLong*mLong/2
+      diagRank(i) = diagRank(i) - (mLong - jLong + ((iLong + mLong - jLong - 1)*(iLong + mLong - jLong))/2)
+    END IF
+  END DO
+
+  CALL sort(diagRank,idxOrig)
+  ! Now update iTmp,jTmp,etc
+  ALLOCATE(iSort(SIZE(idxOrig)))
+  iSort = thisMatrix%iTmp(idxOrig)
+  DEALLOCATE(thisMatrix%iTmp)
+  jSort = thisMatrix%jTmp(idxOrig)
+  DEALLOCATE(thisMatrix%jTmp)
+  valSort = thisMatrix%elemTmp(idxOrig)
+  DEALLOCATE(thisMatrix%elemTmp)
+
+  ! Find number of elements in each band
+  ALLOCATE(numOnDiag(thisMatrix%m+thisMatrix%n-1))
+  numOnDiag = 0_SIK
+  DO i=1,SIZE(iSort)
+    numOnDiag(jSort(i)-iSort(i)+thisMatrix%n) = 1 + numOnDiag(jSort(i)-iSort(i)+thisMatrix%n)
+  END DO
+  nBands = 0
+  DO i=1,SIZE(numOnDiag)
+    IF (numOnDiag(i)/=0) THEN
+      nBands = nBands + 1
+    END IF
+  END DO
+  ALLOCATE(thisMatrix%bandIdx(nBands))
+  ALLOCATE(thisMatrix%bands(nBands))
+  counter = 1
+  DO i=1,SIZE(numOnDiag)
+    IF (numOnDiag(i)/=0) THEN
+      ALLOCATE(thisMatrix%bands(counter)%jIdx(numOnDiag(i)))
+      ALLOCATE(thisMatrix%bands(counter)%elem(numOnDiag(i)))
+      thisMatrix%bandIdx(counter) = i - thisMatrix%n
+      counter = counter + 1
+    END IF
+  END DO
+  counter = 1
+  DO i=1,SIZE(thisMatrix%bandIdx)
+    DO j=1,SIZE(thisMatrix%bands(i)%jIdx)
+      thisMatrix%bands(i)%jIdx(j) = jSort(counter)
+      thisMatrix%bands(i)%elem(j) = valSort(counter)
+      counter = counter + 1
+    END DO
+  END DO
+
+  thisMatrix%isAssembled = .TRUE.
+ENDSUBROUTINE assemble_BandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Assembles Distributed Banded Matrix Type. This rearranges values set into
+!>        matrix bands, and sets the structure to read-only
+!> @param thisMatrix the matrix type to act on
+!>
+SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
+  CHARACTER(LEN=*),PARAMETER :: myName='assemble_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: thisMatrix
+  INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+  TYPE(ParamType) :: bandedPList
+  INTEGER(SIK) :: mpierr, rank, nproc, i, j, nBandLocal
+  INTEGER(SIK),ALLOCATABLE :: nnzPerChunk(:),nband(:),bandSizeTmp(:)
+  LOGICAL(SBK) :: blockNonzero
+
+#ifdef HAVE_MPI
+  REQUIRE(thisMatrix%isInit)
+  CALL MPI_Comm_rank(thisMatrix%comm,rank,mpierr)
+  CALL MPI_Comm_size(thisMatrix%comm,nproc,mpierr)
+  ALLOCATE(nnzPerChunk(nProc))
+  ALLOCATE(nBand(nProc))
+  nnzPerChunk = 0_SIK
+  DO i=1,thisMatrix%nLocal
+    DO j=1,nproc
+      IF (thisMatrix%iTmp(i) > thisMatrix%iOffsets(j) .AND. &
+          thisMatrix%iTmp(i) <= thisMatrix%iOffsets(j+1)) THEN
+        nnzPerChunk(j) = nnzPerChunk(j) + 1
+        EXIT
+      END IF
+    END DO
+  END DO
+  CALL bandedPList%clear()
+
+  ALLOCATE(thisMatrix%chunks(nProc))
+  DO i=1,nProc
+    blockNonzero = nnzPerChunk(i) > 0
+    IF (blockNonzero) THEN
+      CALL bandedPList%add('MatrixType->nnz',nnzPerChunk(i))
+      CALL bandedPList%add('MatrixType->n',thisMatrix%iOffsets(i+1) - thisMatrix%iOffsets(i))
+      CALL bandedPList%add('MatrixType->m',thisMatrix%jOffsets(rank+2) - thisMatrix%jOffsets(rank+1))
+      CALL thisMatrix%chunks(i)%init(bandedPList)
+
+      DO j=1,thisMatrix%nLocal
+        IF (thisMatrix%iTmp(j) > thisMatrix%iOffsets(i) .AND. &
+            thisMatrix%iTmp(j) <= thisMatrix%iOffsets(i+1)) THEN
+          CALL thisMatrix%chunks(i)%set(thisMatrix%iTmp(j)-thisMatrix%iOffsets(i),thisMatrix%jTmp(j)-thisMatrix%jOffsets(rank+1),thisMatrix%elemTmp(j))
+        END IF
+      END DO
+      CALL thisMatrix%chunks(i)%assemble()
+      CALL bandedPList%clear()
+    ENDIF
+    ! Set self var
+    IF (thisMatrix%chunks(i)%isInit) THEN
+      IF (2*thisMatrix%chunks(i)%nnz/3 < thisMatrix%chunks(i)%n) THEN
+        nBandLocal = SIZE(thisMatrix%chunks(i)%bandIdx)
+      ELSE
+        nBandLocal = -1
+      ENDIF
+    ELSE
+      nBandLocal = 0
+    ENDIF
+
+    ! Gather to rank j-1 into nBand(:)
+    CALL MPI_Gather(nBandLocal, 1, MPI_INTEGER, nband(1), 1, MPI_INTEGER, i-1, thisMatrix%comm, mpierr)
+    ! Have rank j-1 allocate
+    IF (rank == i-1) THEN
+      DO j=1,nProc
+        IF (j == i) THEN
+          NULLIFY(thisMatrix%bandSizes(i)%p)
+        ELSE
+          IF (nBand(j) > 0) THEN
+            ALLOCATE(thisMatrix%bandSizes(j)%p(nBand(j)))
+            CALL MPI_Recv(thisMatrix%bandSizes(j)%p(1), nBand(j), MPI_INTEGER, j-1, 0, thisMatrix%comm, MPI_STATUS_IGNORE, mpierr)
+          ELSE
+            IF (nBand(j) == 0) THEN
+              NULLIFY(thisMatrix%bandSizes(j)%p)
+            ELSE
+              ALLOCATE(thisMatrix%bandSizes(j)%p(1))
+              thisMatrix%bandSizes(j)%p(1) = -1
+            ENDIF
+          ENDIF
+        ENDIF
+      ENDDO
+    ELSE
+      IF (nBandLocal > 0) THEN
+        ALLOCATE(bandSizeTmp(nBandLocal))
+        DO j=1,nBandLocal
+          bandSizeTmp(j) = SIZE(thisMatrix%chunks(i)%bands(j)%elem)
+        ENDDO
+        CALL MPI_Send(bandSizeTmp(:), nBandLocal, MPI_INTEGER, i-1, 0, thisMatrix%comm, mpierr)
+        DEALLOCATE(bandSizeTmp)
+      ENDIF
+    END IF
+  END DO
+
+  thisMatrix%isAssembled = .TRUE.
+  DEALLOCATE(thisMatrix%iTmp)
+  DEALLOCATE(thisMatrix%jTmp)
+  DEALLOCATE(thisMatrix%elemTmp)
+#endif
+ENDSUBROUTINE assemble_DistributedBandedMatrixType
+!
+!-------------------------------------------------------------------------------
 !> @brief Initializes Dense Rectangular Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
 !> @param pList the parameter list
@@ -402,6 +988,112 @@ SUBROUTINE clear_TriDiagMatrixType(matrix)
  ENDSUBROUTINE clear_TriDiagMatrixType
 !
 !-------------------------------------------------------------------------------
+!> @brief Clears the banded matrix
+!> @param matrix the matrix type to act on
+!>
+SUBROUTINE clear_BandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='clear_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+  matrix%isInit=.FALSE.
+  matrix%isAssembled=.FALSE.
+  matrix%n=0
+  matrix%m=0
+  matrix%counter=0
+  IF(ALLOCATED(matrix%bands)) THEN
+    DO i=1,SIZE(matrix%bandIdx)
+      IF(ALLOCATED(matrix%bands(i)%elem)) THEN
+        DEALLOCATE(matrix%bands(i)%elem)
+      END IF
+    ENDDO
+    DEALLOCATE(matrix%bands)
+  ENDIF
+  IF(ALLOCATED(matrix%bandIdx)) THEN
+    DEALLOCATE(matrix%bandIdx)
+  ENDIF
+  IF(ALLOCATED(matrix%iTmp)) THEN
+    DEALLOCATE(matrix%iTmp)
+  ENDIF
+  IF(ALLOCATED(matrix%jTmp)) THEN
+    DEALLOCATE(matrix%jTmp)
+  ENDIF
+  IF(ALLOCATED(matrix%elemTmp)) THEN
+    DEALLOCATE(matrix%elemTmp)
+  ENDIF
+  matrix%nnz = 0
+  IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
+ ENDSUBROUTINE clear_BandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Clears the distributed banded matrix
+!> @param matrix the matrix type to act on
+!>
+SUBROUTINE clear_DistributedBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='clear_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+#ifdef HAVE_MPI
+  matrix%isInit=.FALSE.
+  matrix%isCreated=.FALSE.
+  matrix%isAssembled=.FALSE.
+  matrix%comm=MPI_COMM_NULL
+  matrix%n=0
+  matrix%m=0
+  matrix%nnz=0
+  matrix%nLocal=0
+  IF(ALLOCATED(matrix%chunks)) THEN
+    DO i=1,SIZE(matrix%chunks)
+      CALL matrix%chunks(i)%clear()
+    ENDDO
+    DEALLOCATE(matrix%chunks)
+  ENDIF
+  IF(ALLOCATED(matrix%iOffsets)) THEN
+    DEALLOCATE(matrix%iOffsets)
+  ENDIF
+  IF(ALLOCATED(matrix%jOffsets)) THEN
+    DEALLOCATE(matrix%jOffsets)
+  ENDIF
+  IF(ALLOCATED(matrix%iTmp)) THEN
+    DEALLOCATE(matrix%iTmp)
+  ENDIF
+  IF(ALLOCATED(matrix%jTmp)) THEN
+    DEALLOCATE(matrix%jTmp)
+  ENDIF
+  IF(ALLOCATED(matrix%elemTmp)) THEN
+    DEALLOCATE(matrix%elemTmp)
+  ENDIF
+  IF(ALLOCATED(matrix%bandSizes)) THEN
+    DEALLOCATE(matrix%bandSizes)
+  ENDIF
+  IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
+#endif
+ ENDSUBROUTINE clear_DistributedBandedMatrixType
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Clears the distributed block banded matrix
+!> @param matrix the matrix type to act on
+!>
+SUBROUTINE clear_DistributedBlockBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='clear_DistributedBlockBandedMatrixType'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+#ifdef HAVE_MPI
+  matrix%blockMask = .FALSE.
+  matrix%blockSize = 0
+  matrix%nLocalBlocks = 0
+  matrix%blockOffset = 0
+
+  DO i=1,SIZE(matrix%blocks)
+    CALL matrix%blocks(i)%clear()
+  END DO
+  DEALLOCATE(matrix%blocks)
+
+  CALL matrix%DistributedBandedMatrixType%clear()
+#endif
+ ENDSUBROUTINE clear_DistributedBlockBandedMatrixType
+!
+!-------------------------------------------------------------------------------
 !> @brief Clears the dense rectangular matrix
 !> @param matrix the matrix type to act on
 !>
@@ -462,6 +1154,7 @@ ENDSUBROUTINE set_SparseMatrixtype
 !> If setShape has previously been applied to the same sparse matrix.
 !>
 SUBROUTINE setRow_SparseMatrixType(matrix,i,j,setval)
+  CHARACTER(LEN=*),PARAMETER :: myName='set_SparseMatrixType'
   CLASS(SparseMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j(:)
@@ -537,6 +1230,153 @@ SUBROUTINE set_TriDiagMatrixType(matrix,i,j,setval)
     ENDIF
   ENDIF
 ENDSUBROUTINE set_TriDiagMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets the values in the distributed banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
+  CHARACTER(LEN=*),PARAMETER :: myName='set_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(IN) :: setval
+  INTEGER(SIK) :: rank,nproc,mpierr,nHeldLower,bandLoc,elemIdx,k
+  LOGICAL(SBK) :: flag
+#ifdef HAVE_MPI
+  flag = .FALSE.
+  REQUIRE(matrix%isInit)
+  IF(.NOT. matrix%isAssembled) THEN
+    IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
+        .AND. (i>=1) .AND. (j >= 1)) THEN
+
+      CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
+      CALL MPI_Comm_size(matrix%comm,nproc,mpierr)
+
+      IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
+        matrix%nLocal = matrix%nLocal + 1
+        IF (matrix%nLocal > 2*matrix%nnz/nproc) THEN
+          CALL eMatrixType%raiseError('Matrix Element imbalance '// &
+            modName//'::'//myName//' - Check nnz or use a different type')
+        END IF
+        matrix%iTmp(matrix%nLocal) = i
+        matrix%jTmp(matrix%nLocal) = j
+        matrix%elemTmp(matrix%nLocal) = setval
+        flag = .TRUE.
+      END IF
+    ENDIF
+  ELSE
+    CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
+    IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
+      DO k=1,SIZE(matrix%jOffsets)-1
+        IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
+          IF (matrix%chunks(k)%isInit) THEN
+            CALL matrix%chunks(k)%set(i-matrix%iOffsets(k),j-matrix%jOffsets(rank+1),setval)
+            flag = .TRUE.
+            EXIT
+          END IF
+        END IF
+      END DO
+    END IF
+  END IF
+  IF (.NOT. flag) WRITE(*,*) "Invalid matrix set encountered in rank",rank,"at",i,j
+
+#endif
+ENDSUBROUTINE set_DistributedBandedMatrixType
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets the values in the distributed block banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE set_DistributedBlockBandedMatrixType(matrix,i,j,setval)
+  CHARACTER(LEN=*),PARAMETER :: myName='set_DistributedBlockBandedMatrixType'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(IN) :: setval
+  INTEGER(SIK) :: rank,mpierr,offset
+  LOGICAL(SBK) :: flag
+#ifdef HAVE_MPI
+  REQUIRE(matrix%isInit)
+
+  flag = .FALSE.
+  CALL MPI_Comm_Rank(matrix%comm,rank,mpierr)
+  ! Check if element is in a block; if not call parent
+  IF ((i-1)/matrix%blockSize /= (j-1)/matrix%blockSize) THEN
+    CALL matrix%DistributedBandedMatrixType%set(i,j,setval)
+    flag = .TRUE.
+  ELSE
+    IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
+      .AND. (i>=1) .AND. (j >= 1)) THEN
+      IF (.NOT. matrix%blockMask) THEN
+        offset = ((i-1)/matrix%blockSize)*matrix%blockSize
+        IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
+          CALL matrix%blocks((j-1)/matrix%blockSize - matrix%blockOffset+1)%set(i-offset,j-offset,setval)
+          flag = .TRUE.
+        ENDIF
+      ENDIF
+    ENDIF
+  ENDIF
+  IF (.NOT. flag) WRITE(*,*) "Invalid matrix set encountered in rank",rank,"at",i,j
+#endif
+ENDSUBROUTINE set_DistributedBlockBandedMatrixType
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets the values in the distributed banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE setrow_DistributedBandedMatrixType(matrix,i,j,setval)
+  CHARACTER(LEN=*),PARAMETER :: myName='setrow_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j(:)
+  REAL(SRK),INTENT(IN) :: setval(:)
+  CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
+    ' - routine is not implemented!')
+ENDSUBROUTINE setrow_DistributedBandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Sets the values in the banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE set_BandedMatrixType(matrix,i,j,setval)
+  CHARACTER(LEN=*),PARAMETER :: myName='set_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(IN) :: setval
+  INTEGER(SIK) :: bandLoc, elemIdx
+
+  REQUIRE(matrix%isInit)
+  IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
+     .AND. (i>=1) .AND. (j >= 1)) THEN
+    IF(.NOT. matrix%isAssembled) THEN
+      matrix%counter = matrix%counter + 1
+      matrix%iTmp(matrix%counter) = i
+      matrix%jTmp(matrix%counter) = j
+      matrix%elemTmp(matrix%counter) = setval
+    ELSE
+      CALL binarySearch_BandedMatrixType(matrix,i,j,bandLoc,elemIdx)
+      IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
+        matrix%bands(bandLoc)%elem(elemIdx) = setVal
+      END IF
+    END IF
+  END IF
+ENDSUBROUTINE set_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets the values in the dense rectangular matrix
@@ -619,6 +1459,93 @@ SUBROUTINE get_TriDiagMatrixType(matrix,i,j,getval)
     ENDIF
   ENDIF
 ENDSUBROUTINE get_TriDiagMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief Gets the values in the distributed banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE get_DistributedBandedMatrixType(matrix,i,j,getval)
+  CHARACTER(LEN=*),PARAMETER :: myName='get_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(INOUT) :: getval
+  INTEGER(SIK) :: bandLoc, elemidx, k, mpierr, rank
+  LOGICAL(SBK) :: found
+
+#ifdef HAVE_MPI
+  getval = 0.0_SRK
+  CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
+  IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
+    DO k=1,SIZE(matrix%jOffsets)-1
+      IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
+        IF (matrix%chunks(k)%isInit) THEN
+          CALL matrix%chunks(k)%get(i-matrix%iOffsets(k),j-matrix%jOffsets(rank+1),getval)
+          EXIT
+        END IF
+      END IF
+    END DO
+  END IF
+#endif
+ENDSUBROUTINE get_DistributedBandedMatrixType
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Gets the values in the distributed block banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE get_DistributedBlockBandedMatrixType(matrix,i,j,getval)
+  CHARACTER(LEN=*),PARAMETER :: myName='get_DistributedBlockBandedMatrixType'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(INOUT) :: getval
+  INTEGER(SIK) :: rank,mpierr,offset
+  REAL(SRK) :: val
+#if HAVE_MPI
+  CALL MPI_Comm_Rank(matrix%comm,rank,mpierr)
+  IF ((i-1)/matrix%blockSize /= (j-1)/matrix%blockSize) THEN
+    CALL matrix%DistributedBandedMatrixType%get(i,j,getVal)
+  ELSE IF (.NOT. matrix%blockMask) THEN
+    offset = ((i-1)/matrix%blockSize)*matrix%blockSize
+    IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
+      getval = matrix%blocks((i-1)/matrix%blockSize - matrix%blockOffset + 1)%A(i-offset,j-offset)
+    END IF
+  ELSE
+    getval = 0.0_SRK
+  END IF
+#endif
+ENDSUBROUTINE get_DistributedBlockBandedMatrixType
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Gets the values in the banded matrix
+!> @param matrix the matrix type to act on
+!> @param i the ith location in the matrix
+!> @param j the jth location in the matrix
+!> @param setval the value to be set
+!>
+SUBROUTINE get_BandedMatrixType(matrix,i,j,getval)
+  CHARACTER(LEN=*),PARAMETER :: myName='get_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  REAL(SRK),INTENT(INOUT) :: getval
+  INTEGER(SIK) :: bandLoc,elemIdx
+
+  CALL binarySearch_BandedMatrixType(matrix,i,j,bandLoc,elemIdx)
+  getval = 0.0_SRK
+  IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
+    getval = matrix%bands(bandLoc)%elem(elemIdx)
+  END IF
+
+ENDSUBROUTINE get_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets the values in the dense rectangular matrix
@@ -746,7 +1673,48 @@ ENDSUBROUTINE transpose_TriDiagMatrixType
 !> @param matrix declare the matrix type to act on
 !>
 !>
+SUBROUTINE transpose_DistributedBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='transpose_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: mTmp,i
+
+  CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
+    ' - routine is not implemented!')
+
+ENDSUBROUTINE transpose_DistributedBandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief tranpose the matrix
+!> @param matrix declare the matrix type to act on
+!>
+!>
+SUBROUTINE transpose_BandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='transpose_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: mTmp,i
+
+  REQUIRE(matrix%isInit)
+  REQUIRE(matrix%isAssembled)
+
+  mTmp = matrix%n
+  matrix%n = matrix%m
+  matrix%m = mTmp
+
+  DO i=1,SIZE(matrix%bandIdx)
+    matrix%bands(i)%jIdx = matrix%bands(i)%jIdx - matrix%bandIdx(i)
+  END DO
+  matrix%bandIdx = -matrix%bandIdx
+  matrix%isReversed = .NOT. matrix%isReversed
+
+ENDSUBROUTINE transpose_BandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief tranpose the matrix
+!> @param matrix declare the matrix type to act on
+!>
+!>
 SUBROUTINE transpose_SparseMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='transpose_SparseMatrixType'
   CLASS(SparseMatrixType),INTENT(INOUT) :: matrix
 
   INTEGER(SIK),ALLOCATABLE :: tmp_ia(:),tmp_ja(:),A(:,:),tmp(:),Row(:,:),n_Row(:)
@@ -866,10 +1834,166 @@ ENDSUBROUTINE zeroentries_TriDiagMatrixType
 !> @param matrix declare the matrix type to act on
 !>
 !>
+SUBROUTINE  zeroentries_DistributedBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName=&
+                  'zeroentries_DistributedBandedMatrixType'
+  CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+
+  REQUIRE(matrix%isInit)
+  REQUIRE(matrix%isAssembled)
+
+  DO i=1,SIZE(matrix%iOffsets)-1
+    IF (matrix%chunks(i)%isInit) THEN
+      CALL matrix%chunks(i)%zeroentries()
+    END IF
+  END DO
+
+ENDSUBROUTINE zeroentries_DistributedBandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief zero the matrix
+!> @param matrix declare the matrix type to act on
+!>
+!>
+SUBROUTINE  zeroentries_DistributedBlockBandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName=&
+                  'zeroentries_DistributedBlockBandedMatrixType'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+
+  REQUIRE(matrix%isInit)
+  REQUIRE(matrix%isAssembled)
+
+  DO i=1,SIZE(matrix%blocks)
+    CALL matrix%blocks(i)%zeroEntries()
+  END DO
+  CALL matrix%DistributedBandedMatrixType%zeroEntries()
+
+ENDSUBROUTINE zeroentries_DistributedBlockBandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief zero the matrix
+!> @param matrix declare the matrix type to act on
+!>
+!>
+SUBROUTINE  zeroentries_BandedMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_BandedMatrixType'
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK) :: i
+  REQUIRE(matrix%isInit)
+  REQUIRE(matrix%isAssembled)
+  DO i=1,SIZE(matrix%bandIdx)
+    IF(ALLOCATED(matrix%bands(i)%elem)) matrix%bands(i)%elem=0.0_SRK
+  ENDDO
+  !matrix%bandIdx = 0_SIK
+ENDSUBROUTINE zeroentries_BandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief zero the matrix
+!> @param matrix declare the matrix type to act on
+!>
+!>
 SUBROUTINE  zeroentries_DenseRectMatrixType(matrix)
+  CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_DenseRectMatrixType'
   CLASS(DenseRectMatrixType),INTENT(INOUT) :: matrix
   REQUIRE(matrix%isInit)
   matrix%a=0.0_SRK
 ENDSUBROUTINE zeroentries_DenseRectMatrixType
 !
+!-------------------------------------------------------------------------------
+!> @brief Set the block mask for distribed block-banded matrix
+!> setting to True will make all values in the block appear to be zero
+!> without actually setting them. Setting to false restores these values.
+!> @param matrix declare the matrix type to act on
+!>
+!>
+SUBROUTINE setBlockMask_DistributedBlockBandedMatrixType(matrix,maskVal)
+  CHARACTER(LEN=*),PARAMETER :: myName='setBlockMask_DistributedBlockBandedMatrixType'
+  CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
+  LOGICAL(SBK),INTENT(IN) :: maskVal
+
+  REQUIRE(matrix%isInit)
+  matrix%blockMask = maskVal
+ENDSUBROUTINE setBlockMask_DistributedBlockBandedMatrixType
+!
+!-------------------------------------------------------------------------------
+!> @brief performs binary search for (i,j) in the matrix
+!> @param matrix declare the matrix type to act on
+!> @param i the desired row index
+!> @param j the desired col index
+!> @param bandLoc the index of the band (i,j) is located in (negative -> not there)
+!> @param elemIdx the index of the elem(:) array (i,j) is located at (negative -> not there)
+!>
+SUBROUTINE binarySearch_BandedMatrixType(matrix, i, j, bandLoc, elemIdx)
+  CLASS(BandedMatrixType),INTENT(INOUT) :: matrix
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  INTEGER(SIK),INTENT(OUT) :: bandLoc
+  INTEGER(SIK),INTENT(OUT) :: elemIdx
+  INTEGER(SIK) :: bIdx,lo,hi,mid
+  LOGICAL(SBK) :: found
+
+  REQUIRE(matrix%isInit)
+  REQUIRE(matrix%isAssembled)
+  REQUIRE((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i>=1) .AND. (j >= 1))
+
+  found=.FALSE.
+
+  !Check if band is contained (binary search)
+  bIdx = j - i
+  IF (matrix%isReversed) THEN
+    bIdx = -bIdx
+    matrix%bandIdx = -matrix%bandIdx
+  END IF
+  lo = 1
+  hi = SIZE(matrix%bandIdx)
+
+  IF (bIdx < matrix%bandIdx(1) .OR. bIdx > matrix%bandIdx(hi)) THEN
+    bandLoc = -1
+  ELSE
+    DO WHILE (lo <= hi .AND. .NOT. found)
+      mid = (hi+lo)/2
+      IF (bIdx < matrix%bandIdx(mid)) THEN
+        hi = mid-1
+      ELSE IF (bIdx > matrix%bandIdx(mid)) THEN
+        lo = mid+1
+      ELSE
+        found = .TRUE.
+        EXIT
+      END IF
+    END DO
+    IF (found) THEN
+      bandLoc = mid
+      lo = 1
+      hi = SIZE(matrix%bands(bandLoc)%elem)
+      found = .FALSE.
+      IF (j < matrix%bands(bandLoc)%jIdx(lo) .OR. j > matrix%bands(bandLoc)%jIdx(hi)) THEN
+        elemIdx = -1
+      ELSE
+        DO WHILE (lo <= hi .AND. .NOT. found)
+          mid = (hi+lo)/2
+          IF (j < matrix%bands(bandLoc)%jIdx(mid)) THEN
+            hi = mid-1
+          ELSE IF (j > matrix%bands(bandLoc)%jIdx(mid)) THEN
+            lo = mid+1
+          ELSE
+            found = .TRUE.
+            EXIT
+          END IF
+        END DO
+      END IF
+      elemIdx = -1
+      IF (found) THEN
+        elemIdx = mid
+      END IF
+    ELSE
+      bandLoc = -1
+    END IF
+  END IF
+  IF (matrix%isReversed) THEN
+    matrix%bandIdx = -matrix%bandIdx
+  END IF
+END SUBROUTINE binarySearch_BandedMatrixType
+
 ENDMODULE MatrixTypes_Native

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -103,104 +103,105 @@ TYPE,EXTENDS(SquareMatrixType) :: TriDiagMatrixType
   REAL(SRK),ALLOCATABLE :: a(:,:)
 !
 !List of Type Bound Procedures
-  CONTAINS
-    !> @copybrief MatrixTypes::clear_TriDiagMatrixType
-    !> @copydetails MatrixTypes::clear_TriDiagMatrixType
-    PROCEDURE,PASS :: clear => clear_TriDiagMatrixType
-    !> @copybrief MatrixTypes::init_TriDiagMatrixType
-    !> @copydetails MatrixTypes::init_TriDiagMatrixType
-    PROCEDURE,PASS :: init => init_TriDiagMatrixParam
-    !> @copybrief MatrixTypes::set_TriDiagMatrixType
-    !> @copydetails MatrixTypes::set_TriDiagMatrixType
-    PROCEDURE,PASS :: set => set_TriDiagMatrixType
-    !> @copybrief MatrixTypes::get_TriDiagMatrixType
-    !> @copydetails MatrixTypes::get_TriDiagMatrixType
-    PROCEDURE,PASS :: get => get_TriDiagMatrixType
-    !> @copybrief MatrixTypes::transpose_TriDiagMatrixType
-    !> @copydetails MatrixTypes::transpose_TriDiagMatrixType
-    PROCEDURE,PASS :: transpose => transpose_TriDiagMatrixType
-    !> @copybrief MatrixTypes::zeroentries_TriDiagMatrixType
-    !> @copydetails MatrixTypes::zeroentries_TriDiagMatrixType
-    PROCEDURE,PASS :: zeroentries => zeroentries_TriDiagMatrixType
+CONTAINS
+  !> @copybrief MatrixTypes::clear_TriDiagMatrixType
+  !> @copydetails MatrixTypes::clear_TriDiagMatrixType
+  PROCEDURE,PASS :: clear => clear_TriDiagMatrixType
+  !> @copybrief MatrixTypes::init_TriDiagMatrixType
+  !> @copydetails MatrixTypes::init_TriDiagMatrixType
+  PROCEDURE,PASS :: init => init_TriDiagMatrixParam
+  !> @copybrief MatrixTypes::set_TriDiagMatrixType
+  !> @copydetails MatrixTypes::set_TriDiagMatrixType
+  PROCEDURE,PASS :: set => set_TriDiagMatrixType
+  !> @copybrief MatrixTypes::get_TriDiagMatrixType
+  !> @copydetails MatrixTypes::get_TriDiagMatrixType
+  PROCEDURE,PASS :: get => get_TriDiagMatrixType
+  !> @copybrief MatrixTypes::transpose_TriDiagMatrixType
+  !> @copydetails MatrixTypes::transpose_TriDiagMatrixType
+  PROCEDURE,PASS :: transpose => transpose_TriDiagMatrixType
+  !> @copybrief MatrixTypes::zeroentries_TriDiagMatrixType
+  !> @copydetails MatrixTypes::zeroentries_TriDiagMatrixType
+  PROCEDURE,PASS :: zeroentries => zeroentries_TriDiagMatrixType
 ENDTYPE TriDiagMatrixType
 
 !> @brief Type used to hold the bands in the banded type
 TYPE Band
-  ! jIdx stores j index of each element in band
-  INTEGER(SIK), ALLOCATABLE :: jIdx(:)
-  REAL(SRK), ALLOCATABLE :: elem(:)
+! jIdx stores j index of each element in band
+INTEGER(SIK), ALLOCATABLE :: jIdx(:)
+REAL(SRK), ALLOCATABLE :: elem(:)
 ENDTYPE Band
 
 TYPE IntPtr
-  INTEGER(SIK),POINTER :: p(:) => NULL()
+INTEGER(SIK),POINTER :: p(:) => NULL()
 ENDTYPE IntPtr
 
 !> @brief The basic banded matrix type
 TYPE,EXTENDS(MatrixType) :: BandedMatrixType
-  !> Map of band indices stored (-m to n)
-  INTEGER(SIK),ALLOCATABLE :: bandIdx(:)
-  !> The bands stored in the matrix
-  TYPE(Band),ALLOCATABLE :: bands(:)
-  !> Number of nonzero elements
-  INTEGER(SIK) :: nnz
-  !> Number of columns
-  INTEGER(SIK) :: m
-  !> Counter to keep track of added elements before assembly
-  INTEGER(SIK) :: counter
-  !> Temporary containers used before (and deallocated after) assembly
-  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
-  REAL(SRK),ALLOCATABLE :: elemTmp(:)
-  LOGICAL(SBK) :: isAssembled, isReversed
+!> Map of band indices stored (-m to n)
+INTEGER(SIK),ALLOCATABLE :: bandIdx(:)
+!> The bands stored in the matrix
+TYPE(Band),ALLOCATABLE :: bands(:)
+!> Number of nonzero elements
+INTEGER(SIK) :: nnz
+!> Number of columns
+INTEGER(SIK) :: m
+!> Counter to keep track of added elements before assembly
+INTEGER(SIK) :: counter
+!> Temporary containers used before (and deallocated after) assembly
+INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+REAL(SRK),ALLOCATABLE :: elemTmp(:)
+!> Logical flag for whether the matrix is assembled
+LOGICAL(SBK) :: isAssembled
+!> Logical flag for whether bands are stored in ascending or desending
+!> order by index
+LOGICAL(SBK) :: isReversed
 
 !
 !List of Type Bound Procedures
-  CONTAINS
-    !> @copybrief MatrixTypes::clear_BandedMatrixType
-    !> @copydetails MatrixTypes::clear_BandedMatrixType
-    PROCEDURE,PASS :: clear => clear_BandedMatrixType
-    !> @copybrief MatrixTypes::init_BandedMatrixType
-    !> @copydetails MatrixTypes::init_BandedMatrixType
-    PROCEDURE,PASS :: init => init_BandedMatrixParam
-    !> @copybrief MatrixTypes::assemble_BandedMatrixType
-    !> @copydetails MatrixTypes::assemble_BandedMatrixType
-    PROCEDURE,PASS :: assemble => assemble_BandedMatrixType
-    !> @copybrief MatrixTypes::set_BandedMatrixType
-    !> @copydetails MatrixTypes::set_BandedMatrixType
-    PROCEDURE,PASS :: set => set_BandedMatrixType
-    !> @copybrief MatrixTypes::get_BandedMatrixType
-    !> @copydetails MatrixTypes::get_BandedMatrixType
-    PROCEDURE,PASS :: get => get_BandedMatrixType
-    !> @copybrief MatrixTypes::transpose_BandedMatrixType
-    !> @copydetails MatrixTypes::transpose_BandedMatrixType
-    PROCEDURE,PASS :: transpose => transpose_BandedMatrixType
-    !> @copybrief MatrixTypes::zeroentries_BandedMatrixType
-    !> @copydetails MatrixTypes::zeroentries_BandedMatrixType
-    PROCEDURE,PASS :: zeroentries => zeroentries_BandedMatrixType
-    !> @copybrief MatrixTypes::binarySearch_BandedMatrixType
-    !> @copydetails MatrixTypes::binarySearch_BandedMatrixType
-    PROCEDURE,PASS,PRIVATE :: binarySearch => binarySearch_BandedMatrixType
+CONTAINS
+  !> @copybrief MatrixTypes::clear_BandedMatrixType
+  !> @copydetails MatrixTypes::clear_BandedMatrixType
+  PROCEDURE,PASS :: clear => clear_BandedMatrixType
+  !> @copybrief MatrixTypes::init_BandedMatrixType
+  !> @copydetails MatrixTypes::init_BandedMatrixType
+  PROCEDURE,PASS :: init => init_BandedMatrixParam
+  !> @copybrief MatrixTypes::assemble_BandedMatrixType
+  !> @copydetails MatrixTypes::assemble_BandedMatrixType
+  PROCEDURE,PASS :: assemble => assemble_BandedMatrixType
+  !> @copybrief MatrixTypes::set_BandedMatrixType
+  !> @copydetails MatrixTypes::set_BandedMatrixType
+  PROCEDURE,PASS :: set => set_BandedMatrixType
+  !> @copybrief MatrixTypes::get_BandedMatrixType
+  !> @copydetails MatrixTypes::get_BandedMatrixType
+  PROCEDURE,PASS :: get => get_BandedMatrixType
+  !> @copybrief MatrixTypes::transpose_BandedMatrixType
+  !> @copydetails MatrixTypes::transpose_BandedMatrixType
+  PROCEDURE,PASS :: transpose => transpose_BandedMatrixType
+  !> @copybrief MatrixTypes::zeroentries_BandedMatrixType
+  !> @copydetails MatrixTypes::zeroentries_BandedMatrixType
+  PROCEDURE,PASS :: zeroentries => zeroentries_BandedMatrixType
+  !> @copybrief MatrixTypes::binarySearch_BandedMatrixType
+  !> @copydetails MatrixTypes::binarySearch_BandedMatrixType
+  PROCEDURE,PASS,PRIVATE :: binarySearch => binarySearch_BandedMatrixType
 ENDTYPE BandedMatrixType
 
-!> @brief The basic banded matrix type
+!> @brief The distributed banded matrix type
 TYPE,EXTENDS(DistributedMatrixType) :: DistributedBandedMatrixType
-  !> Map of band indices stored (-m to n)
-  INTEGER(SIK),ALLOCATABLE :: iOffsets(:),jOffsets(:)
-  !> The bands stored in the matrix
-  TYPE(BandedMatrixType),ALLOCATABLE :: chunks(:)
-  !> Number of nonzero elements
-  INTEGER(SIK) :: nnz
-  !> Number of columns
-  INTEGER(SIK) :: m
-  !> Block size (smallest indivisble unit)
-  INTEGER(SIK) :: blockSize
-  !> For those ranks that contribute at row = rank, holds array of band sizes
-  !> Used for matvec; if contrib(i,j) is false, bandSizes(i,j) is unassociated
-  !> If size 0, it is unused. Otherwise, it is used for sparse data transfer
-  TYPE(IntPtr), ALLOCATABLE :: bandSizes(:)
-  !> Temporary containers used before (and deallocated after) assembly
-  INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
-  REAL(SRK),ALLOCATABLE :: elemTmp(:)
-  LOGICAL(SBK) :: isReversed
+!> Map of band indices stored (-m to n)
+INTEGER(SIK),ALLOCATABLE :: iOffsets(:),jOffsets(:)
+!> The column of banded matrix 'chunks' stored locally
+TYPE(BandedMatrixType),ALLOCATABLE :: chunks(:)
+!> Number of nonzero elements
+INTEGER(SIK) :: nnz
+!> Number of columns
+INTEGER(SIK) :: m
+!> Block size (smallest indivisble unit)
+INTEGER(SIK) :: blockSize
+!> Array of band sizes used to determine optimal communication
+TYPE(IntPtr), ALLOCATABLE :: bandSizes(:)
+!> Temporary containers used before (and deallocated after) assembly
+INTEGER(SIK), ALLOCATABLE :: iTmp(:),jTmp(:)
+REAL(SRK),ALLOCATABLE :: elemTmp(:)
 !
 !List of Type Bound Procedures
   CONTAINS
@@ -327,7 +328,7 @@ CONTAINS
 !-------------------------------------------------------------------------------
 !> @brief Initializes Sparse Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_SparseMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_SparseMatrixParam'
@@ -377,7 +378,7 @@ ENDSUBROUTINE init_SparseMatrixParam
 !-------------------------------------------------------------------------------
 !> @brief Initializes Tridiagonal Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_TriDiagMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_TriDiagMatrixParam'
@@ -423,7 +424,7 @@ ENDSUBROUTINE init_TriDiagMatrixParam
 !-------------------------------------------------------------------------------
 !> @brief Initializes Banded Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_BandedMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_BandedMatrixParam'
@@ -431,7 +432,6 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
   CLASS(ParamType),INTENT(IN) :: Params
   TYPE(ParamType) :: validParams
   INTEGER(SIK) :: n,m,nnz
-  LOGICAL(SBK) :: bool
 
   !Check to set up required and optional param lists.
   IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
@@ -446,21 +446,19 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
   CALL validParams%get('MatrixType->nnz',nnz)
   CALL validParams%clear()
 
-  ! be greater than 1 and n < 1 are note logically equivalent. is this
-  ! desired behavior?
   IF(.NOT. matrix%isInit) THEN
-    IF(n < 1) THEN
+    IF(n <= 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of rows (n) must'// &
-          ' be greater than 1!')
-    ELSEIF(m < 1) THEN
+           modName//'::'//myName//' - Number of rows (n) must'// &
+           ' be greater than 1!')
+    ELSEIF(m <= 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of columns (m) must'// &
-          ' be greater than 1!')
+           modName//'::'//myName//' - Number of columns (m) must'// &
+           ' be greater than 1!')
     ELSEIF(nnz < 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of nonzero elements (nnz)'// &
-          ' must be greater than 0!')
+           modName//'::'//myName//' - Number of nonzero elements (nnz)'// &
+           ' must be greater than 0!')
     ELSE
       ALLOCATE(matrix%iTmp(nnz))
       ALLOCATE(matrix%jTmp(nnz))
@@ -476,24 +474,23 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
     ENDIF
   ELSE
     CALL eMatrixType%raiseError('Incorrect call to '// &
-      modName//'::'//myName//' - MatrixType already initialized')
+         modName//'::'//myName//' - MatrixType already initialized')
   ENDIF
 ENDSUBROUTINE init_BandedMatrixParam
 !
 !-------------------------------------------------------------------------------
 !> @brief Initializes Distributed Banded Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_DistributedBandedMatrixParam'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
   CLASS(ParamType),INTENT(IN) :: Params
-  TYPE(ParamType) :: validParams
-  INTEGER(SIK) :: n,m,nnz,MPI_COMM_ID,rank,mpierr,nproc,i,blocksize,nlocal
-  LOGICAL(SBK) :: bool
-
 #ifdef HAVE_MPI
+  TYPE(ParamType) :: validParams
+  INTEGER(SIK) :: n,m,nnz,commID,rank,mpierr,nproc,i,blocksize,nlocal
+
   !Check to set up required and optional param lists.
   IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
 
@@ -504,32 +501,32 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
   ! Pull Data From Parameter List
   CALL validParams%get('MatrixType->n',n)
   CALL validParams%get('MatrixType->m',m)
-  CALL validParams%get('MatrixType->MPI_Comm_ID',MPI_COMM_ID)
+  CALL validParams%get('MatrixType->MPI_Comm_ID',commID)
   CALL validParams%get('MatrixType->nnz',nnz)
   CALL validParams%get('MatrixType->blockSize',blockSize)
   CALL validParams%get('MatrixType->nlocal',nlocal)
   CALL validParams%clear()
 
   IF(.NOT. matrix%isInit) THEN
-    IF(n < 1) THEN
+    IF(n <= 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of rows (n) must'// &
-          ' be greater than 1!')
-    ELSEIF(m < 1) THEN
+           modName//'::'//myName//' - Number of rows (n) must'// &
+           ' be greater than 1!')
+    ELSEIF(m <= 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of columns (m) must'// &
-          ' be greater than 1!')
-    ELSEIF(nnz < 1) THEN
+           modName//'::'//myName//' - Number of columns (m) must'// &
+           ' be greater than 1!')
+    ELSEIF(nnz <= 1) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - Number of nonzero entries (nnz)'// &
-          ' must be greater than 0!')
-    ELSEIF(MPI_COMM_ID == MPI_COMM_NULL) THEN
+           modName//'::'//myName//' - Number of nonzero entries (nnz)'// &
+           ' must be greater than 0!')
+    ELSEIF(commID == MPI_COMM_NULL) THEN
       CALL eMatrixType%raiseError('Incorrect input to '// &
-        modName//'::'//myName//' - MPI communicator cannot have the same'// &
-          ' value as MPI_COMM_NULL')
+           modName//'::'//myName//' - MPI communicator cannot have the same'// &
+           ' value as MPI_COMM_NULL')
     ELSE
-      CALL MPI_Comm_rank(MPI_COMM_ID,rank,mpierr)
-      CALL MPI_Comm_size(MPI_COMM_ID,nproc,mpierr)
+      CALL MPI_Comm_rank(commID,rank,mpierr)
+      CALL MPI_Comm_size(commID,nproc,mpierr)
 
       REQUIRE(MOD(n,blockSize)==0)
       REQUIRE(MOD(m,blockSize)==0)
@@ -542,30 +539,37 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
       matrix%nlocal = 0
       n = n/blockSize
       m = m/blockSize
+      ! We assume that the matrix is somewhat evenly balanced
+      ! among its columns; that is, no one chunk of columns contains
+      ! more than twice the average nonzero entries
       ALLOCATE(matrix%iTmp(2*nnz/nProc))
       ALLOCATE(matrix%jTmp(2*nnz/nProc))
       ALLOCATE(matrix%elemTmp(2*nnz/nProc))
       IF (nlocal < 0) THEN
+        ! Automatic division of matrix by greedy partitioning of blocks
         DO i=2,nproc+1
           matrix%jOffsets(i) = matrix%jOffsets(i-1) + m/nproc
           IF (MOD(m,nproc) > i-2) THEN
             matrix%jOffsets(i) = matrix%jOffsets(i) + 1
-          END IF
-        END DO
+          ENDIF
+        ENDDO
 
         DO i=2,nproc+1
           matrix%iOffsets(i) = matrix%iOffsets(i-1) + n/nproc
           IF (MOD(n,nproc) > i-2) THEN
             matrix%iOffsets(i) = matrix%iOffsets(i) + 1
-          END IF
-        END DO
+          ENDIF
+        ENDDO
+        ! Separate i/jOffsets are maintained in the case of a rectangular
+        ! matrix
         matrix%iOffsets = matrix%iOffsets*blockSize
         matrix%jOffsets = matrix%jOffsets*blockSize
       ELSE
+        ! Partitioning explicitly specified (square only)
         REQUIRE(MOD(nlocal,blockSize)==0)
         REQUIRE(m == n)
         ! Gather all nlocal and sum going forward
-        CALL MPI_AllGather(nlocal,1,MPI_INTEGER,matrix%iOffsets(2),1,MPI_INTEGER,MPI_Comm_ID,mpierr)
+        CALL MPI_AllGather(nlocal,1,MPI_INTEGER,matrix%iOffsets(2),1,MPI_INTEGER,commID,mpierr)
         DO i=2,nproc+1
           matrix%iOffsets(i) = matrix%iOffsets(i) + matrix%iOffsets(i-1)
         ENDDO
@@ -573,20 +577,20 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
         matrix%jOffsets(:) = matrix%iOffsets(:)
       ENDIF
 
-      ALLOCATE(matrix%bandSizes(nProc))
+      REQUIRE(MOD(n,blockSize)==0)
+      REQUIRE(MOD(m,blockSize)==0)
 
       matrix%isInit=.TRUE.
       matrix%isAssembled=.FALSE.
-      matrix%isReversed=.FALSE.
       matrix%n=n*blockSize
       matrix%m=m*blockSize
       matrix%nnz=nnz
       matrix%blockSize = blockSize
-      matrix%comm=MPI_COMM_ID
+      matrix%comm=commID
     ENDIF
   ELSE
     CALL eMatrixType%raiseError('Incorrect call to '// &
-      modName//'::'//myName//' - MatrixType already initialized')
+        modName//'::'//myName//' - MatrixType already initialized')
   ENDIF
 #endif
 ENDSUBROUTINE init_DistributedBandedMatrixParam
@@ -595,18 +599,17 @@ ENDSUBROUTINE init_DistributedBandedMatrixParam
 !-------------------------------------------------------------------------------
 !> @brief Initializes Distributed Block-Banded Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_DistributedBlockBandedMatrixParam'
   CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
   CLASS(ParamType),INTENT(IN) :: Params
-  TYPE(ParamType) :: validParams,blockParams
-  INTEGER(SIK) :: n,m,nnz,MPI_COMM_ID,rank,mpierr,nproc,i,blockSize,nlocal
-  INTEGER(SIK),ALLOCATABLE :: blkOffsetTmp(:)
-  LOGICAL(SBK) :: bool
-
 #ifdef HAVE_MPI
+  TYPE(ParamType) :: validParams,blockParams
+  INTEGER(SIK) :: n,rank,mpierr,commID,nproc,i,blockSize,nlocal
+  INTEGER(SIK),ALLOCATABLE :: blkOffsetTmp(:)
+
   !Check to set up required and optional param lists.
   IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
 
@@ -616,7 +619,7 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
 
   ! Pull Data From Parameter List
   CALL validParams%get('MatrixType->n',n)
-  CALL validParams%get('MatrixType->MPI_Comm_ID',MPI_COMM_ID)
+  CALL validParams%get('MatrixType->MPI_Comm_ID',commID)
   CALL validParams%get('MatrixType->blockSize',blockSize)
   CALL validParams%get('MatrixType->nlocal',nlocal)
 
@@ -630,8 +633,8 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
   ! %parent%
 
   ! Default to greedy partitioning, respecting blockSize
-  CALL MPI_Comm_rank(MPI_COMM_ID,rank,mpierr)
-  CALL MPI_Comm_size(MPI_COMM_ID,nproc,mpierr)
+  CALL MPI_Comm_rank(commID,rank,mpierr)
+  CALL MPI_Comm_size(commID,nproc,mpierr)
   REQUIRE(n/blockSize >= nproc)
 
 
@@ -649,7 +652,7 @@ SUBROUTINE init_DistributedBlockBandedMatrixParam(matrix,Params)
     ALLOCATE(blkOffsetTmp(nproc))
     REQUIRE(MOD(nlocal,blockSize)==0)
     matrix%nlocalBlocks = nlocal/blockSize
-    CALL MPI_AllGather(matrix%nlocalBlocks,1,MPI_INTEGER,blkOffsetTmp,1,MPI_INTEGER,MPI_Comm_ID,mpierr)
+    CALL MPI_AllGather(matrix%nlocalBlocks,1,MPI_INTEGER,blkOffsetTmp,1,MPI_INTEGER,commID,mpierr)
     matrix%blockOffset = SUM(blkOffsetTmp(1:rank))
     DEALLOCATE(blkOffsetTmp)
   ENDIF
@@ -674,7 +677,6 @@ ENDSUBROUTINE init_DistributedBlockBandedMatrixParam
 !> @brief Assembles Serial Banded Matrix Type. This rearranges values set into
 !>        matrix bands, and sets the structure to read-only
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
 !>
 SUBROUTINE assemble_BandedMatrixType(thisMatrix)
   CHARACTER(LEN=*),PARAMETER :: myName='assemble_BandedMatrixType'
@@ -682,7 +684,7 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
   INTEGER(SIK),ALLOCATABLE :: numOnDiag(:),idxOrig(:)
   INTEGER(SIK),ALLOCATABLE :: iSort(:),jSort(:)
   REAL(SRK),ALLOCATABLE :: valSort(:)
-  INTEGER(SIK) :: counter,currIdx,currBand,nBands,i,j
+  INTEGER(SIK) :: counter,nBands,i,j
   INTEGER(SLK) :: iLong,jLong,nLong,mLong
   INTEGER(SLK),ALLOCATABLE :: diagRank(:)
 
@@ -697,14 +699,20 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
     nLong = INT(thisMatrix%n,kind=SLK)
     mLong = INT(thisMatrix%m,kind=SLK)
     idxOrig(i) = i
-    IF (thisMatrix%n - thisMatrix%iTmp(i) + 1 + thisMatrix%jTmp(i) <= MAX(thisMatrix%m,thisMatrix%n)) THEN
+    ! The diagonal rank counts upwards as one moves southeast in the matrix,
+    ! starting at a large negative number in the bottom left, and reaching
+    ! zero near the middle
+    IF (thisMatrix%n - thisMatrix%iTmp(i) + 1 + thisMatrix%jTmp(i) &
+        <= MAX(thisMatrix%m,thisMatrix%n)) THEN
       diagRank(i) = -mLong*nLong/2
-      diagRank(i) = diagRank(i) + jLong - 1 + ((nLong - iLong + jLong - 1)*(nLong - iLong + jLong))/2
+      diagRank(i) = diagRank(i) + jLong - 1 + ((nLong - iLong + jLong - 1) &
+                    *(nLong - iLong + jLong))/2
     ELSE
       diagRank(i) = nLong*mLong/2
-      diagRank(i) = diagRank(i) - (mLong - jLong + ((iLong + mLong - jLong - 1)*(iLong + mLong - jLong))/2)
-    END IF
-  END DO
+      diagRank(i) = diagRank(i) - (mLong - jLong + ((iLong + mLong - jLong &
+                    - 1)*(iLong + mLong - jLong))/2)
+    ENDIF
+  ENDDO
 
   CALL sort(diagRank,idxOrig)
   ! Now update iTmp,jTmp,etc
@@ -721,51 +729,55 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
   numOnDiag = 0_SIK
   DO i=1,SIZE(iSort)
     numOnDiag(jSort(i)-iSort(i)+thisMatrix%n) = 1 + numOnDiag(jSort(i)-iSort(i)+thisMatrix%n)
-  END DO
+  ENDDO
+  ! Now count up the number of bands necessary
   nBands = 0
   DO i=1,SIZE(numOnDiag)
     IF (numOnDiag(i)/=0) THEN
       nBands = nBands + 1
-    END IF
-  END DO
+    ENDIF
+  ENDDO
   ALLOCATE(thisMatrix%bandIdx(nBands))
   ALLOCATE(thisMatrix%bands(nBands))
   counter = 1
+  ! Allocate the bands
   DO i=1,SIZE(numOnDiag)
     IF (numOnDiag(i)/=0) THEN
       ALLOCATE(thisMatrix%bands(counter)%jIdx(numOnDiag(i)))
       ALLOCATE(thisMatrix%bands(counter)%elem(numOnDiag(i)))
       thisMatrix%bandIdx(counter) = i - thisMatrix%n
       counter = counter + 1
-    END IF
-  END DO
+    ENDIF
+  ENDDO
   counter = 1
+  ! Set the bands
   DO i=1,SIZE(thisMatrix%bandIdx)
     DO j=1,SIZE(thisMatrix%bands(i)%jIdx)
       thisMatrix%bands(i)%jIdx(j) = jSort(counter)
       thisMatrix%bands(i)%elem(j) = valSort(counter)
       counter = counter + 1
-    END DO
-  END DO
+    ENDDO
+  ENDDO
 
   thisMatrix%isAssembled = .TRUE.
 ENDSUBROUTINE assemble_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
-!> @brief Assembles Distributed Banded Matrix Type. This rearranges values set into
-!>        matrix bands, and sets the structure to read-only
+!> @brief Assembles Distributed Banded Matrix Type. This sets some values and
+!>        assembles all chunks, setting the structure to read-only
 !> @param thisMatrix the matrix type to act on
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
   CHARACTER(LEN=*),PARAMETER :: myName='assemble_DistributedBandedMatrixType'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: thisMatrix
   INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+#ifdef HAVE_MPI
   TYPE(ParamType) :: bandedPList
   INTEGER(SIK) :: mpierr, rank, nproc, i, j, nBandLocal
   INTEGER(SIK),ALLOCATABLE :: nnzPerChunk(:),nband(:),bandSizeTmp(:)
   LOGICAL(SBK) :: blockNonzero
 
-#ifdef HAVE_MPI
   REQUIRE(thisMatrix%isInit)
   CALL MPI_Comm_rank(thisMatrix%comm,rank,mpierr)
   CALL MPI_Comm_size(thisMatrix%comm,nproc,mpierr)
@@ -778,9 +790,9 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
           thisMatrix%iTmp(i) <= thisMatrix%iOffsets(j+1)) THEN
         nnzPerChunk(j) = nnzPerChunk(j) + 1
         EXIT
-      END IF
-    END DO
-  END DO
+      ENDIF
+    ENDDO
+  ENDDO
   CALL bandedPList%clear()
 
   ALLOCATE(thisMatrix%chunks(nProc))
@@ -788,20 +800,25 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
     blockNonzero = nnzPerChunk(i) > 0
     IF (blockNonzero) THEN
       CALL bandedPList%add('MatrixType->nnz',nnzPerChunk(i))
-      CALL bandedPList%add('MatrixType->n',thisMatrix%iOffsets(i+1) - thisMatrix%iOffsets(i))
-      CALL bandedPList%add('MatrixType->m',thisMatrix%jOffsets(rank+2) - thisMatrix%jOffsets(rank+1))
+      CALL bandedPList%add('MatrixType->n',thisMatrix%iOffsets(i+1) - &
+                           thisMatrix%iOffsets(i))
+      CALL bandedPList%add('MatrixType->m',thisMatrix%jOffsets(rank+2) - &
+                           thisMatrix%jOffsets(rank+1))
       CALL thisMatrix%chunks(i)%init(bandedPList)
 
       DO j=1,thisMatrix%nLocal
         IF (thisMatrix%iTmp(j) > thisMatrix%iOffsets(i) .AND. &
             thisMatrix%iTmp(j) <= thisMatrix%iOffsets(i+1)) THEN
-          CALL thisMatrix%chunks(i)%set(thisMatrix%iTmp(j)-thisMatrix%iOffsets(i),thisMatrix%jTmp(j)-thisMatrix%jOffsets(rank+1),thisMatrix%elemTmp(j))
-        END IF
-      END DO
+          CALL thisMatrix%chunks(i)%set(thisMatrix%iTmp(j) - &
+               thisMatrix%iOffsets(i), &
+               thisMatrix%jTmp(j)-thisMatrix%jOffsets(rank+1), &
+               thisMatrix%elemTmp(j))
+        ENDIF
+      ENDDO
       CALL thisMatrix%chunks(i)%assemble()
       CALL bandedPList%clear()
     ENDIF
-    ! Set self var
+    ! Set nbandlocal (to be gathered into nband
     IF (thisMatrix%chunks(i)%isInit) THEN
       IF (2*thisMatrix%chunks(i)%nnz/3 < thisMatrix%chunks(i)%n) THEN
         nBandLocal = SIZE(thisMatrix%chunks(i)%bandIdx)
@@ -812,9 +829,9 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
       nBandLocal = 0
     ENDIF
 
-    ! Gather to rank j-1 into nBand(:)
+    ! Gather to rank i-1 into nBand(:)
     CALL MPI_Gather(nBandLocal, 1, MPI_INTEGER, nband(1), 1, MPI_INTEGER, i-1, thisMatrix%comm, mpierr)
-    ! Have rank j-1 allocate
+    ! Have rank i-1 allocate
     IF (rank == i-1) THEN
       DO j=1,nProc
         IF (j == i) THEN
@@ -822,7 +839,9 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
         ELSE
           IF (nBand(j) > 0) THEN
             ALLOCATE(thisMatrix%bandSizes(j)%p(nBand(j)))
-            CALL MPI_Recv(thisMatrix%bandSizes(j)%p(1), nBand(j), MPI_INTEGER, j-1, 0, thisMatrix%comm, MPI_STATUS_IGNORE, mpierr)
+            CALL MPI_Recv(thisMatrix%bandSizes(j)%p(1), nBand(j), &
+                          MPI_INTEGER, j-1, 0, thisMatrix%comm, &
+                          MPI_STATUS_IGNORE, mpierr)
           ELSE
             IF (nBand(j) == 0) THEN
               NULLIFY(thisMatrix%bandSizes(j)%p)
@@ -839,11 +858,12 @@ SUBROUTINE assemble_DistributedBandedMatrixType(thisMatrix,ierr)
         DO j=1,nBandLocal
           bandSizeTmp(j) = SIZE(thisMatrix%chunks(i)%bands(j)%elem)
         ENDDO
-        CALL MPI_Send(bandSizeTmp(:), nBandLocal, MPI_INTEGER, i-1, 0, thisMatrix%comm, mpierr)
+        CALL MPI_Send(bandSizeTmp(:), nBandLocal, MPI_INTEGER, i-1, 0, &
+                      thisMatrix%comm, mpierr)
         DEALLOCATE(bandSizeTmp)
       ENDIF
-    END IF
-  END DO
+    ENDIF
+  ENDDO
 
   thisMatrix%isAssembled = .TRUE.
   DEALLOCATE(thisMatrix%iTmp)
@@ -855,7 +875,7 @@ ENDSUBROUTINE assemble_DistributedBandedMatrixType
 !-------------------------------------------------------------------------------
 !> @brief Initializes Dense Rectangular Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_DenseRectMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_DenseRectMatrixParam'
@@ -900,7 +920,7 @@ ENDSUBROUTINE init_DenseRectMatrixParam
 !-------------------------------------------------------------------------------
 !> @brief Initializes Dense Square Matrix Type with a Parameter List
 !> @param matrix the matrix type to act on
-!> @param pList the parameter list
+!> @param Params the parameter list
 !>
 SUBROUTINE init_DenseSquareMatrixParam(matrix,Params)
   CHARACTER(LEN=*),PARAMETER :: myName='init_DenseSquareMatrixParam'
@@ -1002,24 +1022,14 @@ SUBROUTINE clear_BandedMatrixType(matrix)
   matrix%counter=0
   IF(ALLOCATED(matrix%bands)) THEN
     DO i=1,SIZE(matrix%bandIdx)
-      IF(ALLOCATED(matrix%bands(i)%elem)) THEN
-        DEALLOCATE(matrix%bands(i)%elem)
-      END IF
+      IF(ALLOCATED(matrix%bands(i)%elem)) DEALLOCATE(matrix%bands(i)%elem)
     ENDDO
     DEALLOCATE(matrix%bands)
   ENDIF
-  IF(ALLOCATED(matrix%bandIdx)) THEN
-    DEALLOCATE(matrix%bandIdx)
-  ENDIF
-  IF(ALLOCATED(matrix%iTmp)) THEN
-    DEALLOCATE(matrix%iTmp)
-  ENDIF
-  IF(ALLOCATED(matrix%jTmp)) THEN
-    DEALLOCATE(matrix%jTmp)
-  ENDIF
-  IF(ALLOCATED(matrix%elemTmp)) THEN
-    DEALLOCATE(matrix%elemTmp)
-  ENDIF
+  IF(ALLOCATED(matrix%bandIdx)) DEALLOCATE(matrix%bandIdx)
+  IF(ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
+  IF(ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
+  IF(ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
   matrix%nnz = 0
   IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
  ENDSUBROUTINE clear_BandedMatrixType
@@ -1031,8 +1041,9 @@ SUBROUTINE clear_BandedMatrixType(matrix)
 SUBROUTINE clear_DistributedBandedMatrixType(matrix)
   CHARACTER(LEN=*),PARAMETER :: myName='clear_DistributedBandedMatrixType'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
-  INTEGER(SIK) :: i
 #ifdef HAVE_MPI
+  INTEGER(SIK) :: i
+
   matrix%isInit=.FALSE.
   matrix%isCreated=.FALSE.
   matrix%isAssembled=.FALSE.
@@ -1047,24 +1058,12 @@ SUBROUTINE clear_DistributedBandedMatrixType(matrix)
     ENDDO
     DEALLOCATE(matrix%chunks)
   ENDIF
-  IF(ALLOCATED(matrix%iOffsets)) THEN
-    DEALLOCATE(matrix%iOffsets)
-  ENDIF
-  IF(ALLOCATED(matrix%jOffsets)) THEN
-    DEALLOCATE(matrix%jOffsets)
-  ENDIF
-  IF(ALLOCATED(matrix%iTmp)) THEN
-    DEALLOCATE(matrix%iTmp)
-  ENDIF
-  IF(ALLOCATED(matrix%jTmp)) THEN
-    DEALLOCATE(matrix%jTmp)
-  ENDIF
-  IF(ALLOCATED(matrix%elemTmp)) THEN
-    DEALLOCATE(matrix%elemTmp)
-  ENDIF
-  IF(ALLOCATED(matrix%bandSizes)) THEN
-    DEALLOCATE(matrix%bandSizes)
-  ENDIF
+  IF(ALLOCATED(matrix%iOffsets)) DEALLOCATE(matrix%iOffsets)
+  IF(ALLOCATED(matrix%jOffsets)) DEALLOCATE(matrix%jOffsets)
+  IF(ALLOCATED(matrix%iTmp)) DEALLOCATE(matrix%iTmp)
+  IF(ALLOCATED(matrix%jTmp)) DEALLOCATE(matrix%jTmp)
+  IF(ALLOCATED(matrix%elemTmp)) DEALLOCATE(matrix%elemTmp)
+  IF(ALLOCATED(matrix%bandSizes)) DEALLOCATE(matrix%bandSizes)
   IF(MatrixType_Paramsflag) CALL MatrixTypes_Clear_ValidParams()
 #endif
  ENDSUBROUTINE clear_DistributedBandedMatrixType
@@ -1077,16 +1076,19 @@ SUBROUTINE clear_DistributedBandedMatrixType(matrix)
 SUBROUTINE clear_DistributedBlockBandedMatrixType(matrix)
   CHARACTER(LEN=*),PARAMETER :: myName='clear_DistributedBlockBandedMatrixType'
   CLASS(DistributedBlockBandedMatrixType),INTENT(INOUT) :: matrix
-  INTEGER(SIK) :: i
 #ifdef HAVE_MPI
+  INTEGER(SIK) :: i
   matrix%blockMask = .FALSE.
   matrix%blockSize = 0
   matrix%nLocalBlocks = 0
   matrix%blockOffset = 0
+  matrix%isInit = .FALSE.
+  matrix%isCreated=.FALSE.
+  matrix%isAssembled = .FALSE.
 
   DO i=1,SIZE(matrix%blocks)
     CALL matrix%blocks(i)%clear()
-  END DO
+  ENDDO
   DEALLOCATE(matrix%blocks)
 
   CALL matrix%DistributedBandedMatrixType%clear()
@@ -1244,12 +1246,16 @@ SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(IN) :: setval
-  INTEGER(SIK) :: rank,nproc,mpierr,nHeldLower,bandLoc,elemIdx,k
-  LOGICAL(SBK) :: flag
 #ifdef HAVE_MPI
+  INTEGER(SIK) :: rank,nproc,mpierr,k
+  LOGICAL(SBK) :: flag
+  CHARACTER(LEN=64) :: msg
+
   flag = .FALSE.
   REQUIRE(matrix%isInit)
   IF(.NOT. matrix%isAssembled) THEN
+    ! If the matrix is not yet assembled, we are adding to the temporary
+    ! containers i/j/elemTmp
     IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
         .AND. (i>=1) .AND. (j >= 1)) THEN
 
@@ -1260,29 +1266,36 @@ SUBROUTINE set_DistributedBandedMatrixType(matrix,i,j,setval)
         matrix%nLocal = matrix%nLocal + 1
         IF (matrix%nLocal > 2*matrix%nnz/nproc) THEN
           CALL eMatrixType%raiseError('Matrix Element imbalance '// &
-            modName//'::'//myName//' - Check nnz or use a different type')
-        END IF
+               modName//'::'//myName//' - Check nnz or use a different type')
+        ENDIF
         matrix%iTmp(matrix%nLocal) = i
         matrix%jTmp(matrix%nLocal) = j
         matrix%elemTmp(matrix%nLocal) = setval
         flag = .TRUE.
-      END IF
+      ENDIF
     ENDIF
   ELSE
+    ! If the matrix is assmbled then we find the corresponding chunk and
+    ! call set there
     CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
     IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
       DO k=1,SIZE(matrix%jOffsets)-1
         IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
           IF (matrix%chunks(k)%isInit) THEN
-            CALL matrix%chunks(k)%set(i-matrix%iOffsets(k),j-matrix%jOffsets(rank+1),setval)
+            CALL matrix%chunks(k)%set(i-matrix%iOffsets(k), &
+                                      j-matrix%jOffsets(rank+1),setval)
             flag = .TRUE.
             EXIT
-          END IF
-        END IF
-      END DO
-    END IF
-  END IF
-  IF (.NOT. flag) WRITE(*,*) "Invalid matrix set encountered in rank",rank,"at",i,j
+          ENDIF
+        ENDIF
+      ENDDO
+    ENDIF
+  ENDIF
+  IF (.NOT. flag) THEN
+    WRITE(msg,'(I2,A,I9,A,I9)') rank," at ",i,',',j
+    CALL eMatrixType%raiseWarning('Invalid matrix set in '// &
+         modName//'::'//myname//' for rank '//msg)
+  ENDIF
 
 #endif
 ENDSUBROUTINE set_DistributedBandedMatrixType
@@ -1301,9 +1314,10 @@ SUBROUTINE set_DistributedBlockBandedMatrixType(matrix,i,j,setval)
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(IN) :: setval
+#ifdef HAVE_MPI
   INTEGER(SIK) :: rank,mpierr,offset
   LOGICAL(SBK) :: flag
-#ifdef HAVE_MPI
+  CHARACTER(LEN=64) :: msg
   REQUIRE(matrix%isInit)
 
   flag = .FALSE.
@@ -1324,7 +1338,11 @@ SUBROUTINE set_DistributedBlockBandedMatrixType(matrix,i,j,setval)
       ENDIF
     ENDIF
   ENDIF
-  IF (.NOT. flag) WRITE(*,*) "Invalid matrix set encountered in rank",rank,"at",i,j
+  IF (.NOT. flag) THEN
+    WRITE(msg,'(I2,A,I9,A,I9)') rank," at ",i,',',j
+    CALL eMatrixType%raiseWarning('Invalid matrix set in '// &
+         modName//'::'//myname//' for rank '//msg)
+  ENDIF
 #endif
 ENDSUBROUTINE set_DistributedBlockBandedMatrixType
 
@@ -1343,7 +1361,7 @@ SUBROUTINE setrow_DistributedBandedMatrixType(matrix,i,j,setval)
   INTEGER(SIK),INTENT(IN) :: j(:)
   REAL(SRK),INTENT(IN) :: setval(:)
   CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
-    ' - routine is not implemented!')
+       ' - routine is not implemented!')
 ENDSUBROUTINE setrow_DistributedBandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1365,17 +1383,19 @@ SUBROUTINE set_BandedMatrixType(matrix,i,j,setval)
   IF(((j <= matrix%m) .AND. (i <= matrix%n)) &
      .AND. (i>=1) .AND. (j >= 1)) THEN
     IF(.NOT. matrix%isAssembled) THEN
+      ! If it is not assembled, add to tmp variables
       matrix%counter = matrix%counter + 1
       matrix%iTmp(matrix%counter) = i
       matrix%jTmp(matrix%counter) = j
       matrix%elemTmp(matrix%counter) = setval
     ELSE
+      ! Otherwise, perform binary search to set in existing structure
       CALL binarySearch_BandedMatrixType(matrix,i,j,bandLoc,elemIdx)
       IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
         matrix%bands(bandLoc)%elem(elemIdx) = setVal
-      END IF
-    END IF
-  END IF
+      ENDIF
+    ENDIF
+  ENDIF
 ENDSUBROUTINE set_BandedMatrixType
 !
 !-------------------------------------------------------------------------------
@@ -1473,22 +1493,22 @@ SUBROUTINE get_DistributedBandedMatrixType(matrix,i,j,getval)
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(INOUT) :: getval
-  INTEGER(SIK) :: bandLoc, elemidx, k, mpierr, rank
-  LOGICAL(SBK) :: found
-
 #ifdef HAVE_MPI
+  INTEGER(SIK) :: k, mpierr, rank
+
   getval = 0.0_SRK
   CALL MPI_Comm_rank(matrix%comm,rank,mpierr)
   IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
     DO k=1,SIZE(matrix%jOffsets)-1
       IF (i > matrix%iOffsets(k) .AND. i <= matrix%iOffsets(k+1)) THEN
         IF (matrix%chunks(k)%isInit) THEN
-          CALL matrix%chunks(k)%get(i-matrix%iOffsets(k),j-matrix%jOffsets(rank+1),getval)
+          CALL matrix%chunks(k)%get(i-matrix%iOffsets(k), &
+                                    j-matrix%jOffsets(rank+1),getval)
           EXIT
-        END IF
-      END IF
-    END DO
-  END IF
+        ENDIF
+      ENDIF
+    ENDDO
+  ENDIF
 #endif
 ENDSUBROUTINE get_DistributedBandedMatrixType
 
@@ -1506,9 +1526,8 @@ SUBROUTINE get_DistributedBlockBandedMatrixType(matrix,i,j,getval)
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(INOUT) :: getval
+#ifdef HAVE_MPI
   INTEGER(SIK) :: rank,mpierr,offset
-  REAL(SRK) :: val
-#if HAVE_MPI
   CALL MPI_Comm_Rank(matrix%comm,rank,mpierr)
   IF ((i-1)/matrix%blockSize /= (j-1)/matrix%blockSize) THEN
     CALL matrix%DistributedBandedMatrixType%get(i,j,getVal)
@@ -1516,10 +1535,10 @@ SUBROUTINE get_DistributedBlockBandedMatrixType(matrix,i,j,getval)
     offset = ((i-1)/matrix%blockSize)*matrix%blockSize
     IF (j > matrix%jOffsets(rank+1) .AND. j <= matrix%jOffsets(rank+2)) THEN
       getval = matrix%blocks((i-1)/matrix%blockSize - matrix%blockOffset + 1)%A(i-offset,j-offset)
-    END IF
+    ENDIF
   ELSE
     getval = 0.0_SRK
-  END IF
+  ENDIF
 #endif
 ENDSUBROUTINE get_DistributedBlockBandedMatrixType
 
@@ -1543,7 +1562,7 @@ SUBROUTINE get_BandedMatrixType(matrix,i,j,getval)
   getval = 0.0_SRK
   IF (bandLoc >= 0 .AND. elemIdx >= 0) THEN
     getval = matrix%bands(bandLoc)%elem(elemIdx)
-  END IF
+  ENDIF
 
 ENDSUBROUTINE get_BandedMatrixType
 !
@@ -1676,10 +1695,9 @@ ENDSUBROUTINE transpose_TriDiagMatrixType
 SUBROUTINE transpose_DistributedBandedMatrixType(matrix)
   CHARACTER(LEN=*),PARAMETER :: myName='transpose_DistributedBandedMatrixType'
   CLASS(DistributedBandedMatrixType),INTENT(INOUT) :: matrix
-  INTEGER(SIK) :: mTmp,i
 
   CALL eMatrixType%raiseFatalError(modName//'::'//myName// &
-    ' - routine is not implemented!')
+       ' - routine is not implemented!')
 
 ENDSUBROUTINE transpose_DistributedBandedMatrixType
 !
@@ -1702,7 +1720,7 @@ SUBROUTINE transpose_BandedMatrixType(matrix)
 
   DO i=1,SIZE(matrix%bandIdx)
     matrix%bands(i)%jIdx = matrix%bands(i)%jIdx - matrix%bandIdx(i)
-  END DO
+  ENDDO
   matrix%bandIdx = -matrix%bandIdx
   matrix%isReversed = .NOT. matrix%isReversed
 
@@ -1846,8 +1864,8 @@ SUBROUTINE  zeroentries_DistributedBandedMatrixType(matrix)
   DO i=1,SIZE(matrix%iOffsets)-1
     IF (matrix%chunks(i)%isInit) THEN
       CALL matrix%chunks(i)%zeroentries()
-    END IF
-  END DO
+    ENDIF
+  ENDDO
 
 ENDSUBROUTINE zeroentries_DistributedBandedMatrixType
 !
@@ -1867,7 +1885,7 @@ SUBROUTINE  zeroentries_DistributedBlockBandedMatrixType(matrix)
 
   DO i=1,SIZE(matrix%blocks)
     CALL matrix%blocks(i)%zeroEntries()
-  END DO
+  ENDDO
   CALL matrix%DistributedBandedMatrixType%zeroEntries()
 
 ENDSUBROUTINE zeroentries_DistributedBlockBandedMatrixType
@@ -1945,24 +1963,24 @@ SUBROUTINE binarySearch_BandedMatrixType(matrix, i, j, bandLoc, elemIdx)
   IF (matrix%isReversed) THEN
     bIdx = -bIdx
     matrix%bandIdx = -matrix%bandIdx
-  END IF
+  ENDIF
   lo = 1
-  hi = SIZE(matrix%bandIdx)
-
-  IF (bIdx < matrix%bandIdx(1) .OR. bIdx > matrix%bandIdx(hi)) THEN
-    bandLoc = -1
+  hi = SIZE(matrix%bands(bandLoc)%elem)
+  found = .FALSE.
+  IF (j < matrix%bands(bandLoc)%jIdx(lo) .OR. j > matrix%bands(bandLoc)%jIdx(hi)) THEN
+    elemIdx = -1
   ELSE
     DO WHILE (lo <= hi .AND. .NOT. found)
       mid = (hi+lo)/2
-      IF (bIdx < matrix%bandIdx(mid)) THEN
+      IF (j < matrix%bands(bandLoc)%jIdx(mid)) THEN
         hi = mid-1
-      ELSE IF (bIdx > matrix%bandIdx(mid)) THEN
+      ELSE IF (j > matrix%bands(bandLoc)%jIdx(mid)) THEN
         lo = mid+1
       ELSE
         found = .TRUE.
         EXIT
-      END IF
-    END DO
+      ENDIF
+    ENDDO
     IF (found) THEN
       bandLoc = mid
       lo = 1
@@ -1980,20 +1998,20 @@ SUBROUTINE binarySearch_BandedMatrixType(matrix, i, j, bandLoc, elemIdx)
           ELSE
             found = .TRUE.
             EXIT
-          END IF
-        END DO
-      END IF
+          ENDIF
+        ENDDO
+      ENDIF
       elemIdx = -1
       IF (found) THEN
         elemIdx = mid
-      END IF
+      ENDIF
     ELSE
       bandLoc = -1
-    END IF
-  END IF
+    ENDIF
+  ENDIF
   IF (matrix%isReversed) THEN
     matrix%bandIdx = -matrix%bandIdx
-  END IF
+  ENDIF
 END SUBROUTINE binarySearch_BandedMatrixType
 
 ENDMODULE MatrixTypes_Native

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -193,7 +193,6 @@ ENDSUBROUTINE init_PETScMatrixParam
 !> @param matrix the matrix type to act on
 !>
 SUBROUTINE clear_PETScMatrixType(matrix)
-  CHARACTER(LEN=*),PARAMETER :: myName='clear_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   PetscErrorCode  :: ierr
 
@@ -213,7 +212,6 @@ ENDSUBROUTINE clear_PETScMatrixType
 !> @param setval the value to be set
 !>
 SUBROUTINE set_PETScMatrixType(matrix,i,j,setval)
-  CHARACTER(LEN=*),PARAMETER :: myName='set_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
@@ -242,7 +240,6 @@ ENDSUBROUTINE set_PETScMatrixType
 !> @param setval a list of values corresponding to the j locations (must be same size as j)
 !>
 SUBROUTINE setRow_PETScMatrixType(matrix,i,j,setval)
-  CHARACTER(LEN=*),PARAMETER :: myName='set_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j(:)
@@ -266,7 +263,6 @@ ENDSUBROUTINE setRow_PETScMatrixType
 !> out of bounds, then -1051.0 (an arbitrarily chosen key) is returned.
 !>
 SUBROUTINE get_PETScMatrixType(matrix,i,j,getval)
-  CHARACTER(LEN=*),PARAMETER :: myName='get_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
@@ -309,7 +305,6 @@ ENDSUBROUTINE assemble_PETScMatrixType
 !>
 !>
 SUBROUTINE transpose_PETScMatrixType(matrix)
-  CHARACTER(LEN=*),PARAMETER :: myName='transpose_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   PetscErrorCode  :: iperr
   IF(.NOT.matrix%isAssembled) CALL matrix%assemble()
@@ -445,7 +440,6 @@ ENDSUBROUTINE matvec_PETScVector
 !> @param incx_in integer containing distance between elements in @c x
 !>
 SUBROUTINE matvec_PETSc(thisMatrix,trans,alpha,x,beta,y,uplo,diag,incx_in)
-  CHARACTER(LEN=*),PARAMETER :: myName='matvec_MatrixType'
   TYPE(PETScMatrixType),INTENT(INOUT) :: thisMatrix
   CHARACTER(LEN=1),OPTIONAL,INTENT(IN) :: trans
   REAL(SRK),INTENT(IN),OPTIONAL :: alpha
@@ -516,7 +510,6 @@ ENDSUBROUTINE matvec_PETSc
 !> matrices, or at the very least implement them using functionality of tha
 !> backing TPLs
 SUBROUTINE matmult_PETSc(A,B,C,alpha,beta,transA,transB)
-  CHARACTER(LEN=*),PARAMETER :: myName='matmult_MatrixType'
   TYPE(PETScMatrixType),INTENT(INOUT) :: A
   TYPE(PETScMatrixType),INTENT(INOUT) :: B
   TYPE(PETScMatrixType),INTENT(INOUT) :: C
@@ -593,7 +586,6 @@ ENDSUBROUTINE matmult_PETSc
 !>
 !>
 SUBROUTINE zeroentries_PETScMatrixType(matrix)
-  CHARACTER(LEN=*),PARAMETER :: myName='zeroentries_PETScMatrixType'
   CLASS(PETScMatrixType),INTENT(INOUT) :: matrix
   PetscErrorCode  :: ierr
   REQUIRE(matrix%isInit)

--- a/src/Sorting.f90
+++ b/src/Sorting.f90
@@ -507,14 +507,13 @@ ENDSUBROUTINE insert_sort_real
       INTEGER(SIK) :: i,j,n,val
 
       n=SIZE(vals)
-
       DO i=2,n
-        key = keys(i)
-        val = vals(i)
+        key=keys(i)
+        val=vals(i)
         j=i-1
         DO WHILE(keys(j) > key)
-          keys(j+1) = keys(j)
-          vals(j+1) = vals(j)
+          keys(j+1)=keys(j)
+          vals(j+1)=vals(j)
           j=j-1
           IF (j < 1) EXIT
         ENDDO

--- a/src/Sorting.f90
+++ b/src/Sorting.f90
@@ -27,6 +27,9 @@ INTERFACE sort
   !> @copybrief Sorting::qsort_1DInt
   !> @copydetails Sorting::qsort_1DInt
   MODULE PROCEDURE qsort_1DInt
+  !> @copybrief Sorting::qsort_1DLong_1DInt
+  !> @copydetails Sorting::qsort_1DLong_1DInt
+  MODULE PROCEDURE qsort_1DLong_1DInt
   !> @copybrief Sorting::bubble_sort_2DInt
   !> @copydetails Sorting::bubble_sort_2DInt
   MODULE PROCEDURE bubble_sort_2DInt
@@ -54,6 +57,9 @@ INTERFACE insert_sort
   !> @copybrief Sorting::insert_sort_real
   !> @copydetails Sorting::insert_sort_real
   MODULE PROCEDURE insert_sort_real
+  !> @copybrief Sorting::insert_sort_1DLong_1DInt
+  !> @copydetails Sorting::insert_sort_1DLong_1DInt
+  MODULE PROCEDURE insert_sort_1DLong_1DInt
 ENDINTERFACE insert_sort
 
 
@@ -489,6 +495,35 @@ PURE SUBROUTINE insert_sort_real(list)
 ENDSUBROUTINE insert_sort_real
 !
 !-------------------------------------------------------------------------------
+!> @brief Sorts a list of long keys and integer values using the insert sort
+!>        algorithm
+!> @param keys the key values to sort over
+!> @param vals the data values to move with key
+    PURE SUBROUTINE insert_sort_1DLong_1DInt(keys,vals)
+      INTEGER(SLK),INTENT(INOUT) :: keys(:)
+      INTEGER(SIK),INTENT(INOUT) :: vals(:)
+      !
+      INTEGER(SLK) :: key
+      INTEGER(SIK) :: i,j,n,val
+
+      n=SIZE(vals)
+
+      DO i=2,n
+        key = keys(i)
+        val = vals(i)
+        j=i-1
+        DO WHILE(keys(j) > key)
+          keys(j+1) = keys(j)
+          vals(j+1) = vals(j)
+          j=j-1
+          IF (j < 1) EXIT
+        ENDDO
+        keys(j+1)=key
+        vals(j+1)=val
+      ENDDO
+    ENDSUBROUTINE insert_sort_1DLong_1DInt
+!
+!-------------------------------------------------------------------------------
 !  QuickSort
 !-------------------------------------------------------------------------------
 !> @brief QuickSort 1D integer array
@@ -550,6 +585,85 @@ PURE SUBROUTINE partition_array_1DInt(A,p,i)
   i=i-1
   CALL swap_int(A,1,i)
 ENDSUBROUTINE partition_array_1DInt
+
+!
+!-------------------------------------------------------------------------------
+!> @brief Quicksort 1D array of Ints and apply same sorting operations to
+!> 1D array of Reals
+!> @param keys Integers to sort over
+!> @param values ints to sort based on keys
+PURE RECURSIVE SUBROUTINE qsort_1DLong_1DInt(keys, values)
+  INTEGER(SLK),INTENT(INOUT) :: keys(:)
+  INTEGER(SIK),INTENT(INOUT) :: values(:)
+
+  INTEGER(SIK) :: n,l,p,c
+
+  n=SIZE(values)
+
+  IF (n>50) THEN
+    !median of 3 pivot
+    c=n/2+1
+    IF (keys(c) < keys(1)) THEN
+      CALL swap_long(keys,c,1)
+      CALL swap_int(values,c,1)
+    END IF
+    IF (keys(n) < keys(1)) THEN
+      CALL swap_long(keys,1,n)
+      CALL swap_int(values,1,n)
+    END IF
+    IF (keys(n) < keys(c)) THEN
+      CALL swap_long(keys,c,n)
+      CALL swap_int(values,c,n)
+    END IF
+    p=c
+    CALL partition_array_qsort_1DLong_1DInt(keys,values,p,l)
+    CALL qsort_1DLong_1DInt(keys(1:l-1),values(1:l-1))
+    CALL qsort_1DLong_1DInt(keys(l+1:n),values(l+1:n))
+  ELSE
+    CALL insert_sort_1DLong_1DInt(keys,values)
+  ENDIF
+ENDSUBROUTINE qsort_1DLong_1DInt
+!
+!-------------------------------------------------------------------------------
+!> @brief Partition method 1D integer key array and associated 1D int
+!>         array. For a given partion, sorts values greater than and less than
+!>         the partition
+!> @param keys 1D integer array, modified in place and returned partioned
+!> @param values 1D int array, modified in place and returned partioned
+!> @param p Index of array element to partition with
+!> @param i Index of the partition element once A is partitioned
+!>
+PURE SUBROUTINE partition_array_qsort_1DLong_1DInt(keys,values,p,i)
+  INTEGER(SLK),INTENT(INOUT) :: keys(:)
+  INTEGER(SIK),INTENT(INOUT) :: values(:)
+  INTEGER(SIK),INTENT(IN) :: p
+  INTEGER(SIK),INTENT(OUT) :: i
+
+  INTEGER(SIK) :: j,n
+  INTEGER(SLK) :: pval
+
+  pval=keys(p)
+  n=SIZE(values)
+  IF (p>1) THEN
+    ! if Mo3 sort, 1st element is smaller than pivot, don't throw away
+    CALL swap_long(keys,1,2)
+    CALL swap_int(values,1,2)
+    CALL swap_long(keys,1,p)
+    CALL swap_int(values,1,p)
+  ENDIF
+
+  i=2
+  DO j=2,n
+    IF (keys(j)<pval) THEN
+      CALL swap_long(keys,i,j)
+      CALL swap_int(values,i,j)
+      i=i+1
+    ENDIF
+  ENDDO
+  i=i-1
+  CALL swap_long(keys,1,i)
+  CALL swap_int(values,1,i)
+ENDSUBROUTINE partition_array_qsort_1DLong_1DInt
 !
 !-------------------------------------------------------------------------------
 !> @brief Swap location of 2 locations in 1D integer array.
@@ -567,6 +681,23 @@ PURE SUBROUTINE swap_int(A,i,j)
   A(i)=A(j)
   A(j)=tmp
 ENDSUBROUTINE swap_int
+!
+!-------------------------------------------------------------------------------
+!> @brief Swap location of 2 locations in 1D long integer array.
+!> @param A 1D integer array, modified in place and returned partioned
+!> @param i Index of location 1
+!> @param j Index of location 2
+!>
+
+PURE SUBROUTINE swap_long(A,i,j)
+  INTEGER(SLK),INTENT(INOUT) :: A(:)
+  INTEGER(SIK),INTENT(IN) :: i
+  INTEGER(SIK),INTENT(IN) :: j
+  INTEGER(SLK) :: tmp
+  tmp=A(i)
+  A(i)=A(j)
+  A(j)=tmp
+ENDSUBROUTINE swap_long
 !
 !-------------------------------------------------------------------------------
 !> @brief QuickSort 1D real array

--- a/src/Sorting.f90
+++ b/src/Sorting.f90
@@ -606,15 +606,15 @@ PURE RECURSIVE SUBROUTINE qsort_1DLong_1DInt(keys, values)
     IF (keys(c) < keys(1)) THEN
       CALL swap_long(keys,c,1)
       CALL swap_int(values,c,1)
-    END IF
+    ENDIF
     IF (keys(n) < keys(1)) THEN
       CALL swap_long(keys,1,n)
       CALL swap_int(values,1,n)
-    END IF
+    ENDIF
     IF (keys(n) < keys(c)) THEN
       CALL swap_long(keys,c,n)
       CALL swap_int(values,c,n)
-    END IF
+    ENDIF
     p=c
     CALL partition_array_qsort_1DLong_1DInt(keys,values,p,l)
     CALL qsort_1DLong_1DInt(keys(1:l-1),values(1:l-1))

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -225,7 +225,7 @@ SUBROUTINE VectorFactory(vector, params)
 
   IF(ASSOCIATED(vector)) THEN
     CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-      "Vector pointer is already allocated")
+        "Vector pointer is already allocated")
     RETURN
   ENDIF
 
@@ -239,23 +239,23 @@ SUBROUTINE VectorFactory(vector, params)
   ENDIF
 
   IF(params%has("VectorType->vecType")) THEN
-    CALL params%get("VectorType->vecType", vecType)
+    CALL params%get("VectorType->vecType",vecType)
   ENDIF
 
   SELECTCASE(engine)
-    CASE(VM_NATIVE)
-      SELECTCASE(vecType)
-        CASE(REAL_NATIVE)
-          ALLOCATE(RealVectorType :: vector)
+  CASE(VM_NATIVE)
+    SELECTCASE(vecType)
+    CASE(REAL_NATIVE)
+      ALLOCATE(RealVectorType :: vector)
 #ifdef HAVE_MPI
-        CASE(DISTRIBUTED_NATIVE)
-          ALLOCATE(NativeDistributedVectorType :: vector)
+    CASE(DISTRIBUTED_NATIVE)
+      ALLOCATE(NativeDistributedVectorType :: vector)
 #endif
-        CASE DEFAULT
-          CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-               "Unrecognized vector type requested")
-        ENDSELECT
-    CASE(VM_PETSC)
+    CASE DEFAULT
+      CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
+          "Unrecognized vector type requested")
+    ENDSELECT
+  CASE(VM_PETSC)
 #ifdef FUTILITY_HAVE_PETSC
     ALLOCATE(PETScVectorType :: vector)
 #endif
@@ -297,49 +297,49 @@ SUBROUTINE VectorResemble(dest, source, params)
 
   IF(.NOT. ASSOCIATED(source)) THEN
     CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-      "Source vector is not associated")
+        "Source vector is not associated")
     RETURN
   ENDIF
 
   IF(.NOT. source%isInit) THEN
     CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-      "Source vector is not initialized")
+        "Source vector is not initialized")
   ENDIF
 
   IF(ASSOCIATED(dest)) THEN
     CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-      "Destination vector is already associated")
+        "Destination vector is already associated")
     RETURN
   ENDIF
 
   IF(.NOT. params%has("VectorType->n")) THEN
     CALL params%add("VectorType->n",source%n)
   ENDIF
-  SELECTTYPE(source)
-    CLASS IS(DistributedVectorType)
-      IF(.NOT. params%has("VectorType->nlocal")) THEN
-        CALL params%add("VectorType->nlocal",source%nlocal)
-      ENDIF
-      IF(.NOT. params%has("VectorType->MPI_Comm_Id")) THEN
-        CALL params%add("VectorType->MPI_Comm_Id",source%comm)
-      ENDIF
+  SELECT TYPE(source)
+  CLASS IS(DistributedVectorType)
+    IF(.NOT. params%has("VectorType->nlocal")) THEN
+      CALL params%add("VectorType->nlocal",source%nlocal)
+    ENDIF
+    IF(.NOT. params%has("VectorType->MPI_Comm_Id")) THEN
+      CALL params%add("VectorType->MPI_Comm_Id",source%comm)
+    ENDIF
 #ifdef HAVE_MPI
-    TYPE IS(NativeDistributedVectorType)
-      IF(.NOT. params%has("VectorType->chunkSize")) THEN
-        CALL params%add("VectorType->chunkSize",source%chunkSize)
-      ENDIF
-      IF(.NOT. params%has("VectorType->MPI_Comm_Id")) THEN
-        CALL params%add("VectorType->MPI_Comm_Id",source%comm)
-      ENDIF
+  TYPE IS(NativeDistributedVectorType)
+    IF(.NOT. params%has("VectorType->chunkSize")) THEN
+      CALL params%add("VectorType->chunkSize",source%chunkSize)
+    ENDIF
+    IF(.NOT. params%has("VectorType->MPI_Comm_Id")) THEN
+      CALL params%add("VectorType->MPI_Comm_Id",source%comm)
+    ENDIF
 #endif
   ENDSELECT
 
-  SELECTTYPE(source)
-    TYPE IS(RealVectorType)
-      ALLOCATE(RealVectorType :: dest)
+  SELECT TYPE(source)
+  TYPE IS(RealVectorType)
+    ALLOCATE(RealVectorType :: dest)
 #ifdef HAVE_MPI
-    TYPE IS(NativeDistributedVectorType)
-      ALLOCATE(NativeDistributedVectorType :: dest)
+  TYPE IS(NativeDistributedVectorType)
+    ALLOCATE(NativeDistributedVectorType :: dest)
 #endif
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
@@ -370,7 +370,7 @@ FUNCTION asum_VectorType(thisVector,n,incx) RESULT(r)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   REAL(SRK) :: r
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
     IF(PRESENT(n) .AND. PRESENT(incx)) THEN
       r=BLAS1_asum(n,thisVector%b,incx)
@@ -419,8 +419,8 @@ SUBROUTINE axpy_scalar_VectorType(thisVector,newVector,a,n,incx,incy)
   alpha=1._SRK
   IF(PRESENT(a)) alpha=a
 
-  SELECTTYPE(thisVector); TYPE IS(RealVectorType)
-    SELECTTYPE(newVector); TYPE IS(RealVectorType)
+  SELECT TYPE(thisVector); TYPE IS(RealVectorType)
+    SELECT TYPE(newVector); TYPE IS(RealVectorType)
       IF(PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
         CALL BLAS1_axpy(n,alpha,thisVector%b,incx,newVector%b,incy)
       ELSEIF(.NOT. PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
@@ -441,7 +441,7 @@ SUBROUTINE axpy_scalar_VectorType(thisVector,newVector,a,n,incx,incy)
     ENDSELECT
 #ifdef HAVE_MPI
   TYPE IS(NativeDistributedVectorType)
-    SELECTTYPE(newVector); TYPE IS(NativeDistributedVectorType)
+    SELECT TYPE(newVector); TYPE IS(NativeDistributedVectorType)
       IF(PRESENT(incx) .AND. PRESENT(incy)) THEN
         CALL BLAS1_axpy(SIZE(thisVector%b),alpha,thisVector%b,incx,newVector%b,incy)
       ELSEIF(PRESENT(incx) .AND. .NOT.PRESENT(incy)) THEN
@@ -455,7 +455,7 @@ SUBROUTINE axpy_scalar_VectorType(thisVector,newVector,a,n,incx,incy)
 #endif
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(PETScVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble(iperr)
       IF(iperr == 0) CALL VecAXPY(newVector%b,alpha,thisVector%b,iperr)
@@ -463,7 +463,7 @@ SUBROUTINE axpy_scalar_VectorType(thisVector,newVector,a,n,incx,incy)
 #endif
 #ifdef FUTILITY_HAVE_Trilinos
   TYPE IS(TrilinosVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(TrilinosVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble()
       CALL ForPETRA_VecAXPY(newVector%b,thisVector%b,alpha,1.0_SRK)
@@ -499,11 +499,11 @@ SUBROUTINE axpy_vector_VectorType(thisVector,newVector,aVector,n,incx,incy)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incy
   REAL(SRK),ALLOCATABLE :: tmpthis(:),tmpnew(:),tmpa(:)
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(RealVectorType)
-      SELECTTYPE(aVector)
+      SELECT TYPE(aVector)
       TYPE IS(RealVectorType)
         ALLOCATE(tmpthis(thisVector%n))
         ALLOCATE(tmpnew(newVector%n))
@@ -515,9 +515,9 @@ SUBROUTINE axpy_vector_VectorType(thisVector,newVector,aVector,n,incx,incy)
     ENDSELECT
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(PETScVectorType)
-      SELECTTYPE(aVector)
+      SELECT TYPE(aVector)
       TYPE IS(PETScVectorType)
         ALLOCATE(tmpthis(thisVector%n))
         ALLOCATE(tmpnew(newVector%n))
@@ -569,8 +569,8 @@ SUBROUTINE copy_VectorType(thisVector,newVector,n,incx,incy)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incy
 
-  SELECTTYPE(thisVector); TYPE IS(RealVectorType)
-    SELECTTYPE(newVector); TYPE IS(RealVectorType)
+  SELECT TYPE(thisVector); TYPE IS(RealVectorType)
+    SELECT TYPE(newVector); TYPE IS(RealVectorType)
       IF(PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
         CALL BLAS1_copy(n,thisVector%b,incx,newVector%b,incy)
       ELSEIF(.NOT.PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
@@ -591,7 +591,7 @@ SUBROUTINE copy_VectorType(thisVector,newVector,n,incx,incy)
     ENDSELECT
 #ifdef HAVE_MPI
   TYPE IS(NativeDistributedVectorType)
-    SELECTTYPE(newVector); TYPE IS(NativeDistributedVectorType)
+    SELECT TYPE(newVector); TYPE IS(NativeDistributedVectorType)
       IF(PRESENT(incx) .AND. PRESENT(incy)) THEN
         CALL BLAS1_copy(thisVector%b,incx,newVector%b,incy)
       ELSEIF(PRESENT(incx) .AND. .NOT.PRESENT(incy)) THEN
@@ -605,7 +605,7 @@ SUBROUTINE copy_VectorType(thisVector,newVector,n,incx,incy)
 #endif
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(PETScVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble(iperr)
       IF(iperr == 0) CALL VecCopy(thisVector%b,newVector%b,iperr)
@@ -613,7 +613,7 @@ SUBROUTINE copy_VectorType(thisVector,newVector,n,incx,incy)
 #endif
 #ifdef FUTILITY_HAVE_Trilinos
   TYPE IS(TrilinosVectorType)
-    SELECTTYPE(newVector)
+    SELECT TYPE(newVector)
     TYPE IS(TrilinosVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble()
       CALL ForPETRA_VecCopy(newVector%b,thisVector%b)
@@ -646,8 +646,8 @@ FUNCTION dot_VectorType(thisVector,thatVector,n,incx,incy)  RESULT(r)
 #ifdef HAVE_MPI
   INTEGER(SIK) :: mpierr
 #endif
-  SELECTTYPE(thisVector); TYPE IS(RealVectorType)
-    SELECTTYPE(thatVector); TYPE IS(RealVectorType)
+  SELECT TYPE(thisVector); TYPE IS(RealVectorType)
+    SELECT TYPE(thatVector); TYPE IS(RealVectorType)
       IF(PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
         r=BLAS1_dot(n,thisVector%b,incx,thatVector%b,incy)
       ELSEIF(.NOT.PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
@@ -668,7 +668,7 @@ FUNCTION dot_VectorType(thisVector,thatVector,n,incx,incy)  RESULT(r)
     ENDSELECT
 #ifdef HAVE_MPI
   TYPE IS(NativeDistributedVectorType)
-    SELECTTYPE(thatVector); TYPE IS(NativeDistributedVectorType)
+    SELECT TYPE(thatVector); TYPE IS(NativeDistributedVectorType)
       IF(PRESENT(incx) .AND. PRESENT(incy)) THEN
         r=BLAS1_dot(thisVector%b,incx,thatVector%b,incy)
       ELSEIF(PRESENT(incx) .AND. .NOT.PRESENT(incy)) THEN
@@ -683,7 +683,7 @@ FUNCTION dot_VectorType(thisVector,thatVector,n,incx,incy)  RESULT(r)
 #endif
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(thatVector)
+    SELECT TYPE(thatVector)
     TYPE IS(PETScVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble(iperr)
       IF(iperr == 0) CALL VecTDot(thisVector%b,thatVector%b,r,iperr)
@@ -712,7 +712,7 @@ FUNCTION iamax_VectorType(thisVector,n,incx)  RESULT(imax)
   REAL(SRK),ALLOCATABLE :: tmpthis(:)
   INTEGER(SIK) :: imax
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
     ALLOCATE(tmpthis(thisVector%n))
     CALL thisVector%get(tmpthis)
@@ -755,7 +755,7 @@ FUNCTION iamin_VectorType(thisVector,n,incx)  RESULT(imin)
   REAL(SRK),ALLOCATABLE :: tmpthis(:)
   INTEGER(SIK) :: imin
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
     ALLOCATE(tmpthis(thisVector%n))
     CALL thisVector%get(tmpthis)
@@ -799,7 +799,7 @@ FUNCTION nrm2_VectorType(thisVector,n,incx)  RESULT(norm2)
   INTEGER(SIK) :: mpierr
 #endif
 
-  SELECTTYPE(thisVector); TYPE IS(RealVectorType)
+  SELECT TYPE(thisVector); TYPE IS(RealVectorType)
     IF(PRESENT(n) .AND. PRESENT(incx)) THEN
       norm2=BLAS1_nrm2(n,thisVector%b,incx)
     ELSEIF(.NOT.PRESENT(n) .AND. PRESENT(incx)) THEN
@@ -851,7 +851,7 @@ SUBROUTINE scal_scalar_VectorType(thisVector,a,n,incx)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: n
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
     IF(PRESENT(n) .AND. PRESENT(incx)) THEN
       CALL BLAS1_scal(n,a,thisVector%b,incx)
@@ -893,9 +893,9 @@ SUBROUTINE scal_vector_VectorType(thisVector,aVector,n,incx)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   REAL(SRK),ALLOCATABLE :: tmpthis(:),tmpa(:)
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
-    SELECTTYPE(aVector)
+    SELECT TYPE(aVector)
     TYPE IS(RealVectorType)
       ALLOCATE(tmpthis(thisVector%n))
       ALLOCATE(tmpa(aVector%n))
@@ -904,7 +904,7 @@ SUBROUTINE scal_vector_VectorType(thisVector,aVector,n,incx)
     ENDSELECT
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(aVector)
+    SELECT TYPE(aVector)
     TYPE IS(PETScVectorType)
       ALLOCATE(tmpthis(thisVector%n))
       ALLOCATE(tmpa(aVector%n))
@@ -949,9 +949,9 @@ SUBROUTINE swap_VectorType(thisVector,thatVector,n,incx,incy)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incy
 
-  SELECTTYPE(thisVector)
+  SELECT TYPE(thisVector)
   TYPE IS(RealVectorType)
-    SELECTTYPE(thatVector)
+    SELECT TYPE(thatVector)
     TYPE IS(RealVectorType)
       IF(PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
         CALL BLAS1_swap(n,thisVector%b,incx,thatVector%b,incy)
@@ -973,7 +973,7 @@ SUBROUTINE swap_VectorType(thisVector,thatVector,n,incx,incy)
     ENDSELECT
 #ifdef FUTILITY_HAVE_PETSC
   TYPE IS(PETScVectorType)
-    SELECTTYPE(thatVector)
+    SELECT TYPE(thatVector)
     TYPE IS(PETScVectorType)
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble(iperr)
       IF(.NOT.thatVector%isAssembled) CALL thatVector%assemble(iperr)

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -253,7 +253,7 @@ SUBROUTINE VectorFactory(vector, params)
 #endif
         CASE DEFAULT
           CALL eVectorType%raiseError(modName//"::"//myName//" - "// &
-            "Unrecognized vector type requested")
+               "Unrecognized vector type requested")
         ENDSELECT
     CASE(VM_PETSC)
 #ifdef FUTILITY_HAVE_PETSC
@@ -643,8 +643,9 @@ FUNCTION dot_VectorType(thisVector,thatVector,n,incx,incy)  RESULT(r)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incy
   REAL(SRK) :: r
+#ifdef HAVE_MPI
   INTEGER(SIK) :: mpierr
-
+#endif
   SELECTTYPE(thisVector); TYPE IS(RealVectorType)
     SELECTTYPE(thatVector); TYPE IS(RealVectorType)
       IF(PRESENT(n) .AND. PRESENT(incx) .AND. PRESENT(incy)) THEN
@@ -794,7 +795,9 @@ FUNCTION nrm2_VectorType(thisVector,n,incx)  RESULT(norm2)
   INTEGER(SIK),INTENT(IN),OPTIONAL :: n
   INTEGER(SIK),INTENT(IN),OPTIONAL :: incx
   REAL(SRK) :: norm2
+#ifdef HAVE_MPI
   INTEGER(SIK) :: mpierr
+#endif
 
   SELECTTYPE(thisVector); TYPE IS(RealVectorType)
     IF(PRESENT(n) .AND. PRESENT(incx)) THEN

--- a/src/VectorTypes_Base.f90
+++ b/src/VectorTypes_Base.f90
@@ -261,11 +261,15 @@ LOGICAL(SBK),SAVE :: VectorType_Paramsflag=.FALSE.
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Real Vector Type.
-TYPE(ParamType),PROTECTED,SAVE :: RealVectorType_reqParams,RealVectorType_optParams,NativeDistributedVectorType_reqParams,NativeDistributedVectorType_optParams
+TYPE(ParamType),PROTECTED,SAVE :: RealVectorType_reqParams, &
+                                  RealVectorType_optParams, &
+                                  NativeDistributedVectorType_reqParams, &
+                                  NativeDistributedVectorType_optParams
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Distributed Vector Type.
-TYPE(ParamType),PROTECTED,SAVE :: DistributedVectorType_reqParams,DistributedVectorType_optParams
+TYPE(ParamType),PROTECTED,SAVE :: DistributedVectorType_reqParams, &
+                                  DistributedVectorType_optParams
 
 !> Exception Handler for use in VectorTypes
 TYPE(ExceptionHandlerType),SAVE :: eVectorType

--- a/src/VectorTypes_Base.f90
+++ b/src/VectorTypes_Base.f90
@@ -43,7 +43,9 @@ PUBLIC :: VectorType
 PUBLIC :: DistributedVectorType
 PUBLIC :: RealVectorType_reqParams,RealVectorType_optParams
 PUBLIC :: DistributedVectorType_reqParams,DistributedVectorType_optParams
+PUBLIC :: NativeDistributedVectorType_reqParams,NativeDistributedVectorType_optParams
 PUBLIC :: VectorType_Paramsflag
+INTEGER(SIK),PARAMETER,PUBLIC :: REAL_NATIVE=0,DISTRIBUTED_NATIVE=1
 PUBLIC :: VectorType_Declare_ValidParams
 PUBLIC :: VectorType_Clear_ValidParams
 
@@ -259,7 +261,7 @@ LOGICAL(SBK),SAVE :: VectorType_Paramsflag=.FALSE.
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Real Vector Type.
-TYPE(ParamType),PROTECTED,SAVE :: RealVectorType_reqParams,RealVectorType_optParams
+TYPE(ParamType),PROTECTED,SAVE :: RealVectorType_reqParams,RealVectorType_optParams,NativeDistributedVectorType_reqParams,NativeDistributedVectorType_optParams
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Distributed Vector Type.
@@ -283,10 +285,11 @@ CONTAINS
 !> The optional parameters for the Distributed Vector Type do not exist.
 !>
 SUBROUTINE VectorType_Declare_ValidParams()
-  INTEGER(SIK) :: n,MPI_Comm,nlocal
+  INTEGER(SIK) :: n,MPI_Comm,nlocal,chunkSize
 
   !Setup the required and optional parameter lists
   n=1
+  chunkSize =1
   MPI_Comm=1
   nlocal=-1
   !Real Vector Type - Required
@@ -298,6 +301,13 @@ SUBROUTINE VectorType_Declare_ValidParams()
 
   !There are no optional parameters at this time.
   CALL DistributedVectorType_optParams%add('VectorType->nlocal',nlocal)
+
+  !Native Distributed vector - Required
+  CALL NativeDistributedVectorType_reqParams%add('VectorType->n',n)
+  CALL NativeDistributedVectorType_reqParams%add('VectorType->MPI_Comm_ID',MPI_Comm)
+
+  CALL NativeDistributedVectorType_optParams%add('VectorType->chunkSize',chunkSize)
+  CALL NativeDistributedVectorType_optParams%add('VectorType->nlocal',nlocal)
 
   !Set flag to true since the defaults have been set for this type.
   VectorType_Paramsflag=.TRUE.
@@ -320,7 +330,8 @@ SUBROUTINE VectorType_Clear_ValidParams()
   !There are no optional parameters at this time.
   CALL DistributedVectorType_optParams%clear()
 
+  CALL NativeDistributedVectorType_reqParams%clear()
+  CALL NativeDistributedVectorType_optParams%clear()
+
 ENDSUBROUTINE VectorType_Clear_ValidParams
-
-
 ENDMODULE

--- a/src/VectorTypes_Base.f90
+++ b/src/VectorTypes_Base.f90
@@ -262,14 +262,13 @@ LOGICAL(SBK),SAVE :: VectorType_Paramsflag=.FALSE.
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Real Vector Type.
 TYPE(ParamType),PROTECTED,SAVE :: RealVectorType_reqParams, &
-                                  RealVectorType_optParams, &
-                                  NativeDistributedVectorType_reqParams, &
-                                  NativeDistributedVectorType_optParams
+    RealVectorType_optParams,NativeDistributedVectorType_reqParams, &
+    NativeDistributedVectorType_optParams
 
 !> The parameter lists to use when validating a parameter list for
 !> initialization for the Distributed Vector Type.
 TYPE(ParamType),PROTECTED,SAVE :: DistributedVectorType_reqParams, &
-                                  DistributedVectorType_optParams
+    DistributedVectorType_optParams
 
 !> Exception Handler for use in VectorTypes
 TYPE(ExceptionHandlerType),SAVE :: eVectorType

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -745,54 +745,11 @@ SUBROUTINE getRange_NativeDistributedVectorType(thisVector,istt,istp,getval,ierr
   ENDIF
 
 ENDSUBROUTINE getRange_NativeDistributedVectorType
-#endif
-
-  REQUIRE(thisVector%isInit)
-  REQUIRE(0 < istt .AND. istt <= istp .AND. istp <= thisVector%n)
-  REQUIRE(istp - istt+1 == SIZE(getVal))
-
-  srcLow = MAX(istt,thisVector%offset+1) - thisVector%offset
-  srcHigh = MIN(istp,thisVector%offset+thisVector%nlocal) - thisVector%offset
-  IF(istt > thisVector%offset) THEN
-    destLow = 1
-  ELSE
-    destLow = thisVector%offset - istt + 2
-  ENDIF
-  IF(istp <= thisVector%offset + thisVector%nlocal) THEN
-    destHigh = istp - istt + 1
-  ELSE
-    destHigh = istp - istt + 1 - (istp - thisVector%offset - thisVector%nlocal)
-  ENDIF
-
-  getval(destLow:destHigh) = thisVector%b(srcLow:srcHigh)
-
-  ierrc = 0
-
-  IF(PRESENT(ierr)) ierr=ierrc
-ENDSUBROUTINE getRange_NativeDistributedVectorType
-
-SUBROUTINE inLocalMem_single_NativeDistributedVectorType(thisVector,i,ret,ierr)
-  CLASS(NativeDistributedVectorType),INTENT(INOUT) :: thisVector
-  INTEGER(SIK),INTENT(IN) :: i
-  LOGICAL(SBK),INTENT(OUT) :: ret
-  INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
-  INTEGER(SIK) :: ierrc
-
-  ierrc=-1
-  IF(thisVector%isInit) THEN
-    ierrc = 0
-    IF(i > thisVector%offset .AND. i <= thisVector%offset + thisVector%nlocal) THEN
-      ret = .TRUE.
-    ELSE
-      ret = .FALSE.
-    END IF
-  END IF
-  IF(PRESENT(ierr)) ierr = ierrc
-ENDSUBROUTINE inLocalMem_single_NativeDistributedVectorType
 
 SUBROUTINE assemble_NativeDistributedVectorType(thisVector,ierr)
   CLASS(NativeDistributedVectorType),INTENT(INOUT) :: thisVector
   INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
 ENDSUBROUTINE
 #endif
+
 END MODULE VectorTypes_Native

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -443,14 +443,15 @@ SUBROUTINE init_NativeDistributedVectorType(thisVector,Params)
 
   !Validate against the reqParams and OptParams
   validParams=Params
-  CALL validParams%validate(NativeDistributedVectorType_reqParams,NativeDistributedVectorType_optParams)
+  CALL validParams%validate(NativeDistributedVectorType_reqParams, &
+      NativeDistributedVectorType_optParams)
 
   !Pull Data from Parameter List
   CALL validParams%get('VectorType->n',n)
   CALL validParams%get('VectorType->MPI_Comm_ID',comm)
   CALL validParams%get('VectorType->nlocal',nlocal)
 
-  chunksize = 1
+  chunksize=1
   IF (validParams%has('VectorType->chunkSize')) THEN
     CALL validParams%get('VectorType->chunkSize',chunkSize)
   ENDIF
@@ -458,12 +459,12 @@ SUBROUTINE init_NativeDistributedVectorType(thisVector,Params)
   REQUIRE(.NOT. thisVector%isInit)
   REQUIRE(n > 1)
   REQUIRE(chunkSize > 0)
-  REQUIRE(MOD(n,chunkSize)==0)
+  REQUIRE(MOD(n,chunkSize) == 0)
 
   thisVector%isInit=.TRUE.
   thisVector%n=n
-  thisVector%chunkSize = chunkSize
-  thisVector%comm = comm
+  thisVector%chunkSize=chunkSize
+  thisVector%comm=comm
 
   CALL MPI_Comm_rank(comm,rank,mpierr)
   CALL MPI_Comm_size(comm,nproc,mpierr)
@@ -471,20 +472,20 @@ SUBROUTINE init_NativeDistributedVectorType(thisVector,Params)
   ! Default to greedy partitioning, respecting chunk size
   IF (nlocal < 0) THEN
     n = n/chunkSize
-    IF(rank < MOD(n,nproc)) THEN
-      offset = (rank)*(n/nproc + 1)
-      nlocal = n/nproc + 1
+    IF (rank < MOD(n,nproc)) THEN
+      offset=(rank)*(n/nproc+1)
+      nlocal=n/nproc+1
     ELSE
-      offset = (rank)*(n/nproc) + MOD(n,nproc)
-      nlocal = n/nproc
+      offset=(rank)*(n/nproc)+MOD(n,nproc)
+      nlocal=n/nproc
     ENDIF
-    offset = offset*chunkSize
-    nlocal = nlocal*chunkSize
+    offset=offset*chunkSize
+    nlocal=nlocal*chunkSize
   ELSE
-    REQUIRE(MOD(nlocal,chunksize)==0)
+    REQUIRE(MOD(nlocal,chunksize) == 0)
     ALLOCATE(offsets(nproc))
     CALL MPI_AllGather(nlocal,1,MPI_INTEGER,offsets(1),1,MPI_INTEGER,comm,mpierr)
-    offset = SUM(offsets(1:rank))
+    offset=SUM(offsets(1:rank))
   ENDIF
 
   ALLOCATE(thisVector%b((offset+1):(offset+nlocal)))
@@ -504,7 +505,7 @@ SUBROUTINE clear_NativeDistributedVectorType(thisVector)
   thisVector%n=0
   thisVector%comm=-1
   thisVector%chunksize=1
-  IF(ALLOCATED(thisVector%b)) CALL demallocA(thisVector%b)
+  IF (ALLOCATED(thisVector%b)) CALL demallocA(thisVector%b)
 
 ENDSUBROUTINE clear_NativeDistributedVectorType
 !
@@ -524,7 +525,7 @@ SUBROUTINE setOne_NativeDistributedVectorType(thisVector,i,setval,ierr)
 
   REQUIRE(thisVector%isInit)
   REQUIRE(i >= LBOUND(thisVector%b,1) .AND. i <= UBOUND(thisVector%b,1))
-  thisVector%b(i) = setval
+  thisVector%b(i)=setval
 
 ENDSUBROUTINE setOne_NativeDistributedVectorType
 !
@@ -541,7 +542,7 @@ SUBROUTINE setAll_scalar_NativeDistributedVectorType(thisVector,setval,ierr)
   INTEGER(SIK),INTENT(OUT),OPTIONAL ::ierr
 
   REQUIRE(thisVector%isInit)
-  thisVector%b = setval
+  thisVector%b=setval
 
 ENDSUBROUTINE setAll_scalar_NativeDistributedVectorType
 !
@@ -561,9 +562,9 @@ SUBROUTINE setAll_array_NativeDistributedVectorType(thisVector,setval,ierr)
   REQUIRE(SIZE(setval) == SIZE(thisVector%b) .OR. SIZE(setval)==thisVector%n)
 
   IF (SIZE(setval) == thisVector%n) THEN
-    thisVector%b(:) = setval(LBOUND(thisVector%b,1):UBOUND(thisVector%b,1))
+    thisVector%b(:)=setval(LBOUND(thisVector%b,1):UBOUND(thisVector%b,1))
   ELSE
-    thisVector%b = setval
+    thisVector%b=setval
   ENDIF
 
 ENDSUBROUTINE setAll_array_NativeDistributedVectorType
@@ -583,10 +584,10 @@ SUBROUTINE setSelected_NativeDistributedVectorType(thisVector,indices,setval,ier
 
   REQUIRE(thisVector%isInit)
   REQUIRE(SIZE(setval) == SIZE(indices))
-  REQUIRE(ALL(indices>0) .AND. ALL(indices<=thisVector%n))
+  REQUIRE(ALL(indices>0) .AND. ALL(indices <= thisVector%n))
 
   WHERE (indices <= UBOUND(thisVector%b,1) .AND. indices >= LBOUND(thisVector%b,1)) &
-   thisVector%b(indices) = setval
+   thisVector%b(indices)=setval
 
 ENDSUBROUTINE setSelected_NativeDistributedVectorType
 
@@ -610,12 +611,11 @@ SUBROUTINE setRange_scalar_NativeDistributedVectorType(thisVector,istt,istp,setv
   REQUIRE(istt <= istp)
   REQUIRE(istt > 0 .AND. istp <=thisVector%n)
 
-  IF(istt <= UBOUND(thisVector%b,1)  .OR. istp >= LBOUND(thisVector%b,1)) THEN
-    thisVector%b(MAX(istt,UBOUND(thisVector%b,1)): &
-                 MIN(istp,LBOUND(thisVector%b,1))) = setval
-  ENDIF
+  IF(istt <= UBOUND(thisVector%b,1) .OR. istp >= LBOUND(thisVector%b,1)) &
+      thisVector%b(MAX(istt,UBOUND(thisVector%b,1)):MIN(istp,LBOUND(thisVector%b,1))) &
+      = setval
 
-END SUBROUTINE setRange_scalar_NativeDistributedVectorType
+ENDSUBROUTINE setRange_scalar_NativeDistributedVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets a range of values in the native distributed vector to
@@ -639,13 +639,12 @@ SUBROUTINE setRange_array_NativeDistributedVectorType(thisVector,istt,istp,setva
   REQUIRE(istt <= istp)
   REQUIRE(SIZE(setval)==istp-istt+1)
 
-  IF(istt <= UBOUND(thisVector%b,1) .OR. &
-     istp >= LBOUND(thisVector%b,1)) THEN
-    lowSrc = MAX(1,LBOUND(thisVector%b,1)-istt)
-    highSrc = SIZE(setval) - MAX(0,istp-UBOUND(thisVector%b,1))
-    lowDest = MAX(istt,LBOUND(thisVector%b,1))
-    highDest = MIN(istp,UBOUND(thisVector%b,1))
-    thisVector%b(lowDest:highDest) = setval(lowSrc:highSrc)
+  IF(istt <= UBOUND(thisVector%b,1) .OR. istp >= LBOUND(thisVector%b,1)) THEN
+    lowSrc=MAX(1,LBOUND(thisVector%b,1)-istt)
+    highSrc=SIZE(setval)-MAX(0,istp-UBOUND(thisVector%b,1))
+    lowDest=MAX(istt,LBOUND(thisVector%b,1))
+    highDest=MIN(istp,UBOUND(thisVector%b,1))
+    thisVector%b(lowDest:highDest)=setval(lowSrc:highSrc)
   ENDIF
 
 ENDSUBROUTINE setRange_array_NativeDistributedVectorType
@@ -664,9 +663,9 @@ SUBROUTINE getOne_NativeDistributedVectorType(thisVector,i,getval,ierr)
   INTEGER(SIK),INTENT(OUT),OPTIONAL ::ierr
 
   REQUIRE(thisVector%isInit)
-  REQUIRE(i>=LBOUND(thisVector%b,1) .AND. i<=UBOUND(thisVector%b,1))
+  REQUIRE(i >= LBOUND(thisVector%b,1) .AND. i <= UBOUND(thisVector%b,1))
 
-  getval = thisVector%b(i)
+  getval=thisVector%b(i)
 
 ENDSUBROUTINE getOne_NativeDistributedVectorType
 !
@@ -686,7 +685,7 @@ SUBROUTINE getAll_NativeDistributedVectorType(thisVector,getval,ierr)
   REQUIRE(thisVector%isInit)
   REQUIRE(SIZE(getVal) == SIZE(thisVector%b))
 
-  getval = thisVector%b(:)
+  getval=thisVector%b(:)
 
 ENDSUBROUTINE getAll_NativeDistributedVectorType
 !
@@ -710,7 +709,7 @@ SUBROUTINE getSelected_NativeDistributedVectorType(thisVector,indices,getval,ier
 
   DO i=1,SIZE(indices)
     IF (indices(i) >= LBOUND(thisVector%b,1) .AND. indices(i) <= UBOUND(thisVector%b,1)) &
-      getval(i) = thisVector%b(indices(i))
+        getval(i) = thisVector%b(indices(i))
   ENDDO
 
 ENDSUBROUTINE getSelected_NativeDistributedVectorType
@@ -734,14 +733,14 @@ SUBROUTINE getRange_NativeDistributedVectorType(thisVector,istt,istp,getval,ierr
 
   REQUIRE(thisVector%isInit)
   REQUIRE(0 < istt .AND. istt <= istp .AND. istp <= thisVector%n)
-  REQUIRE(istp - istt+1 == SIZE(getVal))
+  REQUIRE(istp-istt+1 == SIZE(getVal))
 
-  IF(istt <= UBOUND(thisVector%b,1)  .OR. istp >= LBOUND(thisVector%b,1)) THEN
-    lowDest = MAX(1,LBOUND(thisVector%b,1)-istt)
-    highDest = SIZE(getval) - MAX(0,istp-UBOUND(thisVector%b,1))
-    lowSrc = MAX(istt,LBOUND(thisVector%b,1))
-    highSrc = MIN(istp,UBOUND(thisVector%b,1))
-    getval(lowDest:highDest) = thisVector%b(lowSrc:highSrc)
+  IF(istt <= UBOUND(thisVector%b,1) .OR. istp >= LBOUND(thisVector%b,1)) THEN
+    lowDest=MAX(1,LBOUND(thisVector%b,1)-istt)
+    highDest=SIZE(getval)-MAX(0,istp-UBOUND(thisVector%b,1))
+    lowSrc=MAX(istt,LBOUND(thisVector%b,1))
+    highSrc=MIN(istp,UBOUND(thisVector%b,1))
+    getval(lowDest:highDest)=thisVector%b(lowSrc:highSrc)
   ENDIF
 
 ENDSUBROUTINE getRange_NativeDistributedVectorType
@@ -749,7 +748,8 @@ ENDSUBROUTINE getRange_NativeDistributedVectorType
 SUBROUTINE assemble_NativeDistributedVectorType(thisVector,ierr)
   CLASS(NativeDistributedVectorType),INTENT(INOUT) :: thisVector
   INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
+  ! This routine does not need to do anything
 ENDSUBROUTINE
 #endif
 
-END MODULE VectorTypes_Native
+ENDMODULE VectorTypes_Native

--- a/src/VectorTypes_Native.f90
+++ b/src/VectorTypes_Native.f90
@@ -200,6 +200,7 @@ ENDSUBROUTINE clear_RealVectorType
 !> @param thisVector the vector type to act on
 !> @param i the location in the vector to set
 !> @param setval the value to be set
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setOne_RealVectorType(thisVector,i,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -218,9 +219,10 @@ SUBROUTINE setOne_RealVectorType(thisVector,i,setval,ierr)
 ENDSUBROUTINE setOne_RealVectorType
 !
 !-------------------------------------------------------------------------------
-!> @brief Sets all values in the real vector with a scalar value
-!> @param declares the vector type to act on
+!> @brief Sets all values in the real vector to a scalar value
+!> @param thisVector the vector type to act on
 !> @param setval the scalar value to be set
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setAll_scalar_RealVectorType(thisVector,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -235,9 +237,10 @@ SUBROUTINE setAll_scalar_RealVectorType(thisVector,setval,ierr)
 ENDSUBROUTINE setAll_scalar_RealVectorType
 !
 !-------------------------------------------------------------------------------
-!> @brief Sets all the values in the real vector
-!> @param declare the vector type to act on
+!> @brief Sets all the values in the real vector to an array of values
+!> @param thisVector the vector type to act on
 !> @param setval the array of values to be set
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setAll_array_RealVectorType(thisVector,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -256,9 +259,10 @@ ENDSUBROUTINE setAll_array_RealVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets selected values in the real vector
-!> @param declare the vector type to act on
+!> @param thisVector the vector type to act on
 !> @param indices a list of indices in the vector to set
 !> @param setval the array of values to be set (must be same size as indices)
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setSelected_RealVectorType(thisVector,indices,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -274,11 +278,12 @@ ENDSUBROUTINE setSelected_RealVectorType
 
 !
 !-------------------------------------------------------------------------------
-!> @brief Sets a range of values in the real vector with a scalar value
-!> @param declare the vector type to act on
-!> @param setval the scalar value to be set
+!> @brief Sets a range of values in the real vector to a scalar value
+!> @param thisVector the vector type to act on
 !> @param istt the starting point of the range
 !> @param istp the stopping point in the range
+!> @param setval the scalar value to be set
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setRange_scalar_RealVectorType(thisVector,istt,istp,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -299,10 +304,11 @@ ENDSUBROUTINE setRange_scalar_RealVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Sets a range of values in the real vector with an array of values
-!> @param declare the vector type to act on
-!> @param setval the scalar value to be set
+!> @param thisVector the vector type to act on
 !> @param istt the starting point of the range
 !> @param istp the stopping point in the range
+!> @param setval the array of values to set to
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE setRange_array_RealVectorType(thisVector,istt,istp,setval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -326,8 +332,10 @@ ENDSUBROUTINE setRange_array_RealVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets one value in the real vector
-!> @param declares the vector type to act on
-!> @param i the ith location in the vector
+!> @param thisVector the vector type to act on
+!> @param i the vector location to access
+!> @param getval the variable to store the vector element
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE getOne_RealVectorType(thisVector,i,getval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -347,10 +355,10 @@ ENDSUBROUTINE getOne_RealVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets all values in the real vector
-!> Works on serial vectors only, meaning the indices used to extract data from the vector
-!> are 1->N, where N is the size of the vector.
-!> @param declares the vector type to act on
-!> @param getval Correctly sized array that will be filled with contents of this vector
+!> @param thisVector the vector type to act on
+!> @param getval Correctly sized array that will be filled with vector contents
+!> @param ierr optional error code return (not used for native types)
+!>
 SUBROUTINE getAll_RealVectorType(thisVector,getval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
   REAL(SRK),INTENT(OUT) :: getval(:)
@@ -368,9 +376,11 @@ ENDSUBROUTINE getAll_RealVectorType
 !
 !-------------------------------------------------------------------------------
 !> @brief Gets a list of selected values from the vector
-!> @param declares the vector type to act on
-!> @param indices A list of the indices in the vector
-!> @param getval Correctly sized array that will be filled with contents of this vector
+!> @param thisVector the vector type to act on
+!> @param indices A list of the indices to access
+!> @param getval Correctly sized array that will be filled with vector contents
+!> @param ierr optional error code return (not used for native types)
+!>
 SUBROUTINE getSelected_RealVectorType(thisVector,indices,getval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
   INTEGER(SIK),INTENT(IN) :: indices(:)
@@ -390,6 +400,8 @@ ENDSUBROUTINE getSelected_RealVectorType
 !> @param declares the vector type to act on
 !> @param istt the starting point of the range
 !> @param istp the stopping point in the range
+!> @param getval Correctly sized array to be filled with contents in range
+!> @param ierr optional error code return (not used for native types)
 !>
 SUBROUTINE getRange_RealVectorType(thisVector,istt,istp,getval,ierr)
   CLASS(RealVectorType),INTENT(INOUT) :: thisVector
@@ -543,7 +555,6 @@ ENDSUBROUTINE setAll_scalar_NativeDistributedVectorType
 SUBROUTINE setAll_array_NativeDistributedVectorType(thisVector,setval,ierr)
   CLASS(NativeDistributedVectorType),INTENT(INOUT) :: thisVector
   REAL(SRK),INTENT(IN) :: setval(:)
-  INTEGER(SIK) :: i
   INTEGER(SIK),INTENT(OUT),OPTIONAL ::ierr
 
   REQUIRE(thisVector%isInit)
@@ -594,7 +605,6 @@ SUBROUTINE setRange_scalar_NativeDistributedVectorType(thisVector,istt,istp,setv
   INTEGER(SIK),INTENT(IN) :: istt
   INTEGER(SIK),INTENT(IN) :: istp
   INTEGER(SIK),INTENT(OUT),OPTIONAL ::ierr
-  INTEGER(SIK) :: low,high
 
   REQUIRE(thisVector%isInit)
   REQUIRE(istt <= istp)
@@ -720,7 +730,7 @@ SUBROUTINE getRange_NativeDistributedVectorType(thisVector,istt,istp,getval,ierr
   INTEGER(SIK),INTENT(IN) :: istp
   REAL(SRK),INTENT(OUT) :: getval(:)
   INTEGER(SIK),INTENT(OUT),OPTIONAL ::ierr
-  INTEGER(SIK) :: i, lowDest, highDest, lowSrc, highSrc
+  INTEGER(SIK) :: lowDest, highDest, lowSrc, highSrc
 
   REQUIRE(thisVector%isInit)
   REQUIRE(0 < istt .AND. istt <= istp .AND. istp <= thisVector%n)

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -130,9 +130,10 @@ SUBROUTINE testMatrix()
   CALL xTrilinosVector%init(vecPList)
   CALL yTrilinosVector%init(vecPlist)
 #endif
+  COMPONENT_TEST("sparse%clear")
   SELECTTYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
-!Test for sparse matrices
+    !Test for sparse matrices
     !test clear
     !make matrix w/out using untested init
     thisMatrix%isInit=.TRUE.
@@ -145,12 +146,12 @@ SUBROUTINE testMatrix()
     ALLOCATE(thisMatrix%a(100))
     ALLOCATE(thisMatrix%ja(100))
     thisMatrix%ia(101)=101
-ENDSELECT
+  ENDSELECT
 
-!clear it
-CALL thisMatrix%clear()
+  !clear it
+  CALL thisMatrix%clear()
 
-SELECTTYPE(thisMatrix)
+  SELECTTYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !check for success
     bool = ((thisMatrix%jPrev == 0).AND.(thisMatrix%iPrev == 0)) &
@@ -160,17 +161,16 @@ SELECTTYPE(thisMatrix)
     bool = (.NOT.ALLOCATED(thisMatrix%a) .AND. .NOT.ALLOCATED(thisMatrix%ja)) &
             .AND. .NOT.ALLOCATED(thisMatrix%ia)
     ASSERT(bool, 'sparse%clear()')
-    WRITE(*,*) '  Passed: CALL sparse%clear()'
-ENDSELECT
+  ENDSELECT
 
-!check init
-
-! build parameter list
-CALL pList%add('MatrixType->n',10_SNK)
-CALL pList%add('MatrixType->nnz',10_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%init(pList)
-SELECTTYPE(thisMatrix)
+  !check init
+  COMPONENT_TEST("sparse%init")
+  ! build parameter list
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%add('MatrixType->nnz',10_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  SELECTTYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !check for success
     bool = (((thisMatrix%isInit) .OR. (thisMatrix%jCount == 0)) &
@@ -180,80 +180,81 @@ SELECTTYPE(thisMatrix)
     bool = ((SIZE(thisMatrix%a) == 10).OR.(SIZE(thisMatrix%ja) == 10)) &
       .OR.((SIZE(thisMatrix%ia) == 11).OR.(thisMatrix%ia(11) == 11))
     ASSERT(bool, 'sparse%init(...)')
-ENDSELECT
-CALL thisMatrix%clear()
-CALL pList%clear()
+  ENDSELECT
+  CALL thisMatrix%clear()
+  CALL pList%clear()
 
-!now check init without m being provided
-CALL pList%add('MatrixType->n',10_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%init(pList) !expect exception
-bool = .NOT. thisMatrix%isInit
-ASSERT(bool, 'sparse%init(...)')
-CALL thisMatrix%clear()
+  !now check init without m being provided
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  bool = .NOT. thisMatrix%isInit
+  ASSERT(bool, 'sparse%init(...)')
+  CALL thisMatrix%clear()
 
-!init it twice so on 2nd init, isInit==.TRUE.
-CALL thisMatrix%init(pList)
-SELECTTYPE(thisMatrix)
-  TYPE IS(SparseMatrixType); thisMatrix%nnz=1
-ENDSELECT
-CALL thisMatrix%init(pList)
-SELECTTYPE(thisMatrix)
-  TYPE IS(SparseMatrixType)
-    ASSERT(thisMatrix%nnz==1, 'sparse%init(...)')
-ENDSELECT
-!init with n<1
-CALL thisMatrix%clear()
-CALL pList%clear()
-CALL pList%add('MatrixType->n',-1_SNK)
-CALL pList%add('MatrixType->nnz',10_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%init(pList) !expect exception
-ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-CALL thisMatrix%clear()
-CALL pList%clear()
-!n<1, and m not provided
-CALL pList%add('MatrixType->n',-1_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%init(pList) !expect exception
-ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-CALL thisMatrix%clear()
-CALL pList%clear()
-!init with m<1
-CALL pList%add('MatrixType->n',10_SNK)
-CALL pList%add('MatrixType->nnz',-10_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%init(pList) !expect exception
-ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-CALL thisMatrix%clear()
-WRITE(*,*) '  Passed: CALL sparse%init(...)'
-!test setShape
-!intend to make: [1 0 2]
-!                [0 0 3]
-!                [4 5 6]
-DO i=1,6
-  a_vals(i)=i
-ENDDO
-ja_vals(1)=1
-ja_vals(2)=3
-ja_vals(3)=3
-ja_vals(4)=1
-ja_vals(5)=2
-ja_vals(6)=3
-ia_vals(1)=1
-ia_vals(2)=3
-ia_vals(3)=4
-ia_vals(4)=7
+  !init it twice so on 2nd init, isInit==.TRUE.
+  CALL thisMatrix%init(pList)
+  SELECTTYPE(thisMatrix)
+    TYPE IS(SparseMatrixType); thisMatrix%nnz=1
+  ENDSELECT
+  CALL thisMatrix%init(pList)
+  SELECTTYPE(thisMatrix)
+    TYPE IS(SparseMatrixType)
+      ASSERT(thisMatrix%nnz==1, 'sparse%init(...)')
+  ENDSELECT
+  !init with n<1
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',-1_SNK)
+  CALL pList%add('MatrixType->nnz',10_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  !n<1, and m not provided
+  CALL pList%add('MatrixType->n',-1_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  !init with m<1
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%add('MatrixType->nnz',-10_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
+  CALL thisMatrix%clear()
 
-! build parameter list
-CALL pList%clear()
-CALL pList%add('MatrixType->n',3_SNK)
-CALL pList%add('MatrixType->nnz',6_SNK)
-CALL pList%validate(pList,optListMat)
-CALL thisMatrix%clear()
-CALL thisMatrix%init(pList)
+  !test setShape
+  COMPONENT_TEST("sparse%setshape")
+  !intend to make: [1 0 2]
+  !                [0 0 3]
+  !                [4 5 6]
+  DO i=1,6
+    a_vals(i)=i
+  ENDDO
+  ja_vals(1)=1
+  ja_vals(2)=3
+  ja_vals(3)=3
+  ja_vals(4)=1
+  ja_vals(5)=2
+  ja_vals(6)=3
+  ia_vals(1)=1
+  ia_vals(2)=3
+  ia_vals(3)=4
+  ia_vals(4)=7
 
-SELECTTYPE(thisMatrix)
+  ! build parameter list
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',3_SNK)
+  CALL pList%add('MatrixType->nnz',6_SNK)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%clear()
+  CALL thisMatrix%init(pList)
+
+  SELECTTYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     CALL thisMatrix%setShape(1,1,1._SRK)
     CALL thisMatrix%setShape(1,3,2._SRK)
@@ -315,7 +316,7 @@ SELECTTYPE(thisMatrix)
     DBC_COUNTER=0
 #endif
     ! Exception tests done
-
+    COMPONENT_TEST("sparse%set")
     !test set (first initialize the values w/ setShape)
     CALL thisMatrix%clear()
     CALL thisMatrix%init(pList)
@@ -348,8 +349,8 @@ SELECTTYPE(thisMatrix)
     ENDDO
   ENDSELECT
 
-
   !Test BLAS_matvec
+  COMPONENT_TEST("sparse%matvec")
   x=1.0_SRK
   y=1.0_SRK
   CALL BLAS_matvec(THISMATRIX=thisMatrix,X=x,Y=y)
@@ -393,6 +394,7 @@ SELECTTYPE(thisMatrix)
   FINFO() '-sparse'
 
   ! Set row at a time
+  COMPONENT_TEST("sparse%setrow")
   SELECT TYPE (thisMatrix)
   CLASS IS (SparseMatrixType)
     CALL thisMatrix%setRow(1, [1, 3], [11._SRK, 12._SRK])
@@ -413,6 +415,7 @@ SELECTTYPE(thisMatrix)
   ENDSELECT
 
 ! Check sparse triangular solvers
+  COMPONENT_TEST("sparse%dtrsv")
   CALL yRealVector%clear()
   CALL xRealVector%clear()
   CALL thisMatrix%clear()
@@ -568,20 +571,20 @@ SELECTTYPE(thisMatrix)
   ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N'',INXC_IN=2_SIK')
   FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
 
-  WRITE(*,*) '  Passed: CALL BLAS_matvec(...) sparse-matrix'
-
   !Test BLAS_matmult when SparseMatType is supported.
+  COMPONENT_TEST("sparse%matmult")
   CALL testMatrixMultSparse()
 
   !off-nominal tests
   !pass matrix w/out setshape
+  COMPONENT_TEST("spares%malformed")
   CALL thisMatrix%clear()
   CALL pList%clear()
   CALL pList%add('MatrixType->n',3)
   CALL pList%add('MatrixType->nnz',6)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-  TYPE IS(SparseMatrixType); CALL thisMatrix%setShape(1,1)
+  SELECTTYPE(thisMatrix); TYPE IS(SparseMatrixType)
+    CALL thisMatrix%setShape(1,1)
   ENDSELECT
 
   CALL pList%clear()
@@ -602,13 +605,13 @@ SELECTTYPE(thisMatrix)
     DO i=1,SIZE(thisMatrix%a)
       ASSERT(thisMatrix%a(i) /= 1._SRK, 'sparse%set(...)')
     ENDDO
-    WRITE(*,*) '  Passed: CALL sparse%set(...)'
   ENDSELECT
 
   !Perform test of functionality of get function
   ![1 0 2]
   ![0 0 3]
   ![4 5 6]
+  COMPONENT_TEST("sparse%get")
   CALL thisMatrix%clear()
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
@@ -644,11 +647,11 @@ SELECTTYPE(thisMatrix)
     ASSERT(bool, 'sparse%get(...)') !column three check
   ENDSELECT
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL sparse%get(...)'
   DEALLOCATE(thisMatrix)
 !
 !Test for dense square matrices
   ALLOCATE(DenseSquareMatrixType :: thisMatrix)
+  COMPONENT_TEST("dense%clear")
   SELECTTYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     !test clear
@@ -665,10 +668,10 @@ SELECTTYPE(thisMatrix)
         .AND. (.NOT.(thisMatrix%isSymmetric) &
         .AND. (.NOT.ALLOCATED(thisMatrix%a)))
     ASSERT(bool, 'densesquare%clear()')
-    WRITE(*,*) '  Passed: CALL densesquare%clear()'
   ENDSELECT
 
   !check init
+  COMPONENT_TEST("dense%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -680,7 +683,7 @@ SELECTTYPE(thisMatrix)
         .AND. (.NOT.thisMatrix%isSymmetric)
     ASSERT(bool, 'densesquare%init(...)')
     bool = (SIZE(thisMatrix%a,1) == 10) .AND. &
-        (SIZE(thisMatrix%a,2) == 10)
+           (SIZE(thisMatrix%a,2) == 10)
     ASSERT(bool, 'densesquare%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
@@ -692,7 +695,7 @@ SELECTTYPE(thisMatrix)
   SELECTTYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = ((thisMatrix%isInit) .AND. (thisMatrix%n == 10)) &
-        .AND. (thisMatrix%isSymmetric)
+            .AND. (thisMatrix%isSymmetric)
     ASSERT(bool, 'densesquare%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
@@ -702,8 +705,8 @@ SELECTTYPE(thisMatrix)
   CALL pList%add('MatrixType->isSym',.TRUE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-  TYPE IS(DenseSquareMatrixType); thisMatrix%isSymmetric=.FALSE.
+  SELECTTYPE(thisMatrix); TYPE IS(DenseSquareMatrixType)
+    thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric
   SELECTTYPE(thisMatrix)
@@ -728,8 +731,9 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%init(pList) !expect exception
   bool = .NOT.thisMatrix%isInit
   ASSERT(bool, 'densesquare%init(...)')
-  WRITE(*,*) '  Passed: CALL densesquare%init(...)'
+
   !check set
+  COMPONENT_TEST("dense%set")
   !test normal use case (symmetric and nonsymmetric)
   !want to build:
   ![1 2]
@@ -752,6 +756,7 @@ SELECTTYPE(thisMatrix)
   ENDSELECT
 
   !Test BLAS_matvec
+  COMPONENT_TEST("dense%matvec")
   x=1.0_SRK
   y=1.0_SRK
   CALL thisMatrix%clear()
@@ -823,6 +828,7 @@ SELECTTYPE(thisMatrix)
   FINFO() 'BETA=2.0_SRK,Y=yRealVector) -densesq'
 
   ! Check dense triangular solvers
+  COMPONENT_TEST("dense%dtrsv")
   CALL yRealVector%clear()
   CALL xRealVector%clear()
   CALL thisMatrix%clear()
@@ -941,8 +947,10 @@ SELECTTYPE(thisMatrix)
   ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N'',INCX_IN=-2_SIK')
   FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
 
+  COMPONENT_TEST("dense%matmult")
   CALL testMatrixMultSquare()
 
+  COMPONENT_TEST("dense%malformed")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',2_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -970,12 +978,12 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,5,1._SRK)
   !no crash? good
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL densesquare%set(...)'
 
   !Perform test of functionality of get function
   ![1 0 2]
   ![0 0 3]
   ![4 5 6]
+  COMPONENT_TEST("dense%get")
   CALL thisMatrix%clear()
   CALL pList%clear()
   CALL pList%add('MatrixType->n',3_SNK)
@@ -1036,11 +1044,11 @@ SELECTTYPE(thisMatrix)
     ASSERT(bool, 'densesquare%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL densesquare%get(...)'
   DEALLOCATE(thisMatrix)
 !
 !Test for tri-diagonal matrices
   ALLOCATE(TriDiagMatrixType :: thisMatrix)
+  COMPONENT_TEST("tridiag%clear")
   SELECTTYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     !test clear
@@ -1062,7 +1070,6 @@ SELECTTYPE(thisMatrix)
   ncnt2=e%getCounter(EXCEPTION_ERROR)
   ASSERT(ncnt2-ncnt==2, 'BLAS_matvec(...) -tridiag expected failures')
 
-
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
@@ -1070,9 +1077,10 @@ SELECTTYPE(thisMatrix)
         .AND.((.NOT.thisMatrix%isSymmetric) &
         .AND.(.NOT.ALLOCATED(thisMatrix%a)))
     ASSERT(bool, 'tridiag%clear()')
-    WRITE(*,*) '  Passed: CALL tridiag%clear()'
   ENDSELECT
+
   !check init
+  COMPONENT_TEST("tridiag%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -1106,7 +1114,7 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
   SELECTTYPE(thisMatrix)
-  TYPE IS(TriDiagMatrixType); thisMatrix%isSymmetric=.FALSE.
+    TYPE IS(TriDiagMatrixType); thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric
   SELECTTYPE(thisMatrix)
@@ -1132,8 +1140,9 @@ SELECTTYPE(thisMatrix)
   bool = .NOT.thisMatrix%isInit
   ASSERT(bool, 'tridiag%init(...)')
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL tridiag%init(...)'
+
   !check set
+  COMPONENT_TEST("tridiag%set")
   !test normal use case (symmetric and nonsymmetric)
   !want to build:
   ![1 4 0]
@@ -1214,9 +1223,9 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,5,1._SRK)
   !no crash? good
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL tridiag%set(...)'
 
   !Perform test of functionality of get function
+  COMPONENT_TEST("tridiag%get")
   ![1 2 0]
   ![4 0 3]
   ![0 5 6]
@@ -1278,1050 +1287,31 @@ SELECTTYPE(thisMatrix)
     ASSERT(bool, 'tridiag%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL tridiag%get(...)'
-  DEALLOCATE(thisMatrix)
-!
-!Test for banded matrices
-  ALLOCATE(BandedMatrixType :: thisMatrix)
-  SELECT TYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=100
-      thisMatrix%nnz=100
-      thisMatrix%jCount=100
-      thisMatrix%iPrev=100
-      thisMatrix%jPrev=100
-      ALLOCATE(thisMatrix%ia(101))
-      ALLOCATE(thisMatrix%a(100))
-      ALLOCATE(thisMatrix%ja(100))
-      thisMatrix%ia(101)=101
-  ENDSELECT
-
-  COMPONENT_TEST("sparse%clear()")
-  CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType)
-      !check for success
-      bool = ((thisMatrix%jPrev == 0).AND.(thisMatrix%iPrev == 0)) &
-        .AND.(((.NOT.thisMatrix%isInit).AND.(thisMatrix%jCount == 0)) &
-        .AND.((thisMatrix%nnz == 0).AND.(thisMatrix%n == 0)))
-      ASSERT(bool, 'sparse%clear()')
-      bool = (.NOT.ALLOCATED(thisMatrix%a) .AND. .NOT.ALLOCATED(thisMatrix%ja)) &
-              .AND. .NOT.ALLOCATED(thisMatrix%ia)
-      ASSERT(bool, 'sparse%clear()')
-  ENDSELECT
-
-  COMPONENT_TEST("sparse%init()")
-  ! build parameter list
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->m',15_SNK)
-  CALL pList%add('MatrixType->nnz',12_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 12))
-      ASSERT(bool, 'banded%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  !test with double init (isInit==true on 2nd try)
-
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType); thisMatrix%m=1
-  ENDSELECT
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      bool = thisMatrix%m == 1
-      ASSERT(bool, 'banded%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  !test with n<1
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%add('MatrixType->m',10_SNK)
-  CALL pList%add('MatrixType->nnz',12_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'banded%init(...)')
-  CALL thisMatrix%clear()
-  !test with m<1
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->m',-1_SNK)
-  CALL pList%add('MatrixType->nnz',12_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'banded%init(...)')
-  CALL thisMatrix%clear()
-  !test with nnz<1
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->m',15_SNK)
-  CALL pList%add('MatrixType->nnz',-1_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-  CALL thisMatrix%clear()
-
-  COMPONENT_TEST("sparse%setShape")
-  !test setShape
-  !intend to make: [1 0 2]
-  !                [0 0 3]
-  !                [4 5 6]
-  DO i=1,6
-    a_vals(i)=i
-  ENDDO
-  ja_vals(1)=1
-  ja_vals(2)=3
-  ja_vals(3)=3
-  ja_vals(4)=1
-  ja_vals(5)=2
-  ja_vals(6)=3
-  ia_vals(1)=1
-  ia_vals(2)=3
-  ia_vals(3)=4
-  ia_vals(4)=7
-
-  ! build parameter list
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->nnz',6_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%init(...)'
-
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-
-  !check set
-  !test normal diag use case
-  !want to build:
-  ![1 2 0 0]
-  ![0 3 0 0]
-  ![0 0 5 6]
-  ![0 9 0 7]
-
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->m',4_SNK)
-  CALL pList%add('MatrixType->nnz',7_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(3,4,6._SRK)
-  CALL thisMatrix%set(4,4,7._SRK)
-  CALL thisMatrix%set(4,2,9._SRK)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType)
-      !now compare actual values with expected
-      DO i=1,6
-        bool = (thisMatrix%a(i) == a_vals(i)) &
-          .AND. (thisMatrix%ja(i) == ja_vals(i))
-        ASSERT(bool, 'sparse%set(...)')
-        IF(i < 5) THEN
-          bool = thisMatrix%ia(i) == ia_vals(i)
-          ASSERT(bool, 'sparse%set(...)')
-        ENDIF
-      ENDDO
-  ENDSELECT
-
-
-  !Test BLAS_matvec
-  x=1.0_SRK
-  y=1.0_SRK
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=x,Y=y)
-  bool = ALL((y .APPROXEQ. (/4._SRK,4._SRK,16._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,X=x,Y=y) -sparse')
-  CALL xRealVector%set(1.0_SRK)
-  CALL yRealVector%set(1.0_SRK)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector)
-  CALL yRealVector%get(y)
-  bool = ALL((y .APPROXEQ. (/4._SRK,4._SRK,16._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector) -sparse')
-  y=1.0_SRK
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=x,BETA=2.0_SRK,Y=y)
-  bool = ALL((y .APPROXEQ. (/5._SRK,5._SRK,17._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,X=x,BETA=2.0_SRK,Y=y) -sparse')
-  CALL yRealVector%set(1.0_SRK)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,BETA=2.0_SRK,Y=yRealVector)
-  CALL yRealVector%get(y)
-  bool = ALL((y .APPROXEQ. (/5._SRK,5._SRK,17._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,BETA=2.0_SRK,Y=yRealVector) -sparse')
-  y=1.0_SRK
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=x,Y=y)
-  bool = ALL((y .APPROXEQ. (/7._SRK,7._SRK,31._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=x,Y=y) -sparse')
-  CALL yRealVector%set(1.0_SRK)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=xRealVector,Y=yRealVector)
-  CALL yRealVector%get(y)
-  bool = ALL((y .APPROXEQ. (/7._SRK,7._SRK,31._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=xRealVector,Y=yRealVector) -sparse')
-  y=1.0_SRK
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=x,BETA=2.0_SRK,Y=y)
-  bool = ALL((y .APPROXEQ. (/8._SRK,8._SRK,32._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=x,BETA=2.0_SRK,Y=y) -sparse')
-  CALL yRealVector%set(1.0_SRK)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=xRealVector,BETA=2.0_SRK,Y=yRealVector)
-  CALL yRealVector%get(y)
-  bool = ALL((y .APPROXEQ. (/8._SRK,8._SRK,32._SRK/)))
-  ASSERT(bool, ' ')
-  FINFO() 'BLAS_matvec'
-  FINFO() '(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=xRealVector,BETA=2.0_SRK,Y=yRealVector)'
-  FINFO() '-sparse'
-
-  ! Set row at a time
-  SELECT TYPE (thisMatrix)
-  CLASS IS (SparseMatrixType)
-    CALL thisMatrix%setRow(1, [1, 3], [11._SRK, 12._SRK])
-    CALL thisMatrix%setRow(2, [3], [13._SRK])
-    CALL thisMatrix%setRow(3, [1, 2, 3], [15._SRK, 16._SRK, 17._SRK])
-    CALL thisMatrix%get(1, 1, val)
-    ASSERT(val .APPROXEQ. 11._SRK, "SparseMatrixTvalpe::setRow")
-    CALL thisMatrix%get(1, 3, val)
-    ASSERT(val .APPROXEQ. 12._SRK, "SparseMatrixTvalpe::setRow")
-    CALL thisMatrix%get(2, 3, val)
-    ASSERT(val .APPROXEQ. 13._SRK, "SparseMatrixTvalpe::setRow")
-    CALL thisMatrix%get(3, 1, val)
-    ASSERT(val .APPROXEQ. 15._SRK, "SparseMatrixTvalpe::setRow")
-    CALL thisMatrix%get(3, 2, val)
-    ASSERT(val .APPROXEQ. 16._SRK, "SparseMatrixTvalpe::setRow")
-    CALL thisMatrix%get(3, 3, val)
-    ASSERT(val .APPROXEQ. 17._SRK, "SparseMatrixTvalpe::setRow")
-  ENDSELECT
-
-! Check sparse triangular solvers
-  CALL yRealVector%clear()
-  CALL xRealVector%clear()
-  CALL thisMatrix%clear()
-  IF(ALLOCATED(thisMatrix)) DEALLOCATE(thisMatrix)
-  ALLOCATE(SparseMatrixType :: thisMatrix)
-  CALL Plist%clear()
-  CALL vecPList%clear()
-  CALL PList%add('MatrixType->n',4_SIK)
-  CALL PList%add('MatrixType->matType',SPARSE)
-  CALL Plist%add('MatrixType->nnz',16_SIK)
-  CALL vecPList%add('VectorType->n',4_SIK)
-  CALL xRealVector%init(vecPList)
-  CALL yRealVector%init(vecPList)
-  CALL thisMatrix%init(PList)
-  SELECTTYPE(x => xRealVector); TYPE IS(RealVectorType)
-    CALL x%set(1.0_SRK)
-  ENDSELECT
-  SELECTTYPE(mat => thisMatrix); TYPE IS(SparseMatrixType)
-    CALL mat%setShape(1,1,1.0_SRK)
-    CALL mat%setShape(1,2,2.0_SRK)
-    CALL mat%setShape(1,3,3.0_SRK)
-    CALL mat%setShape(1,4,4.0_SRK)
-    CALL mat%setShape(2,1,2.0_SRK)
-    CALL mat%setShape(2,2,2.0_SRK)
-    CALL mat%setShape(2,3,3.0_SRK)
-    CALL mat%setShape(2,4,4.0_SRK)
-    CALL mat%setShape(3,1,3.0_SRK)
-    CALL mat%setShape(3,2,3.0_SRK)
-    CALL mat%setShape(3,3,3.0_SRK)
-    CALL mat%setShape(3,4,4.0_SRK)
-    CALL mat%setShape(4,1,4.0_SRK)
-    CALL mat%setShape(4,2,4.0_SRK)
-    CALL mat%setShape(4,3,4.0_SRK)
-    CALL mat%setShape(4,4,4.0_SRK)
-  ENDSELECT
-
-  ! Test both the VectorType and native interface
-  COMPONENT_TEST("sparse%BLAS_matvec")
-  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-  ALLOCATE(dummyvec(4))
-  dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  dummyvec=(/0.00_SRK,0.00_SRK,0.00_SRK,0.250_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-
-  !Check increments /= 1
-  CALL xRealVector%clear()
-  CALL yRealVector%clear()
-  CALL vecPlist%clear()
-  CALL vecPList%add('VectorType->n',8_SIK)
-  CALL xRealVector%init(vecPList)
-  CALL yRealVector%init(vecPList)
-  SELECTTYPE(x => xrealVector); TYPE IS(RealVectorType)
-    CALL x%set(1.0_SRK)
-  ENDSELECT
-  dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
-  ! Negative Increment
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''L'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''N'',UPLO=''L'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''T'',UPLO=''U'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  ! Positive Increment
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='L',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''L'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='L',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''N'',UPLO=''L'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='U',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='U',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''T'',UPLO=''U'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-
-  dummyvec=(/0.00_SRK,0.00_SRK,0.00_SRK,0.250_SRK/)
-  ! Negative Increment
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''U'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''N'',UPLO=''U'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''L'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N'',INXC_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  !Positive Increment
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='U',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''U'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='U',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''N'',UPLO=''U'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='L',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''L'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='L',DIAG='N',INCX_IN=2_SIK)
-  bool=ALL(yRealVector%b(1:7:2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(MATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N'',INXC_IN=2_SIK')
-  FINFO() 'Result:',yRealVector%b(1:7:2),'Solution:',dummyvec
-
-
-  !Test BLAS_matmult when SparseMatType is supported.
-  CALL testMatrixMultSparse()
-
-  !off-nominal tests
-  !pass matrix w/out setshape
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-
-  COMPONENT_TEST("sparse%set")
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->nnz',6_SNK)
-  CALL thisMatrix%clear()
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(3,4,6._SRK)
-  CALL thisMatrix%set(4,4,7._SRK)
-  CALL thisMatrix%set(4,2,9._SRK)
-
-  SELECT TYPE(thisMatrix)
-  TYPE IS(BandedMatrixType)
-    CALL thisMatrix%assemble()
-  END SELECT
-
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType)
-      DO i=1,SIZE(thisMatrix%a)
-        ASSERT(thisMatrix%a(i) /= 1._SRK, 'sparse%set(...)')
-      ENDDO
-  ENDSELECT
-
-  !Perform test of functionality of get function
-  COMPONENT_TEST("sparse%get")
-  ![1 0 2]
-  ![0 0 3]
-  ![4 5 6]
-  CALL thisMatrix%clear()
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType)
-      CALL thisMatrix%setShape(1,1,1._SRK)
-      CALL thisMatrix%setShape(1,3,2._SRK)
-      CALL thisMatrix%setShape(2,3,3._SRK)
-      CALL thisMatrix%setShape(3,1,4._SRK)
-      CALL thisMatrix%setShape(3,2,5._SRK)
-      CALL thisMatrix%setShape(3,3,6._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(3,1,dummyvec(3))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(2,2,dummyvec(5))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(1,3,dummyvec(7))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 0._SRK) .AND. &
-             (dummyvec(3) == 4._SRK)
-      ASSERT(bool, 'sparse%get(...)') !column one check
-      bool = (dummyvec(4) == 0._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'sparse%get(...)') !column two check
-      bool = (dummyvec(7) == 2._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'sparse%get(...)') !column three check
-  ENDSELECT
-  CALL thisMatrix%clear()
-  DEALLOCATE(thisMatrix)
-!
-!Test for dense square matrices
-  COMPONENT_TEST("denseSquare%clear()")
-  ALLOCATE(DenseSquareMatrixType :: thisMatrix)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%isSymmetric=.TRUE.
-      ALLOCATE(thisMatrix%a(10,10))
-  ENDSELECT
-  CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      bool = (.NOT.(thisMatrix%isInit) .AND. (thisMatrix%n == 0)) &
-          .AND. (.NOT.(thisMatrix%isSymmetric) &
-          .AND. (.NOT.ALLOCATED(thisMatrix%a)))
-      ASSERT(bool, 'densesquare%clear()')
-  ENDSELECT
-
-  !check init
-  COMPONENT_TEST("denseSquare%init")
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !n=10, not symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      bool = ((thisMatrix%isInit) .AND. (thisMatrix%n == 10)) &
-          .AND. (.NOT.thisMatrix%isSymmetric)
-      ASSERT(bool, 'densesquare%init(...)')
-      bool = (SIZE(thisMatrix%a,1) == 10) .AND. &
-             (SIZE(thisMatrix%a,2) == 10)
-      ASSERT(bool, 'densesquare%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%get(...)'
-  !check matvec functionality
-  ![1 2 0 0]
-  ![0 3 0 0]
-  ![0 0 5 6]
-  ![0 9 0 7]
-  !with main diagonal split [1,3],[5,7]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->m',4_SNK)
-  CALL pList%add('MatrixType->nnz',7_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType); thisMatrix%isSymmetric=.FALSE.
-  ENDSELECT
-  CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      bool = .NOT. thisMatrix%isSymmetric
-      ASSERT(bool, 'densesquare%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  !test with n<1
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'densesquare%init(...)')
-  CALL thisMatrix%clear()
-  !test with n<1 and no second parameter
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'densesquare%init(...)')
-  !check set
-  !test normal use case (symmetric and nonsymmetric)
-  !want to build:
-  ![1 2]
-  ![2 3]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',2_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL thisMatrix%init(pList)  !symmetric
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      bool = ((thisMatrix%a(1,1)==1._SRK) &
-          .AND.(thisMatrix%a(1,2)==2._SRK)) &
-          .AND.((thisMatrix%a(2,1)==2._SRK) &
-          .AND.(thisMatrix%a(2,2)==3._SRK))
-      ASSERT(bool, 'densesquare%set(...)')
-  ENDSELECT
-
-  !Test BLAS_matvec
-  x=1.0_SRK
-  y=1.0_SRK
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',2_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL thisMatrix%init(pList)  !symmetric
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,2,2._SRK)
-      CALL thisMatrix%set(2,2,3._SRK)
-      CALL thisMatrix%set(3,3,5._SRK)
-      CALL thisMatrix%set(3,4,6._SRK)
-      CALL thisMatrix%set(4,4,7._SRK)
-      CALL thisMatrix%set(4,2,9._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      IF(ALLOCATED(dummyvec2)) DEALLOCATE(dummyvec2)
-      ALLOCATE(dummyvec(4))
-  dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  dummyvec=(/0.00_SRK,0.00_SRK,0.00_SRK,0.250_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='U',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''U'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='L',DIAG='N')
-  bool=ALL(yRealVector%b .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N''')
-  FINFO() 'Result:',yRealVector%b,'Solution:',dummyvec
-
-  !Check increments /= 1
-  CALL xRealVector%clear()
-  CALL yRealVector%clear()
-  CALL vecPlist%clear()
-  CALL vecPList%add('VectorType->n',8_SIK)
-  CALL xRealVector%init(vecPList)
-  CALL yRealVector%init(vecPList)
-  SELECTTYPE(x => xrealVector); TYPE IS(RealVectorType)
-    CALL x%set(1.0_SRK)
-  ENDSELECT
-  dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''L'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''L'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''U'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''U'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  dummyvec=(/0.00_SRK,0.00_SRK,0.00_SRK,0.250_SRK/)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='N',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''N'',UPLO=''U'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='N',UPLO='U',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''N'',UPLO=''U'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector,TRANS='T',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X,Y,TRANS=''T'',UPLO=''L'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector%b,Y=yRealVector%b,TRANS='T',UPLO='L',DIAG='N',INCX_IN=-2_SIK)
-  bool=ALL(yRealVector%b(7:1:-2) .APPROXEQA. dummyvec)
-  ASSERT(bool,'BLAS_matvec(THISMATRIX,X%b,Y%b,TRANS=''T'',UPLO=''L'',DIAG=''N'',INCX_IN=-2_SIK')
-  FINFO() 'Result:',yRealVector%b(7:1:-2),'Solution:',dummyvec
-
-  CALL testMatrixMultSquare()
-
-  COMPONENT_TEST("denseSquare%set")
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',2_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL thisMatrix%init(pList)  !nonsymmetric
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,1,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      bool = ((thisMatrix%a(1,1)==1._SRK) &
-          .AND.(thisMatrix%a(1,2)==2._SRK)) &
-          .AND.((thisMatrix%a(2,1)==2._SRK) &
-          .AND.(thisMatrix%a(2,2)==3._SRK))
-      ASSERT(bool, 'densesquare%set(...)')
-  ENDSELECT
-  !check matrix that hasnt been init, i,j out of bounds
-  CALL thisMatrix%clear()
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%clear()
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(-1,1,1._SRK)
-  CALL thisMatrix%set(1,-1,1._SRK)
-  CALL thisMatrix%set(5,1,1._SRK)
-  CALL thisMatrix%set(1,5,1._SRK)
-  !no crash? good
-  CALL thisMatrix%clear()
-
-  !Perform test of functionality of get function
-  COMPONENT_TEST("denseSquare%get")
-  ![1 0 2]
-  ![0 0 3]
-  ![4 5 6]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseSquareMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      CALL thisMatrix%set(3,1,4._SRK)
-      CALL thisMatrix%set(3,2,5._SRK)
-      CALL thisMatrix%set(3,3,6._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(3,1,dummyvec(3))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(2,2,dummyvec(5))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(1,3,dummyvec(7))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 0._SRK) .AND. &
-             (dummyvec(3) == 4._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-      FINFO() dummyvec
-      bool = (dummyvec(4) == 0._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-      bool = (dummyvec(7) == 2._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-  ENDSELECT
-  !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      CALL thisMatrix%assemble()
-      WRITE(*,*) "calling matvec"
-      CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
-      WRITE(*,*) "finished matvec call"
-      DO i=1,4
-        bool = ABS(dummyvec2(i)) < 1E-6
-        ASSERT(bool, 'banded%matvec(...)')
-      ENDDO
-  ENDSELECT
-  ! Check for non-trivial vector
-  dummyvec=(/1._SRK,2._SRK,3._SRK,4._SRK/)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-    CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
-    bool = dummyvec2(1) == 5._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-    bool = dummyvec2(2) == 6._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-    bool = dummyvec2(3) == 39._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-    bool = dummyvec2(4) == 46._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  DEALLOCATE(thisMatrix)
-!
-!Test for tri-diagonal matrices
-  ALLOCATE(TriDiagMatrixType :: thisMatrix)
-  COMPONENT_TEST("tridiag%clear")
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%isSymmetric=.TRUE.
-      ALLOCATE(thisMatrix%a(10,10))
-  ENDSELECT
-!  These are unsuported matvecs.  I added an error message in order to catch unsported types so these don't run anymore without throwing an error
-  ncnt=e%getCounter(EXCEPTION_ERROR)
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=x,Y=y) !Error check unsupported type
-  bool = ALL((y .APPROXEQ. (/2._SRK,2._SRK,2._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(...) -tridiag')
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=xRealVector,Y=yRealVector) !Error check unsupported type
-  CALL yRealVector%get(y)
-  bool = ALL((y .APPROXEQ. (/2._SRK,2._SRK,2._SRK/)))
-  ASSERT(bool, 'BLAS_matvec(...) -tridiag')
-  ncnt2=e%getCounter(EXCEPTION_ERROR)
-  ASSERT(ncnt2-ncnt==2, 'BLAS_matvec(...) -tridiag expected failures')
-
-
-  CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.((.NOT.thisMatrix%isSymmetric) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%a)))
-      ASSERT(bool, 'tridiag%clear()')
-  ENDSELECT
-  !check init
-  COMPONENT_TEST("tridiag%init")
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !n=10, not symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(.NOT.thisMatrix%isSymmetric)
-      ASSERT(bool, 'tridiag%init(...)')
-      bool = (SIZE(thisMatrix%a,1) == 3) .AND. (SIZE(thisMatrix%a,2) == 10)
-      ASSERT(bool, 'tridiag%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(thisMatrix%isSymmetric)
-      ASSERT(bool, 'tridiag%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  !test with double init (isInit==true on 2nd try)
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType); thisMatrix%isSymmetric=.FALSE.
-  ENDSELECT
-  CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      bool = .NOT.thisMatrix%isSymmetric
-      ASSERT(bool, 'tridiag%init(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  !test with n<1
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'tridiag%init(...)')
-  CALL thisMatrix%clear()
-  !test with n<1 and no second parameter
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT.thisMatrix%isInit
-  ASSERT(bool, 'tridiag%init(...)')
-  CALL thisMatrix%clear()
-
-  !check set
-  COMPONENT_TEST("tridiag%set")
-  !test normal use case (symmetric and nonsymmetric)
-  !want to build:
-  ![1 4 0]
-  ![4 2 5]
-  ![0 5 3]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->isSym',.TRUE.)
-  CALL thisMatrix%init(pList)  !symmetric
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,4._SRK)
-  CALL thisMatrix%set(2,2,2._SRK)
-  CALL thisMatrix%set(2,3,5._SRK)
-  CALL thisMatrix%set(3,3,3._SRK)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      DO i=1,3
-        bool = thisMatrix%a(2,i) == i
-        ASSERT(bool, 'tridiag%set(...)')
-      ENDDO
-      bool = thisMatrix%a(1,1) == 0
-      ASSERT(bool, 'tridiag%set(...)')
-      DO i=2,3
-        bool = thisMatrix%a(1,i) == i+2
-        ASSERT(bool, 'tridiag%set(...)')
-      ENDDO
-      bool = thisMatrix%a(3,3) == 0
-      ASSERT(bool, 'tridiag%set(...)')
-      DO i=1,2
-        bool = thisMatrix%a(3,i) == i+3
-        ASSERT(bool, 'tridiag%set(...)')
-      ENDDO
-  ENDSELECT
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL thisMatrix%init(pList)  !nonsymmetric
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,1,4._SRK)
-      CALL thisMatrix%set(2,2,5._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(6))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(1,2,dummyvec(3))
-      CALL thisMatrix%get(2,2,dummyvec(4))
-      CALL thisMatrix%get(1,3,dummyvec(5))
-      CALL thisMatrix%get(2,3,dummyvec(6))
-      bool = (dummyvec(1) == 1._SRK)  .AND. &
-          (dummyvec(2) == 4._SRK)
-      ASSERT(bool, 'densesquare%get(...)') !column one check
-      bool = (dummyvec(3) == 0._SRK).AND. &
-              (dummyvec(4) == 5._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-      bool = (dummyvec(5) == 2._SRK).AND. &
-              (dummyvec(6) == 3._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-  ENDSELECT
-  !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
-  ENDSELECT
-  !test get with uninit, make sure no crash.
-  CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      dummy=0.0_SRK
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'densesquare%get(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL densesquare%get(...)'
-  DEALLOCATE(thisMatrix)
-
-  !check matrix that hasnt been init, i,j out of bounds
-  CALL thisMatrix%clear()
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(-1,1,1._SRK)
-  CALL thisMatrix%set(1,-1,1._SRK)
-  CALL thisMatrix%set(5,1,1._SRK)
-  CALL thisMatrix%set(1,5,1._SRK)
-  !no crash? good
-  CALL thisMatrix%clear()
-
-  !Perform test of functionality of get function
-  COMPONENT_TEST("tridiag%get")
-  ![1 2 0]
-  ![4 0 3]
-  ![0 5 6]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',3_SNK)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,2,2._SRK)
-      CALL thisMatrix%set(2,1,4._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      CALL thisMatrix%set(3,2,5._SRK)
-      CALL thisMatrix%set(3,3,6._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      dummyvec=0
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 4._SRK) .AND. &
-             (dummyvec(3) == 0._SRK)
-      ASSERT(bool, 'tridiag%get(...)') !column one check
-      bool = (dummyvec(4) == 2._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'tridiag%get(...)') !column two check
-      bool = (dummyvec(7) == 0._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'tridiag%get(...)') !column three check
-  ENDSELECT
-  !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'tridiag%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'tridiag%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'tridiag%get(...)')
-  ENDSELECT
-  !test get with uninit, make sure no crash.
-  CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(TriDiagMatrixType)
-      dummy=0.0_SRK
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'tridiag%get(...)')
-  ENDSELECT
-  CALL thisMatrix%clear()
   DEALLOCATE(thisMatrix)
 !
 !Test for banded matrices
   ALLOCATE(BandedMatrixType :: thisMatrix)
   COMPONENT_TEST("banded%clear")
   SELECT TYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%m=15
-      thisMatrix%nnz=16
-      ALLOCATE(thisMatrix%bands(4))
-      ALLOCATE(thisMatrix%bandIdx(4))
-      ALLOCATE(thisMatrix%bands(2)%elem(5))
+  TYPE IS(BandedMatrixType)
+    !test clear
+    !make matrix w/out using untested init
+    thisMatrix%isInit=.TRUE.
+    thisMatrix%n=10
+    thisMatrix%m=15
+    thisMatrix%nnz=16
+    ALLOCATE(thisMatrix%bands(4))
+    ALLOCATE(thisMatrix%bandIdx(4))
+    ALLOCATE(thisMatrix%bands(2)%elem(5))
   END SELECT
   CALL thisMatrix%clear()
   SELECT TYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.((thisMatrix%m == 0) &
-          .AND.(thisMatrix%nnz == 0) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%bands)))
-      ASSERT(bool, 'banded%clear()')
+  TYPE IS(BandedMatrixType)
+    bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
+        .AND.((thisMatrix%m == 0) &
+        .AND.(thisMatrix%nnz == 0) &
+        .AND.(.NOT.ALLOCATED(thisMatrix%bands)))
+    ASSERT(bool, 'banded%clear()')
   END SELECT
 
   !check init
@@ -2333,23 +1323,23 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 12))
-      ASSERT(bool, 'banded%init(...)')
+  TYPE IS(BandedMatrixType)
+    bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 12))
+    ASSERT(bool, 'banded%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with double init (isInit==true on 2nd try)
 
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType); thisMatrix%m=1
+  SELECTTYPE(thisMatrix); TYPE IS(BandedMatrixType)
+    thisMatrix%m=1
   ENDSELECT
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      bool = thisMatrix%m == 1
-      ASSERT(bool, 'banded%init(...)')
+  TYPE IS(BandedMatrixType)
+    bool = thisMatrix%m == 1
+    ASSERT(bool, 'banded%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with n<1
@@ -2394,7 +1384,6 @@ SELECTTYPE(thisMatrix)
   ![0 3 0 0]
   ![0 0 5 6]
   ![0 9 0 7]
-
   CALL pList%add('MatrixType->n',4_SNK)
   CALL pList%add('MatrixType->m',4_SNK)
   CALL pList%add('MatrixType->nnz',7_SNK)
@@ -2408,17 +1397,17 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(4,4,7._SRK)
   CALL thisMatrix%set(4,2,9._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      CALL thisMatrix%assemble()
-      bool = .TRUE.
-      bool = bool .AND. thisMatrix%bands(2)%elem(1) == 1
-      bool = bool .AND. thisMatrix%bands(2)%elem(2) == 3
-      bool = bool .AND. thisMatrix%bands(2)%elem(3) == 5
-      bool = bool .AND. thisMatrix%bands(2)%elem(4) == 7
-      bool = bool .AND. thisMatrix%bands(3)%elem(1) == 2
-      bool = bool .AND. thisMatrix%bands(3)%elem(2) == 6
-      bool = bool .AND. thisMatrix%bands(1)%elem(1) == 9
-      ASSERT(bool, 'banded%set(...)')
+  TYPE IS(BandedMatrixType)
+    CALL thisMatrix%assemble()
+    bool = .TRUE.
+    bool = bool .AND. thisMatrix%bands(2)%elem(1) == 1
+    bool = bool .AND. thisMatrix%bands(2)%elem(2) == 3
+    bool = bool .AND. thisMatrix%bands(2)%elem(3) == 5
+    bool = bool .AND. thisMatrix%bands(2)%elem(4) == 7
+    bool = bool .AND. thisMatrix%bands(3)%elem(1) == 2
+    bool = bool .AND. thisMatrix%bands(3)%elem(2) == 6
+    bool = bool .AND. thisMatrix%bands(1)%elem(1) == 9
+    ASSERT(bool, 'banded%set(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   CALL pList%clear()
@@ -2429,7 +1418,6 @@ SELECTTYPE(thisMatrix)
   ![0 3 0 0]
   ![0 0 5 6]
   ![0 9 0 7]
-  !
   CALL pList%add('MatrixType->n',4_SNK)
   CALL pList%add('MatrixType->m',4_SNK)
   CALL pList%add('MatrixType->nnz',7_SNK)
@@ -2474,8 +1462,8 @@ SELECTTYPE(thisMatrix)
   bool = bool .AND. dummyvec(9) == 9
   bool = bool .AND. dummyvec(10) == 0
   ASSERT(bool, 'banded%get(...)')
-
   CALL thisMatrix%clear()
+
   !check matvec functionality
   COMPONENT_TEST("banded%matvec")
   ![1 2 0 0]
@@ -2505,18 +1493,20 @@ SELECTTYPE(thisMatrix)
   dummyvec=0
   dummyvec2=1
   SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
-      CALL thisMatrix%assemble()
-      CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
-      DO i=1,4
-        bool = ABS(dummyvec2(i)) < 1E-6
-        ASSERT(bool, 'banded%matvec(...)')
-      ENDDO
+  TYPE IS(BandedMatrixType)
+    CALL thisMatrix%assemble()
+    WRITE(*,*) "calling matvec"
+    CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
+    WRITE(*,*) "finished matvec call"
+    DO i=1,4
+      bool = ABS(dummyvec2(i)) < 1E-6
+      ASSERT(bool, 'banded%matvec(...)')
+    ENDDO
   ENDSELECT
   ! Check for non-trivial vector
   dummyvec=(/1._SRK,2._SRK,3._SRK,4._SRK/)
   SELECTTYPE(thisMatrix)
-    TYPE IS(BandedMatrixType)
+  TYPE IS(BandedMatrixType)
     CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
     bool = dummyvec2(1) == 5._SRK
     ASSERT(bool, 'banded%matvec(...)')
@@ -2528,26 +1518,27 @@ SELECTTYPE(thisMatrix)
     ASSERT(bool, 'banded%matvec(...)')
   ENDSELECT
   DEALLOCATE(thisMatrix)
+
 !
 !Test for dense rectangular matrices
   ALLOCATE(DenseRectMatrixType :: thisMatrix)
   COMPONENT_TEST("denseRect%clear")
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%m=15
-      ALLOCATE(thisMatrix%a(10,15))
+  TYPE IS(DenseRectMatrixType)
+    !test clear
+    !make matrix w/out using untested init
+    thisMatrix%isInit=.TRUE.
+    thisMatrix%n=10
+    thisMatrix%m=15
+    ALLOCATE(thisMatrix%a(10,15))
   ENDSELECT
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.((thisMatrix%m == 0) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%a)))
-      ASSERT(bool, 'denserect%clear()')
+  TYPE IS(DenseRectMatrixType)
+    bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
+        .AND.((thisMatrix%m == 0) &
+        .AND.(.NOT.ALLOCATED(thisMatrix%a)))
+    ASSERT(bool, 'denserect%clear()')
   ENDSELECT
 
   !check init
@@ -2558,25 +1549,25 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.((thisMatrix%m == 15))
-      ASSERT(bool, 'denserect%init(...)')
-      bool = (SIZE(thisMatrix%a,1) == 10) &
-        .AND.(SIZE(thisMatrix%a,2) == 15)
-      ASSERT(bool, 'denserect%init(...)')
+  TYPE IS(DenseRectMatrixType)
+    bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.((thisMatrix%m == 15))
+    ASSERT(bool, 'denserect%init(...)')
+    bool = (SIZE(thisMatrix%a,1) == 10) &
+      .AND.(SIZE(thisMatrix%a,2) == 15)
+    ASSERT(bool, 'denserect%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with double init (isInit==true on 2nd try)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType); thisMatrix%m=1
+  SELECTTYPE(thisMatrix); TYPE IS(DenseRectMatrixType)
+    thisMatrix%m=1
   ENDSELECT
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      bool = thisMatrix%m == 1
-      ASSERT(bool, 'denserect%init(...)')
+  TYPE IS(DenseRectMatrixType)
+    bool = thisMatrix%m == 1
+    ASSERT(bool, 'denserect%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with n<1
@@ -2616,11 +1607,11 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(2,2,5._SRK)
   CALL thisMatrix%set(2,3,6._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      DO i=1,3
-        bool = (thisMatrix%a(1,i)== i).AND.(thisMatrix%a(2,i)== 3+i)
-        ASSERT(bool, 'denserect%set(...)')
-      ENDDO
+  TYPE IS(DenseRectMatrixType)
+    DO i=1,3
+      bool = (thisMatrix%a(1,i)== i).AND.(thisMatrix%a(2,i)== 3+i)
+      ASSERT(bool, 'denserect%set(...)')
+    ENDDO
   ENDSELECT
 
   !Test BLAS_matvec
@@ -2675,9 +1666,11 @@ SELECTTYPE(thisMatrix)
   FINFO() 'BLAS_matvec(THISMATRIX=thisMatrix,ALPHA=2.0_SRK,X=xRealVector,BETA=2.0_SRK,Y=yRealVector)",'
   FINFO() '-denserect'
 
+  COMPONENT_TEST("denseRect%matmult")
   CALL testMatrixMultRect()
 
   !check matrix that hasnt been init, i,j out of bounds
+  COMPONENT_TEST("denseRect%malformed")
   CALL thisMatrix%clear()
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%clear()
@@ -2702,51 +1695,51 @@ SELECTTYPE(thisMatrix)
   CALL pList%add('MatrixType->m',3_SNK)
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,1,4._SRK)
-      CALL thisMatrix%set(2,2,5._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(6))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(1,2,dummyvec(3))
-      CALL thisMatrix%get(2,2,dummyvec(4))
-      CALL thisMatrix%get(1,3,dummyvec(5))
-      CALL thisMatrix%get(2,3,dummyvec(6))
-      bool = (dummyvec(1) == 1._SRK)  .AND. &
-          (dummyvec(2) == 4._SRK)
-      ASSERT(bool, 'densesquare%get(...)') !column one check
-      bool = (dummyvec(3) == 0._SRK).AND. &
-              (dummyvec(4) == 5._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
-      bool = (dummyvec(5) == 2._SRK).AND. &
-              (dummyvec(6) == 3._SRK)
-      ASSERT(bool, 'densesquare%get(...)')
+  TYPE IS(DenseRectMatrixType)
+    CALL thisMatrix%set(1,1,1._SRK)
+    CALL thisMatrix%set(1,3,2._SRK)
+    CALL thisMatrix%set(2,1,4._SRK)
+    CALL thisMatrix%set(2,2,5._SRK)
+    CALL thisMatrix%set(2,3,3._SRK)
+    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+    ALLOCATE(dummyvec(6))
+    CALL thisMatrix%get(1,1,dummyvec(1))
+    CALL thisMatrix%get(2,1,dummyvec(2))
+    CALL thisMatrix%get(1,2,dummyvec(3))
+    CALL thisMatrix%get(2,2,dummyvec(4))
+    CALL thisMatrix%get(1,3,dummyvec(5))
+    CALL thisMatrix%get(2,3,dummyvec(6))
+    bool = (dummyvec(1) == 1._SRK)  .AND. &
+        (dummyvec(2) == 4._SRK)
+    ASSERT(bool, 'denserect%get(...)') !column one check
+    bool = (dummyvec(3) == 0._SRK).AND. &
+            (dummyvec(4) == 5._SRK)
+    ASSERT(bool, 'denserect%get(...)')
+    bool = (dummyvec(5) == 2._SRK).AND. &
+            (dummyvec(6) == 3._SRK)
+    ASSERT(bool, 'denserect%get(...)')
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'densesquare%get(...)')
+  TYPE IS(DenseRectMatrixType)
+    CALL thisMatrix%get(4,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'denserect%get(...)')
+    CALL thisMatrix%get(-1,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'denserect%get(...)')
+    CALL thisMatrix%get(2,-1,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'denserect%get(...)')
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(DenseRectMatrixType)
-      dummy=0.0_SRK
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'densesquare%get(...)')
+  TYPE IS(DenseRectMatrixType)
+    dummy=0.0_SRK
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy == 0.0_SRK
+    ASSERT(bool, 'densesquare%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   DEALLOCATE(thisMatrix)
@@ -2756,31 +1749,31 @@ SELECTTYPE(thisMatrix)
 
 !Test for PETSc sparsematrices
   ALLOCATE(PETScMatrixType :: thisMatrix)
-  COMPONENT_TEST("petscSparse%clear")
+  COMPONENT_TEST("petscsparse%clear")
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%isSymmetric=.TRUE.
-      CALL MatCreate(MPI_COMM_WORLD,thisMatrix%a,ierr)
-      CALL MatSetSizes(thisMatrix%a,PETSC_DECIDE,PETSC_DECIDE, &
-                                    thisMatrix%n,thisMatrix%n,ierr)
-      CALL MatSetType(thisMatrix%a,MATMPIAIJ,ierr)
-      CALL MatSetUp(thisMatrix%a,ierr)
+  TYPE IS(PETScMatrixType)
+    !test clear
+    !make matrix w/out using untested init
+    thisMatrix%isInit=.TRUE.
+    thisMatrix%n=10
+    thisMatrix%isSymmetric=.TRUE.
+    CALL MatCreate(MPI_COMM_WORLD,thisMatrix%a,ierr)
+    CALL MatSetSizes(thisMatrix%a,PETSC_DECIDE,PETSC_DECIDE, &
+                                  thisMatrix%n,thisMatrix%n,ierr)
+    CALL MatSetType(thisMatrix%a,MATMPIAIJ,ierr)
+    CALL MatSetUp(thisMatrix%a,ierr)
   ENDSELECT
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.((.NOT.thisMatrix%isSymmetric))
-      ASSERT(bool, 'petscsparse%clear()')
-      !check if pointer fo a is null (not supported till 3.3)
+  TYPE IS(PETScMatrixType)
+    bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
+        .AND.((.NOT.thisMatrix%isSymmetric))
+    ASSERT(bool, 'petscsparse%clear()')
+    !check if pointer fo a is null (not supported till 3.3)
   ENDSELECT
 
   !check init
-  COMPONENT_TEST("petscSparse%init")
+  COMPONENT_TEST("petscsparse%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -2788,13 +1781,13 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(.NOT.thisMatrix%isSymmetric)
-      ASSERT(bool, 'petscsparse%init(...)')
-      CALL MatGetSize(thisMatrix%a,matsize1,matsize2,ierr)
-      bool = (matsize1 == 10) .AND. (matsize2 == 10)
-      ASSERT(bool, 'petscsparse%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.(.NOT.thisMatrix%isSymmetric)
+    ASSERT(bool, 'petscsparse%init(...)')
+    CALL MatGetSize(thisMatrix%a,matsize1,matsize2,ierr)
+    bool = (matsize1 == 10) .AND. (matsize2 == 10)
+    ASSERT(bool, 'petscsparse%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   CALL pList%clear()
@@ -2804,10 +1797,10 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(thisMatrix%isSymmetric)
-      ASSERT(bool, 'petscsparse%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.(thisMatrix%isSymmetric)
+    ASSERT(bool, 'petscsparse%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with double init (isInit==true on 2nd try)
@@ -2817,14 +1810,14 @@ SELECTTYPE(thisMatrix)
   CALL pList%add('MatrixType->matType',SPARSE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType); thisMatrix%isSymmetric=.FALSE.
+  SELECTTYPE(thisMatrix); TYPE IS(PETScMatrixType)
+    thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = .NOT.thisMatrix%isSymmetric
-      ASSERT(bool, 'petscsparse%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = .NOT.thisMatrix%isSymmetric
+    ASSERT(bool, 'petscsparse%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with n<1
@@ -2839,6 +1832,7 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%clear()
 
   !check set
+  COMPONENT_TEST("petscsparse%set")
   !test normal use case (symmetric and nonsymmetric)
   !want to build:
   ![1 2]
@@ -2853,21 +1847,21 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      ! manually assemble
-      CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      thisMatrix%isAssembled=.TRUE.
+  TYPE IS(PETScMatrixType)
+    ! manually assemble
+    CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    thisMatrix%isAssembled=.TRUE.
 
-      CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
   ENDSELECT
 
   SELECT TYPE (thisMatrix)
@@ -2884,8 +1878,8 @@ SELECTTYPE(thisMatrix)
  ENDSELECT
 
 
-  COMPONENT_TEST("petscSparse%set")
   CALL thisMatrix%clear()
+
   CALL pList%clear()
   CALL pList%add('MatrixType->n',2_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -2897,24 +1891,24 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      ! manually assemble
-      CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      thisMatrix%isAssembled=.TRUE.
+  TYPE IS(PETScMatrixType)
+    ! manually assemble
+    CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    thisMatrix%isAssembled=.TRUE.
 
-      CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'petscsparse%set(...)')
   ENDSELECT
   !check matrix that hasnt been init, i,j out of bounds
   CALL thisMatrix%clear()
@@ -2927,7 +1921,7 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,5,1._SRK)
   !no crash? good
 
-  COMPONENT_TEST("petscSparse%matvec")
+  COMPONENT_TEST("petscsparse%matvec")
   CALL thisMatrix%clear()
   CALL pList%clear()
   CALL pList%add('MatrixType->n',3_SNK)
@@ -3036,7 +2030,7 @@ SELECTTYPE(thisMatrix)
   FINFO() '-petscsparse'
 
   !Perform test of functionality of get function
-  COMPONENT_TEST("petscSparse%get")
+  COMPONENT_TEST("petscsparse%get")
   ![1 0 2]
   ![0 0 3]
   ![4 5 6]
@@ -3048,91 +2042,90 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      CALL thisMatrix%set(3,1,4._SRK)
-      CALL thisMatrix%set(3,2,5._SRK)
-      CALL thisMatrix%set(3,3,6._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(3,1,dummyvec(3))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(2,2,dummyvec(5))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(1,3,dummyvec(7))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 0._SRK) .AND. &
-             (dummyvec(3) == 4._SRK)
-      ASSERT(bool, 'petscsparse%get(...)')
-      bool = (dummyvec(4) == 0._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'petscsparse%get(...)')
-      FINFO() dummyvec(4:6)
-      bool = (dummyvec(7) == 2._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'petscsparse%get(...)')
-      FINFO() dummyvec(7:9)
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%set(1,1,1._SRK)
+    CALL thisMatrix%set(1,3,2._SRK)
+    CALL thisMatrix%set(2,3,3._SRK)
+    CALL thisMatrix%set(3,1,4._SRK)
+    CALL thisMatrix%set(3,2,5._SRK)
+    CALL thisMatrix%set(3,3,6._SRK)
+    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+    ALLOCATE(dummyvec(9))
+    CALL thisMatrix%get(1,1,dummyvec(1))
+    CALL thisMatrix%get(2,1,dummyvec(2))
+    CALL thisMatrix%get(3,1,dummyvec(3))
+    CALL thisMatrix%get(1,2,dummyvec(4))
+    CALL thisMatrix%get(2,2,dummyvec(5))
+    CALL thisMatrix%get(3,2,dummyvec(6))
+    CALL thisMatrix%get(1,3,dummyvec(7))
+    CALL thisMatrix%get(2,3,dummyvec(8))
+    CALL thisMatrix%get(3,3,dummyvec(9))
+    bool = (dummyvec(1) == 1._SRK) .AND. &
+           (dummyvec(2) == 0._SRK) .AND. &
+           (dummyvec(3) == 4._SRK)
+    ASSERT(bool, 'petscsparse%get(...)')
+    bool = (dummyvec(4) == 0._SRK) .AND. &
+           (dummyvec(5) == 0._SRK) .AND. &
+           (dummyvec(6) == 5._SRK)
+    ASSERT(bool, 'petscsparse%get(...)')
+    FINFO() dummyvec(4:6)
+    bool = (dummyvec(7) == 2._SRK) .AND. &
+           (dummyvec(8) == 3._SRK) .AND. &
+           (dummyvec(9) == 6._SRK)
+    ASSERT(bool, 'petscsparse%get(...)')
+    FINFO() dummyvec(7:9)
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'petscsparse%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy==-1051._SRK
-      ASSERT(bool, 'petscsparse%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy==-1051._SRK
-      ASSERT(bool, 'petscsparse%get(...)')
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%get(4,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'petscsparse%get(...)')
+    CALL thisMatrix%get(-1,2,dummy)
+    bool = dummy==-1051._SRK
+    ASSERT(bool, 'petscsparse%get(...)')
+    CALL thisMatrix%get(2,-1,dummy)
+    bool = dummy==-1051._SRK
+    ASSERT(bool, 'petscsparse%get(...)')
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'petscsparse%get(...)')
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy == 0.0_SRK
+    ASSERT(bool, 'petscsparse%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   DEALLOCATE(thisMatrix)
 
 !Test for PETSc dense square matrices
   ALLOCATE(PETScMatrixType :: thisMatrix)
-  COMPONENT_TEST("petscDense%clear")
+  COMPONENT_TEST("petscdense%clear")
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      !test clear
-      !make matrix w/out using untested init
-      thisMatrix%isInit=.TRUE.
-      thisMatrix%n=10
-      thisMatrix%isSymmetric=.TRUE.
-      CALL MatCreate(MPI_COMM_WORLD,thisMatrix%a,ierr)
-      CALL MatSetSizes(thisMatrix%a,PETSC_DECIDE,PETSC_DECIDE, &
-                                    thisMatrix%n,thisMatrix%n,ierr)
-      CALL MatSetType(thisMatrix%a,MATMPIDENSE,ierr)
-      CALL MatSetUp(thisMatrix%a,ierr)
+  TYPE IS(PETScMatrixType)
+    !test clear
+    !make matrix w/out using untested init
+    thisMatrix%isInit=.TRUE.
+    thisMatrix%n=10
+    thisMatrix%isSymmetric=.TRUE.
+    CALL MatCreate(MPI_COMM_WORLD,thisMatrix%a,ierr)
+    CALL MatSetSizes(thisMatrix%a,PETSC_DECIDE,PETSC_DECIDE, &
+                                  thisMatrix%n,thisMatrix%n,ierr)
+    CALL MatSetType(thisMatrix%a,MATMPIDENSE,ierr)
+    CALL MatSetUp(thisMatrix%a,ierr)
   ENDSELECT
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.((.NOT.thisMatrix%isSymmetric))
-      ASSERT(bool, 'petscdense%clear()')
-       !check if pointer of A is null (not supported till 3.3)
-      !ASSERT(bool, 'petscdense%clear()')
+  TYPE IS(PETScMatrixType)
+    bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
+        .AND.((.NOT.thisMatrix%isSymmetric))
+    ASSERT(bool, 'petscdense%clear()')
+    !check if pointer fo a is null (not supported till 3.3)
   ENDSELECT
 
   !check init
-  COMPONENT_TEST("petscDense%init")
+  COMPONENT_TEST("petscdense%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
@@ -3140,13 +2133,13 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(.NOT.thisMatrix%isSymmetric)
-      ASSERT(bool, 'petscdense%init(...)')
-      CALL MatGetSize(thisMatrix%a,matsize1,matsize2,ierr)
-      bool = (matsize1 == 10) .AND. (matsize2 == 10)
-      ASSERT(bool, 'petscdense%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.(.NOT.thisMatrix%isSymmetric)
+    ASSERT(bool, 'petscdense%init(...)')
+    CALL MatGetSize(thisMatrix%a,matsize1,matsize2,ierr)
+    bool = (matsize1 == 10) .AND. (matsize2 == 10)
+    ASSERT(bool, 'petscdense%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   CALL pList%clear()
@@ -3156,10 +2149,10 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(thisMatrix%isSymmetric)
-      ASSERT(bool, 'petscdense%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.(thisMatrix%isSymmetric)
+    ASSERT(bool, 'petscdense%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with double init (isInit==true on 2nd try)
@@ -3169,19 +2162,19 @@ SELECTTYPE(thisMatrix)
   CALL pList%add('MatrixType->mattype',DENSESQUARE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType); thisMatrix%isSymmetric=.FALSE.
+  SELECTTYPE(thisMatrix); TYPE IS(PETScMatrixType)
+    thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      bool = .NOT.thisMatrix%isSymmetric
-      ASSERT(bool, 'petscdense%init(...)')
+  TYPE IS(PETScMatrixType)
+    bool = .NOT.thisMatrix%isSymmetric
+    ASSERT(bool, 'petscdense%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
 
   !check set
-  COMPONENT_TEST("petscDense%set")
+  COMPONENT_TEST("petscdense%set")
   !test normal use case (symmetric and nonsymmetric)
   !want to build:
   ![1 2]
@@ -3196,21 +2189,21 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      ! manually assemble
-      CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      thisMatrix%isAssembled=.TRUE.
+  TYPE IS(PETScMatrixType)
+    ! manually assemble
+    CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    thisMatrix%isAssembled=.TRUE.
 
-      CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'petscdense%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscdense%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'petscdense%set(...)')
   ENDSELECT
   CALL thisMatrix%clear()
 
@@ -3225,24 +2218,24 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      ! manually assemble
-      CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
-      thisMatrix%isAssembled=.TRUE.
+  TYPE IS(PETScMatrixType)
+    ! manually assemble
+    CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
+    thisMatrix%isAssembled=.TRUE.
 
-      CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'petscdense%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscdense%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'petscdense%set(...)')
-      CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'petscdense%set(...)')
+    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'petscdense%set(...)')
   ENDSELECT
   !check matrix that hasnt been init, i,j out of bounds
   CALL thisMatrix%clear()
@@ -3261,7 +2254,7 @@ SELECTTYPE(thisMatrix)
   !no crash? good
 
   !Test BLAS_matvec
-  COMPONENT_TEST("petscDense%matvec")
+  COMPONENT_TEST("petscdense%matvec")
   CALL thisMatrix%clear()
   CALL pList%clear()
   CALL pList%add('MatrixType->n',3_SNK)
@@ -3370,7 +2363,7 @@ SELECTTYPE(thisMatrix)
   FINFO() '-petscdense'
 
   !Perform test of functionality of get function
-  COMPONENT_TEST("petscDense%get")
+  COMPONENT_TEST("petscdense%get")
   ![1 0 2]
   ![0 0 3]
   ![4 5 6]
@@ -3382,57 +2375,57 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), dense (1)
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      CALL thisMatrix%set(3,1,4._SRK)
-      CALL thisMatrix%set(3,2,5._SRK)
-      CALL thisMatrix%set(3,3,6._SRK)
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(3,1,dummyvec(3))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(2,2,dummyvec(5))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(1,3,dummyvec(7))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 0._SRK) .AND. &
-             (dummyvec(3) == 4._SRK)
-      ASSERT(bool, 'petscdense%get(...)') !column one check
-      bool = (dummyvec(4) == 0._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'petscdense%get(...)')
-      bool = (dummyvec(7) == 2._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'petscdense%get(...)')
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%set(1,1,1._SRK)
+    CALL thisMatrix%set(1,3,2._SRK)
+    CALL thisMatrix%set(2,3,3._SRK)
+    CALL thisMatrix%set(3,1,4._SRK)
+    CALL thisMatrix%set(3,2,5._SRK)
+    CALL thisMatrix%set(3,3,6._SRK)
+    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+    ALLOCATE(dummyvec(9))
+    CALL thisMatrix%get(1,1,dummyvec(1))
+    CALL thisMatrix%get(2,1,dummyvec(2))
+    CALL thisMatrix%get(3,1,dummyvec(3))
+    CALL thisMatrix%get(1,2,dummyvec(4))
+    CALL thisMatrix%get(2,2,dummyvec(5))
+    CALL thisMatrix%get(3,2,dummyvec(6))
+    CALL thisMatrix%get(1,3,dummyvec(7))
+    CALL thisMatrix%get(2,3,dummyvec(8))
+    CALL thisMatrix%get(3,3,dummyvec(9))
+    bool = (dummyvec(1) == 1._SRK) .AND. &
+           (dummyvec(2) == 0._SRK) .AND. &
+           (dummyvec(3) == 4._SRK)
+    ASSERT(bool, 'petscdense%get(...)') !column one check
+    bool = (dummyvec(4) == 0._SRK) .AND. &
+           (dummyvec(5) == 0._SRK) .AND. &
+           (dummyvec(6) == 5._SRK)
+    ASSERT(bool, 'petscdense%get(...)')
+    bool = (dummyvec(7) == 2._SRK) .AND. &
+           (dummyvec(8) == 3._SRK) .AND. &
+           (dummyvec(9) == 6._SRK)
+    ASSERT(bool, 'petscdense%get(...)')
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'petscdensesquare%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'petscdensesquare%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'petscdensesquare%get(...)')
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%get(4,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'petscdensesquare%get(...)')
+    CALL thisMatrix%get(-1,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'petscdensesquare%get(...)')
+    CALL thisMatrix%get(2,-1,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'petscdensesquare%get(...)')
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(PETScMatrixType)
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'petscdensesquare%get(...)')
+  TYPE IS(PETScMatrixType)
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy == 0.0_SRK
+    ASSERT(bool, 'petscdensesquare%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
 
@@ -3446,8 +2439,8 @@ SELECTTYPE(thisMatrix)
 
 !Test for Trilinos sparsematrices
   ALLOCATE(TrilinosMatrixType :: thisMatrix)
-  COMPONENT_TEST("trilinosSparse%init")
   !check init
+  COMPONENT_TEST("trilinos%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->nlocal',10_SNK)
@@ -3461,10 +2454,9 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.(.NOT.thisMatrix%isSymmetric)
-      ASSERT(bool, 'Trilinos%init(...)')
+  TYPE IS(TrilinosMatrixType)
+    bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.(.NOT.thisMatrix%isSymmetric)
   ENDSELECT
   CALL thisMatrix%clear()
   CALL pList%clear()
@@ -3480,9 +2472,9 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      bool = .NOT. thisMatrix%isInit
-      ASSERT(bool, 'Trilinossparse%init(...)')
+  TYPE IS(TrilinosMatrixType)
+    bool = .NOT. thisMatrix%isInit
+    ASSERT(bool, 'Trilinossparse%init(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   !test with n<1
@@ -3497,7 +2489,7 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%clear()
 
   !check set
-  COMPONENT_TEST("trilinosSparse%set")
+  COMPONENT_TEST("trilinos%set")
   !test normal use case (unsymmetric and nonsymmetric)
   !want to build:
   ![1 2]
@@ -3517,17 +2509,17 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      CALL thisMatrix%assemble()
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
-      CALL thisMatrix%get(1,2,dummy)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
-      CALL thisMatrix%get(2,2,dummy)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
+  TYPE IS(TrilinosMatrixType)
+    CALL thisMatrix%assemble()
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(1,2,dummy)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(2,2,dummy)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   CALL pList%clear()
@@ -3546,22 +2538,22 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      ! manually assemble
-      CALL thisMatrix%assemble()
+  TYPE IS(TrilinosMatrixType)
+    ! manually assemble
+    CALL thisMatrix%assemble()
 
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy==1._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
-      CALL thisMatrix%get(1,2,dummy)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
-      CALL thisMatrix%get(2,1,dummy)
-      bool = dummy==2._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
-      CALL thisMatrix%get(2,2,dummy)
-      bool = dummy==3._SRK
-      ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy==1._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(1,2,dummy)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(2,1,dummy)
+    bool = dummy==2._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
+    CALL thisMatrix%get(2,2,dummy)
+    bool = dummy==3._SRK
+    ASSERT(bool, 'Trilinossparse%set(...)')
   ENDSELECT
 
   CALL thisMatrix%clear()
@@ -3594,8 +2586,17 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(1,5,1._SRK)
   !no crash? good
 
-!Test for Trilinos matrices (if necessary)
-#ifdef FUTILITY_HAVE_Trilinos
+  COMPONENT_TEST("trilinos%matvec")
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',3_SNK)
+  CALL pList%add('MatrixType->nlocal',3_SNK)
+  CALL pList%add('MatrixType->isSym',.FALSE.)
+  CALL pList%add('MatrixType->mattype',SPARSE)
+  dnnz=3
+  CALL pList%add('MatrixType->dnnz',dnnz)
+  dnnz=0
+  CALL pList%add('MatrixType->onnz',dnnz)
 
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)  !symmetric
@@ -3606,8 +2607,6 @@ SELECTTYPE(thisMatrix)
   CALL thisMatrix%set(3,1,4._SRK)
   CALL thisMatrix%set(3,2,5._SRK)
   CALL thisMatrix%set(3,3,6._SRK)
-
-  COMPONENT_TEST("trilinosSparse%matvec")
 !TODO: these interfaces are not implemented
 !      x=1.0_SRK
 !      y=1.0_SRK
@@ -3720,7 +2719,7 @@ SELECTTYPE(thisMatrix)
   FINFO() '-Trilsparse'
 
   !Perform test of functionality of get function
-  COMPONENT_TEST("trilinosSparse%get")
+  COMPONENT_TEST("trilinos%get")
   ![1 0 2]
   ![0 0 3]
   ![4 5 6]
@@ -3738,60 +2737,60 @@ SELECTTYPE(thisMatrix)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), sparse (0)
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      CALL thisMatrix%set(1,1,1._SRK)
-      CALL thisMatrix%set(1,3,2._SRK)
-      CALL thisMatrix%set(2,3,3._SRK)
-      CALL thisMatrix%set(3,1,4._SRK)
-      CALL thisMatrix%set(3,2,5._SRK)
-      CALL thisMatrix%set(3,3,6._SRK)
-      CALL thisMatrix%assemble()
-      IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-      ALLOCATE(dummyvec(9))
-      CALL thisMatrix%get(1,1,dummyvec(1))
-      CALL thisMatrix%get(2,1,dummyvec(2))
-      CALL thisMatrix%get(3,1,dummyvec(3))
-      CALL thisMatrix%get(1,2,dummyvec(4))
-      CALL thisMatrix%get(2,2,dummyvec(5))
-      CALL thisMatrix%get(3,2,dummyvec(6))
-      CALL thisMatrix%get(1,3,dummyvec(7))
-      CALL thisMatrix%get(2,3,dummyvec(8))
-      CALL thisMatrix%get(3,3,dummyvec(9))
-      bool = (dummyvec(1) == 1._SRK) .AND. &
-             (dummyvec(2) == 0._SRK) .AND. &
-             (dummyvec(3) == 4._SRK)
-      ASSERT(bool, 'Trilinossparse%get(...)')
-      bool = (dummyvec(4) == 0._SRK) .AND. &
-             (dummyvec(5) == 0._SRK) .AND. &
-             (dummyvec(6) == 5._SRK)
-      ASSERT(bool, 'Trilinossparse%get(...)')
-      FINFO() dummyvec(4:6)
-      bool = (dummyvec(7) == 2._SRK) .AND. &
-             (dummyvec(8) == 3._SRK) .AND. &
-             (dummyvec(9) == 6._SRK)
-      ASSERT(bool, 'Trilinossparse%get(...)')
-      FINFO() dummyvec(7:9)
+  TYPE IS(TrilinosMatrixType)
+    CALL thisMatrix%set(1,1,1._SRK)
+    CALL thisMatrix%set(1,3,2._SRK)
+    CALL thisMatrix%set(2,3,3._SRK)
+    CALL thisMatrix%set(3,1,4._SRK)
+    CALL thisMatrix%set(3,2,5._SRK)
+    CALL thisMatrix%set(3,3,6._SRK)
+    CALL thisMatrix%assemble()
+    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+    ALLOCATE(dummyvec(9))
+    CALL thisMatrix%get(1,1,dummyvec(1))
+    CALL thisMatrix%get(2,1,dummyvec(2))
+    CALL thisMatrix%get(3,1,dummyvec(3))
+    CALL thisMatrix%get(1,2,dummyvec(4))
+    CALL thisMatrix%get(2,2,dummyvec(5))
+    CALL thisMatrix%get(3,2,dummyvec(6))
+    CALL thisMatrix%get(1,3,dummyvec(7))
+    CALL thisMatrix%get(2,3,dummyvec(8))
+    CALL thisMatrix%get(3,3,dummyvec(9))
+    bool = (dummyvec(1) == 1._SRK) .AND. &
+           (dummyvec(2) == 0._SRK) .AND. &
+           (dummyvec(3) == 4._SRK)
+    ASSERT(bool, 'Trilinossparse%get(...)')
+    bool = (dummyvec(4) == 0._SRK) .AND. &
+           (dummyvec(5) == 0._SRK) .AND. &
+           (dummyvec(6) == 5._SRK)
+    ASSERT(bool, 'Trilinossparse%get(...)')
+    FINFO() dummyvec(4:6)
+    bool = (dummyvec(7) == 2._SRK) .AND. &
+           (dummyvec(8) == 3._SRK) .AND. &
+           (dummyvec(9) == 6._SRK)
+    ASSERT(bool, 'Trilinossparse%get(...)')
+    FINFO() dummyvec(7:9)
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      CALL thisMatrix%get(4,2,dummy)
-      bool = dummy == -1051._SRK
-      ASSERT(bool, 'Trilinossparse%get(...)')
-      CALL thisMatrix%get(-1,2,dummy)
-      bool = dummy==-1051._SRK
-      ASSERT(bool, 'Trilinossparse%get(...)')
-      CALL thisMatrix%get(2,-1,dummy)
-      bool = dummy==-1051._SRK
-      ASSERT(bool, 'Trilinossparse%get(...)')
+  TYPE IS(TrilinosMatrixType)
+    CALL thisMatrix%get(4,2,dummy)
+    bool = dummy == -1051._SRK
+    ASSERT(bool, 'Trilinossparse%get(...)')
+    CALL thisMatrix%get(-1,2,dummy)
+    bool = dummy==-1051._SRK
+    ASSERT(bool, 'Trilinossparse%get(...)')
+    CALL thisMatrix%get(2,-1,dummy)
+    bool = dummy==-1051._SRK
+    ASSERT(bool, 'Trilinossparse%get(...)')
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
   SELECTTYPE(thisMatrix)
-    TYPE IS(TrilinosMatrixType)
-      CALL thisMatrix%get(1,1,dummy)
-      bool = dummy == 0.0_SRK
-      ASSERT(bool, 'Trilinossparse%get(...)')
+  TYPE IS(TrilinosMatrixType)
+    CALL thisMatrix%get(1,1,dummy)
+    bool = dummy == 0.0_SRK
+    ASSERT(bool, 'Trilinossparse%get(...)')
   ENDSELECT
   CALL thisMatrix%clear()
   DEALLOCATE(thisMatrix)
@@ -4850,38 +3849,39 @@ SUBROUTINE testTransposeMatrix()
   CALL mat_p%set(4,2,9._SRK)
 
   SELECTTYPE(mat_p)
-    TYPE IS(BandedMatrixType)
-      CALL mat_p%assemble()
-      CALL mat_p%transpose()
-      bool = (mat_p%n == 5).AND.(mat_p%m == 4)
-      ASSERT(bool,"banded%transpose()")
-      bool = .TRUE.
-      CALL mat_p%get(1,1,dummy)
-      bool = bool .AND. dummy == 1.0_SRK
-      CALL mat_p%get(1,3,dummy)
-      bool = bool .AND. dummy == 8.0_SRK
-      CALL mat_p%get(2,1,dummy)
-      bool = bool .AND. dummy == 2.0_SRK
-      CALL mat_p%get(2,2,dummy)
-      bool = bool .AND. dummy == 3.0_SRK
-      CALL mat_p%get(2,4,dummy)
-      bool = bool .AND. dummy == 9.0_SRK
-      CALL mat_p%get(3,2,dummy)
-      bool = bool .AND. dummy == 4.0_SRK
-      CALL mat_p%get(3,3,dummy)
-      bool = bool .AND. dummy == 5.0_SRK
-      CALL mat_p%get(4,3,dummy)
-      bool = bool .AND. dummy == 6.0_SRK
-      CALL mat_p%get(4,4,dummy)
-      bool = bool .AND. dummy == 7.0_SRK
-      CALL mat_p%get(1,2,dummy)
-      bool = bool .AND. dummy == 0.0_SRK
-      ASSERT(bool,"banded%transpose()")
+  TYPE IS(BandedMatrixType)
+    CALL mat_p%assemble()
+    CALL mat_p%transpose()
+    bool = (mat_p%n == 5).AND.(mat_p%m == 4)
+    ASSERT(bool,"banded%transpose()")
+    bool = .TRUE.
+    CALL mat_p%get(1,1,dummy)
+    bool = bool .AND. dummy == 1.0_SRK
+    CALL mat_p%get(1,3,dummy)
+    bool = bool .AND. dummy == 8.0_SRK
+    CALL mat_p%get(2,1,dummy)
+    bool = bool .AND. dummy == 2.0_SRK
+    CALL mat_p%get(2,2,dummy)
+    bool = bool .AND. dummy == 3.0_SRK
+    CALL mat_p%get(2,4,dummy)
+    bool = bool .AND. dummy == 9.0_SRK
+    CALL mat_p%get(3,2,dummy)
+    bool = bool .AND. dummy == 4.0_SRK
+    CALL mat_p%get(3,3,dummy)
+    bool = bool .AND. dummy == 5.0_SRK
+    CALL mat_p%get(4,3,dummy)
+    bool = bool .AND. dummy == 6.0_SRK
+    CALL mat_p%get(4,4,dummy)
+    bool = bool .AND. dummy == 7.0_SRK
+    CALL mat_p%get(1,2,dummy)
+    bool = bool .AND. dummy == 0.0_SRK
+    ASSERT(bool,"banded%transpose()")
   ENDSELECT
   CALL mat_p%clear()
   DEALLOCATE(mat_p)
   NULLIFY(mat_p)
   CALL tmpPlist%clear()
+
 
 #ifdef FUTILITY_HAVE_PETSC
   COMPONENT_TEST('PETSc')
@@ -4946,13 +3946,13 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
   SELECTTYPE(mat_p)
-    TYPE IS(DenseSquareMatrixType)
-      DO i=1,mat_p%n
-        DO j=1,mat_p%n
-          bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
-          ASSERT(bool,"wrong zeroentries")
-        ENDDO
+  TYPE IS(DenseSquareMatrixType)
+    DO i=1,mat_p%n
+      DO j=1,mat_p%n
+        bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
+        ASSERT(bool,"wrong zeroentries")
       ENDDO
+    ENDDO
   ENDSELECT
   CALL mat_p%clear()
   DEALLOCATE(mat_p)
@@ -4968,13 +3968,13 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
   SELECTTYPE(mat_p)
-    TYPE IS(DenseRectMatrixType)
-      DO i=1,mat_p%n
-        DO j=1,mat_p%n
-          bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
-          ASSERT(bool,"wrong zeroentries")
-        ENDDO
+  TYPE IS(DenseRectMatrixType)
+    DO i=1,mat_p%n
+      DO j=1,mat_p%n
+        bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
+        ASSERT(bool,"wrong zeroentries")
       ENDDO
+    ENDDO
   ENDSELECT
   CALL mat_p%clear()
   DEALLOCATE(mat_p)
@@ -4990,13 +3990,13 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
   SELECTTYPE(mat_p)
-    TYPE IS(TridiagMatrixType)
-      DO i=1,SIZE(mat_p%a,DIM=1)
-        DO j=1,mat_p%n
-          bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
-          ASSERT(bool,"wrong zeroentries")
-        ENDDO
+  TYPE IS(TridiagMatrixType)
+    DO i=1,SIZE(mat_p%a,DIM=1)
+      DO j=1,mat_p%n
+        bool=(mat_p%a(i,j) .APPROXEQ. 0.0_SRK)
+        ASSERT(bool,"wrong zeroentries")
       ENDDO
+    ENDDO
   ENDSELECT
   CALL mat_p%clear()
   DEALLOCATE(mat_p)
@@ -5019,16 +4019,16 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL mat_p%set(3,1,8._SRK)
   CALL mat_p%set(4,2,9._SRK)
   SELECTTYPE(mat_p)
-    TYPE IS(BandedMatrixType)
-      CALL mat_p%assemble()
-      CALL mat_p%zeroentries()
+  TYPE IS(BandedMatrixType)
+    CALL mat_p%assemble()
+    CALL mat_p%zeroentries()
 
-      DO i=1,SIZE(mat_p%bands)
-        DO j=1,SIZE(mat_p%bands(i)%elem)
-          bool=(mat_p%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
-          ASSERT(bool,"banded%zeroentries()")
-        ENDDO
+    DO i=1,SIZE(mat_p%bands)
+      DO j=1,SIZE(mat_p%bands(i)%elem)
+        bool=(mat_p%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
+        ASSERT(bool,"banded%zeroentries()")
       ENDDO
+    ENDDO
   ENDSELECT
   CALL mat_p%clear()
   DEALLOCATE(mat_p)
@@ -5052,8 +4052,8 @@ SUBROUTINE testzeroEntriesMatrix()
 
   CALL testA%zeroentries()
   SELECTTYPE(mat_p)
-    TYPE IS(SparseMatrixType)
-      bool=ALL(testA%a(:) .APPROXEQ. (/0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK/))
+  TYPE IS(SparseMatrixType)
+    bool=ALL(testA%a(:) .APPROXEQ. (/0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK/))
   ENDSELECT
   ASSERT(bool,"wrong a")
   CALL tmpPlist%clear()

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -131,7 +131,7 @@ SUBROUTINE testMatrix()
   CALL yTrilinosVector%init(vecPlist)
 #endif
   COMPONENT_TEST("sparse%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !Test for sparse matrices
     !test clear
@@ -151,7 +151,7 @@ SUBROUTINE testMatrix()
   !clear it
   CALL thisMatrix%clear()
 
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !check for success
     bool = ((thisMatrix%jPrev == 0).AND.(thisMatrix%iPrev == 0)) &
@@ -159,7 +159,7 @@ SUBROUTINE testMatrix()
       .AND.((thisMatrix%nnz == 0).AND.(thisMatrix%n == 0)))
     ASSERT(bool, 'sparse%clear()')
     bool = (.NOT.ALLOCATED(thisMatrix%a) .AND. .NOT.ALLOCATED(thisMatrix%ja)) &
-            .AND. .NOT.ALLOCATED(thisMatrix%ia)
+        .AND. .NOT.ALLOCATED(thisMatrix%ia)
     ASSERT(bool, 'sparse%clear()')
   ENDSELECT
 
@@ -170,12 +170,12 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->nnz',10_SNK)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !check for success
     bool = (((thisMatrix%isInit) .OR. (thisMatrix%jCount == 0)) &
       .OR. ((thisMatrix%nnz == 10) .OR. (thisMatrix%n == 10))) &
-      .OR. ((thisMatrix%jPrev ==0) .OR. (thisMatrix%iPrev ==0))
+      .OR. ((thisMatrix%jPrev == 0) .OR. (thisMatrix%iPrev == 0))
     ASSERT(bool, 'sparse%init(...)')
     bool = ((SIZE(thisMatrix%a) == 10).OR.(SIZE(thisMatrix%ja) == 10)) &
       .OR.((SIZE(thisMatrix%ia) == 11).OR.(thisMatrix%ia(11) == 11))
@@ -194,13 +194,12 @@ SUBROUTINE testMatrix()
 
   !init it twice so on 2nd init, isInit==.TRUE.
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType); thisMatrix%nnz=1
+  SELECT TYPE(thisMatrix); TYPE IS(SparseMatrixType)
+    thisMatrix%nnz=1
   ENDSELECT
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
-    TYPE IS(SparseMatrixType)
-      ASSERT(thisMatrix%nnz==1, 'sparse%init(...)')
+  SELECT TYPE(thisMatrix); TYPE IS(SparseMatrixType)
+    ASSERT(thisMatrix%nnz==1, 'sparse%init(...)')
   ENDSELECT
   !init with n<1
   CALL thisMatrix%clear()
@@ -254,7 +253,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%clear()
   CALL thisMatrix%init(pList)
 
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     CALL thisMatrix%setShape(1,1,1._SRK)
     CALL thisMatrix%setShape(1,3,2._SRK)
@@ -335,7 +334,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(3,1,4._SRK)
   CALL thisMatrix%set(3,2,5._SRK)
   CALL thisMatrix%set(3,3,6._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     !now compare actual values with expected
     DO i=1,6
@@ -430,10 +429,10 @@ SUBROUTINE testMatrix()
   CALL xRealVector%init(vecPList)
   CALL yRealVector%init(vecPList)
   CALL thisMatrix%init(PList)
-  SELECTTYPE(x => xRealVector); TYPE IS(RealVectorType)
+  SELECT TYPE(x => xRealVector); TYPE IS(RealVectorType)
     CALL x%set(1.0_SRK)
   ENDSELECT
-  SELECTTYPE(mat => thisMatrix); TYPE IS(SparseMatrixType)
+  SELECT TYPE(mat => thisMatrix); TYPE IS(SparseMatrixType)
     CALL mat%setShape(1,1,1.0_SRK)
     CALL mat%setShape(1,2,2.0_SRK)
     CALL mat%setShape(1,3,3.0_SRK)
@@ -496,7 +495,7 @@ SUBROUTINE testMatrix()
   CALL vecPList%add('VectorType->n',8_SIK)
   CALL xRealVector%init(vecPList)
   CALL yRealVector%init(vecPList)
-  SELECTTYPE(x => xrealVector); TYPE IS(RealVectorType)
+  SELECT TYPE(x => xrealVector); TYPE IS(RealVectorType)
     CALL x%set(1.0_SRK)
   ENDSELECT
   dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
@@ -583,7 +582,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->n',3)
   CALL pList%add('MatrixType->nnz',6)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix); TYPE IS(SparseMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(SparseMatrixType)
     CALL thisMatrix%setShape(1,1)
   ENDSELECT
 
@@ -593,14 +592,14 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%clear()
   CALL thisMatrix%init(pList)
 
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     CALL thisMatrix%setShape(1,1)
     CALL thisMatrix%setShape(2,2)
   ENDSELECT
   CALL thisMatrix%set(1,2,1._SRK)
 
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     DO i=1,SIZE(thisMatrix%a)
       ASSERT(thisMatrix%a(i) /= 1._SRK, 'sparse%set(...)')
@@ -614,7 +613,7 @@ SUBROUTINE testMatrix()
   COMPONENT_TEST("sparse%get")
   CALL thisMatrix%clear()
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(SparseMatrixType)
     CALL thisMatrix%setShape(1,1,1._SRK)
     CALL thisMatrix%setShape(1,3,2._SRK)
@@ -652,7 +651,7 @@ SUBROUTINE testMatrix()
 !Test for dense square matrices
   ALLOCATE(DenseSquareMatrixType :: thisMatrix)
   COMPONENT_TEST("dense%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     !test clear
     !make matrix w/out using untested init
@@ -662,7 +661,7 @@ SUBROUTINE testMatrix()
     ALLOCATE(thisMatrix%a(10,10))
   ENDSELECT
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = (.NOT.(thisMatrix%isInit) .AND. (thisMatrix%n == 0)) &
         .AND. (.NOT.(thisMatrix%isSymmetric) &
@@ -677,7 +676,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.FALSE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = ((thisMatrix%isInit) .AND. (thisMatrix%n == 10)) &
         .AND. (.NOT.thisMatrix%isSymmetric)
@@ -692,7 +691,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.TRUE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = ((thisMatrix%isInit) .AND. (thisMatrix%n == 10)) &
             .AND. (thisMatrix%isSymmetric)
@@ -705,11 +704,11 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.TRUE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix); TYPE IS(DenseSquareMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(DenseSquareMatrixType)
     thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = .NOT. thisMatrix%isSymmetric
     ASSERT(bool, 'densesquare%init(...)')
@@ -746,7 +745,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = ((thisMatrix%a(1,1)==1._SRK) &
         .AND.(thisMatrix%a(1,2)==2._SRK)) &
@@ -843,10 +842,10 @@ SUBROUTINE testMatrix()
   CALL xRealVector%init(vecPList)
   CALL yRealVector%init(vecPList)
   CALL thisMatrix%init(PList)
-  SELECTTYPE(x => xRealVector); TYPE IS(RealVectorType)
+  SELECT TYPE(x => xRealVector); TYPE IS(RealVectorType)
     CALL x%set(1.0_SRK)
   ENDSELECT
-  SELECTTYPE(mat => thisMatrix); TYPE IS(DenseSquareMatrixType)
+  SELECT TYPE(mat => thisMatrix); TYPE IS(DenseSquareMatrixType)
     CALL mat%set(1,1,1.0_SRK)
     CALL mat%set(1,2,2.0_SRK)
     CALL mat%set(1,3,3.0_SRK)
@@ -909,7 +908,7 @@ SUBROUTINE testMatrix()
   CALL vecPList%add('VectorType->n',8_SIK)
   CALL xRealVector%init(vecPList)
   CALL yRealVector%init(vecPList)
-  SELECTTYPE(x => xrealVector); TYPE IS(RealVectorType)
+  SELECT TYPE(x => xrealVector); TYPE IS(RealVectorType)
     CALL x%set(1.0_SRK)
   ENDSELECT
   dummyvec=(/1.0000000_SRK,-0.5000000_SRK,-0.1666666666666666_SRK,-0.083333333333333333_SRK/)
@@ -959,7 +958,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     bool = ((thisMatrix%a(1,1)==1._SRK) &
         .AND.(thisMatrix%a(1,2)==2._SRK)) &
@@ -989,7 +988,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->n',3_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,3,2._SRK)
@@ -1023,7 +1022,7 @@ SUBROUTINE testMatrix()
     ASSERT(bool, 'densesquare%get(...)')
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -1037,7 +1036,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseSquareMatrixType)
     CALL thisMatrix%get(1,1,dummy)
     bool = dummy == 0.0_SRK
@@ -1049,7 +1048,7 @@ SUBROUTINE testMatrix()
 !Test for tri-diagonal matrices
   ALLOCATE(TriDiagMatrixType :: thisMatrix)
   COMPONENT_TEST("tridiag%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     !test clear
     !make matrix w/out using untested init
@@ -1071,7 +1070,7 @@ SUBROUTINE testMatrix()
   ASSERT(ncnt2-ncnt==2, 'BLAS_matvec(...) -tridiag expected failures')
 
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
         .AND.((.NOT.thisMatrix%isSymmetric) &
@@ -1086,7 +1085,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.FALSE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(.NOT.thisMatrix%isSymmetric)
@@ -1100,7 +1099,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.TRUE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(thisMatrix%isSymmetric)
@@ -1113,11 +1112,11 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->isSym',.TRUE.)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
     TYPE IS(TriDiagMatrixType); thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     bool = .NOT.thisMatrix%isSymmetric
     ASSERT(bool, 'tridiag%init(...)')
@@ -1158,7 +1157,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(2,2,2._SRK)
   CALL thisMatrix%set(2,3,5._SRK)
   CALL thisMatrix%set(3,3,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     DO i=1,3
       bool = thisMatrix%a(2,i) == i
@@ -1189,7 +1188,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(2,3,5._SRK)
   CALL thisMatrix%set(3,2,5._SRK)
   CALL thisMatrix%set(3,3,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     DO i=1,3
       bool = thisMatrix%a(2,i) == i
@@ -1234,7 +1233,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->n',3_SNK)
   CALL pList%add('MatrixType->isSym',.FALSE.)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,2,2._SRK)
@@ -1265,7 +1264,7 @@ SUBROUTINE testMatrix()
     ASSERT(bool, 'tridiag%get(...)') !column three check
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -1279,7 +1278,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TriDiagMatrixType)
     dummy=0.0_SRK
     CALL thisMatrix%get(1,1,dummy)
@@ -1303,7 +1302,7 @@ SUBROUTINE testMatrix()
     ALLOCATE(thisMatrix%bands(4))
     ALLOCATE(thisMatrix%bandIdx(4))
     ALLOCATE(thisMatrix%bands(2)%elem(5))
-  END SELECT
+  ENDSELECT
   CALL thisMatrix%clear()
   SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
@@ -1312,7 +1311,7 @@ SUBROUTINE testMatrix()
         .AND.(thisMatrix%nnz == 0) &
         .AND.(.NOT.ALLOCATED(thisMatrix%bands)))
     ASSERT(bool, 'banded%clear()')
-  END SELECT
+  ENDSELECT
 
   !check init
   COMPONENT_TEST("banded%init")
@@ -1322,7 +1321,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->nnz',12_SNK)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 12))
@@ -1332,11 +1331,11 @@ SUBROUTINE testMatrix()
   !test with double init (isInit==true on 2nd try)
 
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix); TYPE IS(BandedMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(BandedMatrixType)
     thisMatrix%m=1
   ENDSELECT
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     bool = thisMatrix%m == 1
     ASSERT(bool, 'banded%init(...)')
@@ -1396,7 +1395,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(3,4,6._SRK)
   CALL thisMatrix%set(4,4,7._SRK)
   CALL thisMatrix%set(4,2,9._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     CALL thisMatrix%assemble()
     bool = .TRUE.
@@ -1434,7 +1433,7 @@ SUBROUTINE testMatrix()
   SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     CALL thisMatrix%assemble()
-  END SELECT
+  ENDSELECT
 
   IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
   ALLOCATE(dummyvec(10))
@@ -1492,7 +1491,7 @@ SUBROUTINE testMatrix()
   ! Check zero vector
   dummyvec=0
   dummyvec2=1
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     CALL thisMatrix%assemble()
     WRITE(*,*) "calling matvec"
@@ -1505,7 +1504,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   ! Check for non-trivial vector
   dummyvec=(/1._SRK,2._SRK,3._SRK,4._SRK/)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
     bool = dummyvec2(1) == 5._SRK
@@ -1523,7 +1522,7 @@ SUBROUTINE testMatrix()
 !Test for dense rectangular matrices
   ALLOCATE(DenseRectMatrixType :: thisMatrix)
   COMPONENT_TEST("denseRect%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     !test clear
     !make matrix w/out using untested init
@@ -1533,7 +1532,7 @@ SUBROUTINE testMatrix()
     ALLOCATE(thisMatrix%a(10,15))
   ENDSELECT
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
         .AND.((thisMatrix%m == 0) &
@@ -1548,7 +1547,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->m',15_SNK)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.((thisMatrix%m == 15))
@@ -1560,11 +1559,11 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%clear()
   !test with double init (isInit==true on 2nd try)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix); TYPE IS(DenseRectMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(DenseRectMatrixType)
     thisMatrix%m=1
   ENDSELECT
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     bool = thisMatrix%m == 1
     ASSERT(bool, 'denserect%init(...)')
@@ -1606,7 +1605,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(2,1,4._SRK)
   CALL thisMatrix%set(2,2,5._SRK)
   CALL thisMatrix%set(2,3,6._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     DO i=1,3
       bool = (thisMatrix%a(1,i)== i).AND.(thisMatrix%a(2,i)== 3+i)
@@ -1694,7 +1693,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->n',2_SNK)
   CALL pList%add('MatrixType->m',3_SNK)
   CALL thisMatrix%init(pList)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,3,2._SRK)
@@ -1720,7 +1719,7 @@ SUBROUTINE testMatrix()
     ASSERT(bool, 'denserect%get(...)')
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -1734,7 +1733,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(DenseRectMatrixType)
     dummy=0.0_SRK
     CALL thisMatrix%get(1,1,dummy)
@@ -1750,7 +1749,7 @@ SUBROUTINE testMatrix()
 !Test for PETSc sparsematrices
   ALLOCATE(PETScMatrixType :: thisMatrix)
   COMPONENT_TEST("petscsparse%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     !test clear
     !make matrix w/out using untested init
@@ -1764,7 +1763,7 @@ SUBROUTINE testMatrix()
     CALL MatSetUp(thisMatrix%a,ierr)
   ENDSELECT
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
         .AND.((.NOT.thisMatrix%isSymmetric))
@@ -1780,7 +1779,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->matType',SPARSE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(.NOT.thisMatrix%isSymmetric)
@@ -1796,7 +1795,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->matType',SPARSE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(thisMatrix%isSymmetric)
@@ -1810,11 +1809,11 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->matType',SPARSE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix); TYPE IS(PETScMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(PETScMatrixType)
     thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = .NOT.thisMatrix%isSymmetric
     ASSERT(bool, 'petscsparse%init(...)')
@@ -1846,7 +1845,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     ! manually assemble
     CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
@@ -1890,7 +1889,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     ! manually assemble
     CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
@@ -2041,7 +2040,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->mattype',SPARSE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,3,2._SRK)
@@ -2076,7 +2075,7 @@ SUBROUTINE testMatrix()
     FINFO() dummyvec(7:9)
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -2090,7 +2089,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%get(1,1,dummy)
     bool = dummy == 0.0_SRK
@@ -2102,7 +2101,7 @@ SUBROUTINE testMatrix()
 !Test for PETSc dense square matrices
   ALLOCATE(PETScMatrixType :: thisMatrix)
   COMPONENT_TEST("petscdense%clear")
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     !test clear
     !make matrix w/out using untested init
@@ -2116,7 +2115,7 @@ SUBROUTINE testMatrix()
     CALL MatSetUp(thisMatrix%a,ierr)
   ENDSELECT
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((.NOT.thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
         .AND.((.NOT.thisMatrix%isSymmetric))
@@ -2132,7 +2131,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->mattype',DENSESQUARE) ! dense
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(.NOT.thisMatrix%isSymmetric)
@@ -2148,7 +2147,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->mattype',DENSESQUARE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(thisMatrix%isSymmetric)
@@ -2162,11 +2161,11 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->mattype',DENSESQUARE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix); TYPE IS(PETScMatrixType)
+  SELECT TYPE(thisMatrix); TYPE IS(PETScMatrixType)
     thisMatrix%isSymmetric=.FALSE.
   ENDSELECT
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     bool = .NOT.thisMatrix%isSymmetric
     ASSERT(bool, 'petscdense%init(...)')
@@ -2188,7 +2187,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     ! manually assemble
     CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
@@ -2217,7 +2216,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     ! manually assemble
     CALL MatAssemblyBegin(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
@@ -2374,7 +2373,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->mattype',DENSESQUARE)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), dense (1)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,3,2._SRK)
@@ -2407,7 +2406,7 @@ SUBROUTINE testMatrix()
     ASSERT(bool, 'petscdense%get(...)')
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -2421,7 +2420,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(PETScMatrixType)
     CALL thisMatrix%get(1,1,dummy)
     bool = dummy == 0.0_SRK
@@ -2453,7 +2452,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->onnz',dnnz)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, not symmetric (0), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     bool = ((thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
         .AND.(.NOT.thisMatrix%isSymmetric)
@@ -2471,7 +2470,7 @@ SUBROUTINE testMatrix()
   CALL pList%add('MatrixType->onnz',dnnz)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) !n=10, symmetric (1), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     bool = .NOT. thisMatrix%isInit
     ASSERT(bool, 'Trilinossparse%init(...)')
@@ -2508,7 +2507,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     CALL thisMatrix%assemble()
     CALL thisMatrix%get(1,1,dummy)
@@ -2537,7 +2536,7 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,1,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     ! manually assemble
     CALL thisMatrix%assemble()
@@ -2736,7 +2735,7 @@ SUBROUTINE testMatrix()
 
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList) ! non-symmetric (0), sparse (0)
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     CALL thisMatrix%set(1,1,1._SRK)
     CALL thisMatrix%set(1,3,2._SRK)
@@ -2772,7 +2771,7 @@ SUBROUTINE testMatrix()
     FINFO() dummyvec(7:9)
   ENDSELECT
   !test with out of bounds i,j, make sure no crash.
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     CALL thisMatrix%get(4,2,dummy)
     bool = dummy == -1051._SRK
@@ -2786,7 +2785,7 @@ SUBROUTINE testMatrix()
   ENDSELECT
   !test get with uninit, make sure no crash.
   CALL thisMatrix%clear()
-  SELECTTYPE(thisMatrix)
+  SELECT TYPE(thisMatrix)
   TYPE IS(TrilinosMatrixType)
     CALL thisMatrix%get(1,1,dummy)
     bool = dummy == 0.0_SRK
@@ -2852,7 +2851,7 @@ SUBROUTINE testMatrixMultSparse()
   ALPHA=1.0_SRK
   ! A: Square  B: Square  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA,transA='n')
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -2868,7 +2867,7 @@ SUBROUTINE testMatrixMultSparse()
   ENDSELECT
   ! A: Square  B: Square  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -2884,7 +2883,7 @@ SUBROUTINE testMatrixMultSparse()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -2900,7 +2899,7 @@ SUBROUTINE testMatrixMultSparse()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -2971,7 +2970,7 @@ SUBROUTINE testMatrixMultSquare()
   ALPHA=1.0_SRK
   ! A: Square  B: Square  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA,transA='n')
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -2986,7 +2985,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3001,7 +3000,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3016,7 +3015,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3052,7 +3051,7 @@ SUBROUTINE testMatrixMultSquare()
 
   ! A: Square  B: Square  C: Rect  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3067,7 +3066,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Rect  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3082,7 +3081,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Rect no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3097,7 +3096,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Rect no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3147,7 +3146,7 @@ SUBROUTINE testMatrixMultSquare()
 
   ! A: Square  B: Rect  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3162,7 +3161,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3177,7 +3176,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3192,7 +3191,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3228,7 +3227,7 @@ SUBROUTINE testMatrixMultSquare()
 
   ! A: Square  B: Rect  C: Rect  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3243,7 +3242,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Rect  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3258,7 +3257,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Rect no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3273,7 +3272,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Rect  C: Rect no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3332,7 +3331,7 @@ SUBROUTINE testMatrixMultSquare()
   ALPHA=1.0_SRK
   ! A: Square  B: Square  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA,transA='n')
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3348,7 +3347,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3364,7 +3363,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3380,7 +3379,7 @@ SUBROUTINE testMatrixMultSquare()
   ENDSELECT
   ! A: Square  B: Square  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(PETScMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3459,7 +3458,7 @@ SUBROUTINE testMatrixMultRect()
   ALPHA=1.0_SRK
   ! A: Rect  B: Square  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA,transB='n')
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3474,7 +3473,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3489,7 +3488,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3504,7 +3503,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3540,7 +3539,7 @@ SUBROUTINE testMatrixMultRect()
 
   ! A: Rect  B: Square  C: Rect  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3555,7 +3554,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Rect  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3570,7 +3569,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Rect no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3585,7 +3584,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Square  C: Rect no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3635,7 +3634,7 @@ SUBROUTINE testMatrixMultRect()
 
   ! A: Rect  B: Rect  C: Square  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3650,7 +3649,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Square  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3665,7 +3664,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Square no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3680,7 +3679,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Square no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3715,7 +3714,7 @@ SUBROUTINE testMatrixMultRect()
 
   ! A: Rect  B: Rect  C: Rect  alpha & beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3730,7 +3729,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Rect  alpha, no beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,alpha=ALPHA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3745,7 +3744,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Rect no alpha, beta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat,beta=BETA)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3760,7 +3759,7 @@ SUBROUTINE testMatrixMultRect()
   ENDSELECT
   ! A: Rect  B: Rect  C: Rect no alpha, nobeta
   CALL BLAS_matmult(A=thisMtrx,B=bmat,C=cmat)
-  SELECTTYPE(cmat)
+  SELECT TYPE(cmat)
   TYPE IS(DenseRectMatrixType)
     DO i=1,cmat%n
       DO j=1,cmat%n
@@ -3848,7 +3847,7 @@ SUBROUTINE testTransposeMatrix()
   CALL mat_p%set(3,1,8._SRK)
   CALL mat_p%set(4,2,9._SRK)
 
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(BandedMatrixType)
     CALL mat_p%assemble()
     CALL mat_p%transpose()
@@ -3945,7 +3944,7 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL params%add("MatrixType->engine",VM_NATIVE)
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(DenseSquareMatrixType)
     DO i=1,mat_p%n
       DO j=1,mat_p%n
@@ -3967,7 +3966,7 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL params%add("MatrixType->engine",VM_NATIVE)
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(DenseRectMatrixType)
     DO i=1,mat_p%n
       DO j=1,mat_p%n
@@ -3989,7 +3988,7 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL params%add("MatrixType->engine",VM_NATIVE)
   CALL mat_p%init(params)
   CALL mat_p%zeroentries()
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(TridiagMatrixType)
     DO i=1,SIZE(mat_p%a,DIM=1)
       DO j=1,mat_p%n
@@ -4018,7 +4017,7 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL mat_p%set(4,4,7._SRK)
   CALL mat_p%set(3,1,8._SRK)
   CALL mat_p%set(4,2,9._SRK)
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(BandedMatrixType)
     CALL mat_p%assemble()
     CALL mat_p%zeroentries()
@@ -4051,7 +4050,7 @@ SUBROUTINE testzeroEntriesMatrix()
   CALL testA%setShape(4,4,6.0_SRK)
 
   CALL testA%zeroentries()
-  SELECTTYPE(mat_p)
+  SELECT TYPE(mat_p)
   TYPE IS(SparseMatrixType)
     bool=ALL(testA%a(:) .APPROXEQ. (/0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK,0.0_SRK/))
   ENDSELECT
@@ -4124,13 +4123,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "dense square matrix not allocated")
   ASSERT(mat_p%isInit, "dense square matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(DenseSquareMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(DenseSquareMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for dense square matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(DenseSquareMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(DenseSquareMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4152,13 +4151,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "dense rect matrix not allocated")
   ASSERT(mat_p%isInit, "dense rect matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(DenseRectMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(DenseRectMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for dense rect matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(DenseRectMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(DenseRectMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4179,13 +4178,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "sparse matrix not allocated")
   ASSERT(mat_p%isInit, "sparse matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(SparseMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(SparseMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for sparse matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(SparseMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(SparseMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4206,13 +4205,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "tridiag matrix not allocated")
   ASSERT(mat_p%isInit, "tridiag matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(TridiagMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(TridiagMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for tridiag matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(TridiagMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(TridiagMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4236,13 +4235,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "PETSc matrix not allocated")
   ASSERT(mat_p%isInit, "PETSc matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(PETScMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(PETScMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for PETSc matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(PETScMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(PETScMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4272,13 +4271,13 @@ SUBROUTINE testFactories()
   CALL MatrixFactory(mat_p,params)
   ASSERT(ASSOCIATED(mat_p), "Trilinos matrix not allocated")
   ASSERT(mat_p%isInit, "Trilinos matrix not initialized")
-  SELECTTYPE(mat_p); TYPE IS(TrilinosMatrixType)
+  SELECT TYPE(mat_p); TYPE IS(TrilinosMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for Trilinos matrix")
   ENDSELECT
   CALL MatrixResemble(other_mat_p,mat_p,params)
-  SELECTTYPE(other_mat_p); TYPE IS(TrilinosMatrixType)
+  SELECT TYPE(other_mat_p); TYPE IS(TrilinosMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for cloned matrix")
@@ -4303,7 +4302,7 @@ SUBROUTINE testFactories()
   CALL DistributedMatrixFactory(dmat_p,params)
   ASSERT(ASSOCIATED(dmat_p), "PETSc matrix not allocated")
   ASSERT(dmat_p%isInit, "PETSc matrix not initialized")
-  SELECTTYPE(dmat_p); TYPE IS(PETScMatrixType)
+  SELECT TYPE(dmat_p); TYPE IS(PETScMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for PETSc matrix")
@@ -4331,7 +4330,7 @@ SUBROUTINE testFactories()
   CALL DistributedMatrixFactory(dmat_p,params)
   ASSERT(ASSOCIATED(dmat_p), "Trilinos matrix not allocated")
   ASSERT(dmat_p%isInit, "Trilinos matrix not initialized")
-  SELECTTYPE(dmat_p); TYPE IS(TrilinosMatrixType)
+  SELECT TYPE(dmat_p); TYPE IS(TrilinosMatrixType)
     ASSERT(.TRUE., "yay")
   CLASS DEFAULT
     ASSERT(.FALSE., "Wrong TYPE ALLOCATED for Trilinos matrix")

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -55,7 +55,8 @@ CALL e%setQuietMode(.TRUE.)
 CALL eParams%addSurrogate(e)
 CALL eMatrixType%addSurrogate(e)
 
-REGISTER_SUBTEST("Matrix Types",testMatrix)
+!REGISTER_SUBTEST("Distributed Banded Matrix",testDistrBandMatrix)
+REGISTER_SUBTEST("Distributed Block-Banded Matrix",testDistrBlockBandMatrix)
 
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -69,19 +70,407 @@ FINALIZE_TEST()
 CONTAINS
 !
 !-------------------------------------------------------------------------------
-SUBROUTINE testMatrix()
+SUBROUTINE testDistrBandMatrix()
 #ifdef HAVE_MPI
-  TYPE(ParamType) :: pList
-  INTEGER(SIK) :: rank, nproc, mpierr
-#if defined(FUTILITY_HAVE_PETSC) || defined(FUTILITY_HAVE_Trilinos)
-  CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
-  REAL(SRK) :: val
-#endif
+  IMPLICIT NONE
 
-  CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
-  CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
+  TYPE(ParamType) :: pList,optListMat,distVecPList
+  INTEGER(SIK) :: rank,nproc,mpierr,i,j
+  CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
+  TYPE(NativeDistributedVectorType),ALLOCATABLE :: distrVec1, distrVec2
+  REAL(SRK),ALLOCATABLE :: dummyvec(:),dummyvec2(:)
+  REAL(SRK) :: val
+  LOGICAL(SBK) :: bool
+
+
+  CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
+  CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)
 
   ASSERT(nproc==2, 'nproc valid')
+!Test for distributed banded matrices
+  ALLOCATE(DistributedBandedMatrixType :: thisMatrix)
+  SELECTTYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+    !test clear
+    !make matrix w/out using untested init
+    thisMatrix%isInit=.TRUE.
+    thisMatrix%n=10
+    thisMatrix%m=15
+    thisMatrix%nnz=4
+    thisMatrix%isCreated=.TRUE.
+    thisMatrix%isAssembled=.FALSE.
+    thisMatrix%comm=33
+    ALLOCATE(thisMatrix%chunks(2))
+    ALLOCATE(thisMatrix%iOffsets(3))
+    ALLOCATE(thisMatrix%jOffsets(3))
+  ENDSELECT
+  CALL thisMatrix%clear()
+  SELECT TYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+      bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
+          .AND.(thisMatrix%m == 0) &
+          .AND.(thisMatrix%nLocal == 0) &
+          .AND.(thisMatrix%isCreated == .FALSE.) &
+          .AND.(thisMatrix%isAssembled == .FALSE.) &
+          .AND.(thisMatrix%comm == MPI_COMM_NULL) &
+          .AND.(thisMatrix%m == 0) &
+          .AND.(.NOT.ALLOCATED(thisMatrix%chunks)) &
+          .AND.(.NOT.ALLOCATED(thisMatrix%jOffsets)) &
+          .AND.(.NOT.ALLOCATED(thisMatrix%iOffsets))
+      ASSERT(bool, 'DistributedBandedMatrixType%clear()')
+  END SELECT
+  !check init
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%add('MatrixType->m',15_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  SELECT TYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+      bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+          .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 9))
+      ASSERT(bool, 'banded%init(...)')
+      IF(rank == 0) THEN
+        bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
+                ALLOCATED(thisMatrix%jTmp) .AND. &
+                ALLOCATED(thisMatrix%elemTmp) .AND. &
+                ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
+                ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
+                thisMatrix%nLocal == 0 .AND. &
+                .NOT.ALLOCATED(thisMatrix%chunks))
+        ASSERT(bool, 'banded%init')
+      ELSE
+        bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
+                ALLOCATED(thisMatrix%jTmp) .AND. &
+                ALLOCATED(thisMatrix%elemTmp) .AND. &
+                thisMatrix%nLocal == 0 .AND. &
+                ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
+                ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
+                .NOT.ALLOCATED(thisMatrix%chunks))
+        ASSERT(bool, 'banded%init')
+      ENDIF
+  ENDSELECT
+  CALL thisMatrix%clear()
+  !test with double init (isInit==true on 2nd try)
+  WRITE(*,*) "Beginning double init"
+  CALL thisMatrix%init(pList)
+  SELECTTYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType); thisMatrix%m=1
+  ENDSELECT
+  CALL thisMatrix%init(pList)
+  SELECTTYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+      bool = thisMatrix%m == 1
+      ASSERT(bool, 'banded%init(...)')
+  ENDSELECT
+  CALL thisMatrix%clear()
+  !test with n<1
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',-1_SNK)
+  CALL pList%add('MatrixType->m',10_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  bool = .NOT.thisMatrix%isInit
+  ASSERT(bool, 'banded%init(...)')
+  CALL thisMatrix%clear()
+  !test with m<1
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%add('MatrixType->m',-1_SNK)
+  CALL pList%add('MatrixType->nnz',3_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  bool = .NOT.thisMatrix%isInit
+  ASSERT(bool, 'banded%init(...)')
+  CALL thisMatrix%clear()
+  !test with nnz<1
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',10_SNK)
+  CALL pList%add('MatrixType->m',15_SNK)
+  CALL pList%add('MatrixType->nnz',-1_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList) !expect exception
+  bool = .NOT.thisMatrix%isInit
+  ASSERT(bool, 'banded%init(...)')
+  CALL thisMatrix%clear()
+  WRITE(*,*) '  Passed: CALL banded%init(...)'
+
+  !check set
+  !test normal use case (split diagonal)
+  !want to build:
+  ![3 0 7 0 0]
+  ![0 4 0 8 0]
+  ![1 0 5 0 9]
+  ![0 2 0 6 0]
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',5_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(3,1,1._SRK)
+  CALL thisMatrix%set(4,2,2._SRK)
+  CALL thisMatrix%set(1,1,3._SRK)
+  CALL thisMatrix%set(2,2,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(4,4,6._SRK)
+  CALL thisMatrix%set(1,3,7._SRK)
+  CALL thisMatrix%set(2,4,8._SRK)
+  CALL thisMatrix%set(3,5,9._SRK)
+  CALL thisMatrix%assemble()
+  SELECTTYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+      IF(rank == 0) THEN
+        bool = SIZE(thisMatrix%chunks) == 2
+        bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 2
+        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 2
+        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 3
+        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(2) == 4
+        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(2)%elem) == 1
+        bool = bool .AND. thisMatrix%chunks(1)%bands(2)%elem(1) == 7
+        bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
+        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 2
+        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 1
+        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(2) == 2
+        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
+        bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 5
+        ASSERT(bool, 'banded%set(...)')
+      ELSE
+        bool = SIZE(thisMatrix%chunks) == 2
+        bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 1
+        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 1
+        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 8
+        bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
+        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 1
+        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 6
+        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
+        bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 9
+        ASSERT(bool, 'banded%set(...)')
+      ENDIF
+  ENDSELECT
+  CALL thisMatrix%clear()
+  WRITE(*,*) '  Passed: CALL banded%set(...)'
+  !check get functionality
+  ![3 0 7 0 0]
+  ![0 4 0 8 0]
+  ![1 0 5 0 9]
+  ![0 2 0 6 0]
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',5_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(3,1,1._SRK)
+  CALL thisMatrix%set(4,2,2._SRK)
+  CALL thisMatrix%set(1,1,3._SRK)
+  CALL thisMatrix%set(2,2,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(4,4,6._SRK)
+  CALL thisMatrix%set(1,3,7._SRK)
+  CALL thisMatrix%set(2,4,8._SRK)
+  CALL thisMatrix%set(3,5,9._SRK)
+  CALL thisMatrix%assemble()
+  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+  ALLOCATE(dummyvec(13))
+  dummyvec=0
+  CALL thisMatrix%get(1,1,dummyvec(1))
+  CALL thisMatrix%get(1,2,dummyvec(2))
+  CALL thisMatrix%get(1,3,dummyvec(3))
+  CALL thisMatrix%get(2,2,dummyvec(4))
+  CALL thisMatrix%get(2,4,dummyvec(5))
+  CALL thisMatrix%get(2,5,dummyvec(6))
+  CALL thisMatrix%get(3,1,dummyvec(7))
+  CALL thisMatrix%get(3,2,dummyvec(8))
+  CALL thisMatrix%get(3,3,dummyvec(9))
+  CALL thisMatrix%get(3,5,dummyvec(10))
+  CALL thisMatrix%get(4,2,dummyvec(11))
+  CALL thisMatrix%get(4,4,dummyvec(12))
+  CALL thisMatrix%get(4,5,dummyvec(13))
+
+  bool = .TRUE.
+  bool = bool .AND. dummyvec(1) == 3._SRK
+  bool = bool .AND. dummyvec(2) == 0._SRK
+  bool = bool .AND. dummyvec(3) == 7._SRK
+  bool = bool .AND. dummyvec(4) == 4._SRK
+  bool = bool .AND. dummyvec(5) == 8._SRK
+  bool = bool .AND. dummyvec(6) == 0._SRK
+  bool = bool .AND. dummyvec(7) == 1._SRK
+  bool = bool .AND. dummyvec(8) == 0._SRK
+  bool = bool .AND. dummyvec(9) == 5._SRK
+  bool = bool .AND. dummyvec(10) == 9._SRK
+  bool = bool .AND. dummyvec(11) == 2._SRK
+  bool = bool .AND. dummyvec(12) == 6._SRK
+  bool = bool .AND. dummyvec(13) == 0._SRK
+  ASSERT(bool, 'banded%get(...)')
+
+  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+  CALL thisMatrix%clear()
+  WRITE(*,*) '  Passed: CALL banded%get(...)'
+  !check transpose functionality
+  ![1 2 0 0 0]
+  ![0 3 4 0 0]
+  ![0 0 5 6 0]
+  ![0 0 0 7 0]
+  !with main diagonal split [1,3],[5,7]
+  !to
+  ![1 0 0 0]
+  ![2 3 0 0]
+  ![0 4 5 0]
+  ![0 0 6 7]
+  ![0 0 0 0]
+  ! CALL thisMatrix%clear()
+  ! CALL pList%clear()
+  ! CALL pList%add('MatrixType->n',4_SNK)
+  ! CALL pList%add('MatrixType->m',5_SNK)
+  ! CALL pList%add('MatrixType->nnz',7_SNK)
+  ! CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  ! CALL pList%validate(pList,optListMat)
+  ! CALL thisMatrix%init(pList)
+  ! CALL thisMatrix%set(1,1,1._SRK)
+  ! CALL thisMatrix%set(1,2,2._SRK)
+  ! CALL thisMatrix%set(2,2,3._SRK)
+  ! CALL thisMatrix%set(2,3,4._SRK)
+  ! CALL thisMatrix%set(3,3,5._SRK)
+  ! CALL thisMatrix%set(3,4,6._SRK)
+  ! CALL thisMatrix%set(4,4,7._SRK)
+  ! CALL thisMatrix%assemble()
+  ! CALL thisMatrix%transpose()
+  !
+  ! ALLOCATE(dummyvec(7))
+  ! CALL thisMatrix%get(1,1,dummyvec(1))
+  ! CALL thisMatrix%get(2,1,dummyvec(2))
+  ! CALL thisMatrix%get(2,2,dummyvec(3))
+  ! CALL thisMatrix%get(3,2,dummyvec(4))
+  ! CALL thisMatrix%get(3,3,dummyvec(5))
+  ! CALL thisMatrix%get(4,3,dummyvec(6))
+  ! CALL thisMatrix%get(4,4,dummyvec(7))
+  !
+  ! bool = .TRUE.
+  ! bool = bool .AND. dummyvec(1) == 1
+  ! bool = bool .AND. dummyvec(2) == 2
+  ! bool = bool .AND. dummyvec(3) == 3
+  ! bool = bool .AND. dummyvec(4) == 4
+  ! bool = bool .AND. dummyvec(5) == 5
+  ! bool = bool .AND. dummyvec(6) == 6
+  ! bool = bool .AND. dummyvec(7) == 7
+  ! ASSERT(bool,"banded%transpose()")
+  !
+  ! CALL thisMatrix%clear()
+  ! WRITE(*,*) '  Passed: CALL banded%transpose(...)'
+
+  !check zero_entries functionality
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',5_SNK)
+  CALL pList%add('MatrixType->nnz',7_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(2,3,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
+  CALL thisMatrix%assemble()
+  CALL thisMatrix%zeroentries()
+  SELECTTYPE(thisMatrix)
+    TYPE IS(DistributedBandedMatrixType)
+      DO i=1,SIZE(thisMatrix%chunks(1)%bands)
+        ! The rank1 chunk1 will not be initialized, so skip
+        IF(rank==0) THEN
+          DO j=1,SIZE(thisMatrix%chunks(1)%bands(i)%elem)
+            bool=(thisMatrix%chunks(1)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
+            ASSERT(bool,"banded%zero()")
+          ENDDO
+        END IF
+      ENDDO
+      DO i=1,SIZE(thisMatrix%chunks(2)%bands)
+        DO j=1,SIZE(thisMatrix%chunks(2)%bands(i)%elem)
+          bool=(thisMatrix%chunks(2)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
+          ASSERT(bool,"banded%zero()")
+        ENDDO
+      ENDDO
+  ENDSELECT
+  CALL thisMatrix%clear()
+  WRITE(*,*) '  Passed: CALL banded%zero(...)'
+
+  !check matvec functionality
+  ![1 2 0 0]
+  ![0 3 0 0]
+  ![0 0 5 6]
+  ![0 9 0 7]
+
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',4_SNK)
+  CALL pList%add('MatrixType->nnz',7_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
+  CALL thisMatrix%set(4,2,9._SRK)
+  CALL thisMatrix%assemble()
+  IF(ALLOCATED(distrVec1)) DEALLOCATE(distrVec1)
+  IF(ALLOCATED(distrVec2)) DEALLOCATE(distrVec2)
+  ALLOCATE(NativeDistributedVectorType :: distrVec1)
+  ALLOCATE(NativeDistributedVectorType :: distrVec2)
+
+  CALL distVecPList%clear()
+  CALL distVecPList%add('VectorType->n',4)
+  CALL distVecPList%add('VectorType->MPI_Comm_ID',PE_COMM_WORLD)
+  CALL distrVec1%init(distVecPList)
+  CALL distrVec2%init(distVecPList)
+
+  ! Check zero vector
+  distrVec1%b = 0.0_SRK
+  distrVec2%b = 0.0_SRK
+
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
+  DO i=1,2
+    bool = ALL(ABS(distrVec2%b) < 1E-6)
+    ASSERT(bool, 'banded%matvec(...)')
+  ENDDO
+  ! Check for non-trivial vector
+  IF (rank == 0) THEN
+    distrVec1%b = (/1._SRK,2._SRK/)
+  ELSE
+    distrVec1%b = (/3._SRK,4._SRK/)
+  END IF
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,alpha=1.0_SRK,beta=0.0_SRK)
+  IF (rank == 0) THEN
+    bool = distrVec2%b(1) == 5._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(2) == 6._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+  ELSE
+    bool = distrVec2%b(1) == 39._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(2) == 46._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+  END IF
+
+  WRITE(*,*) '  Passed: CALL banded%matvec(...)'
+  DEALLOCATE(thisMatrix)
 
   ! Create matrix that looks like this
   ! 1 0 2 0
@@ -91,6 +480,7 @@ SUBROUTINE testMatrix()
   ! Rank 0 owns rows 1 and 2
   ! Rank 1 owns rows 3 and 4
 
+  CALL pList%clear()
   CALL pList%add('MatrixType->n',4_SNK)
   CALL pList%add('MatrixType->nLocal',2_SNK)
   CALL pList%add('MatrixType->nnz',2_SNK)
@@ -166,5 +556,128 @@ SUBROUTINE testMatrix()
   CALL pList%clear()
 
 #endif
-ENDSUBROUTINE testMatrix
+ENDSUBROUTINE testDistrBandMatrix
+
+SUBROUTINE testDistrBlockBandMatrix()
+#ifdef HAVE_MPI
+  IMPLICIT NONE
+
+  TYPE(ParamType) :: pList,optListMat,distVecPList
+  INTEGER(SIK) :: rank,nproc,mpierr,i,j
+  TYPE(DistributedBlockBandedMatrixType),ALLOCATABLE :: thisMatrix
+  TYPE(NativeDistributedVectorType),ALLOCATABLE :: distrVec1, distrVec2
+  REAL(SRK),ALLOCATABLE :: dummyvec(:),dummyvec2(:)
+  REAL(SRK) :: val
+  LOGICAL(SBK) :: bool
+
+
+  CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
+  CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)
+
+  ASSERT(nproc==2, 'nproc valid')
+!Test for distributed block banded matrices
+  ALLOCATE(DistributedBlockBandedMatrixType :: thisMatrix)
+
+  !check init
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',12_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALl pList%add('MatrixType->blockSize',3_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+
+  CALL pList%validate(pList)
+  CALL thisMatrix%init(pList)
+  bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 12))
+  ASSERT(bool, 'banded%init(...)')
+  IF(rank == 0) THEN
+    bool = (ALLOCATED(thisMatrix%blocks) .AND. &
+            SIZE(thisMatrix%blocks)==2   .AND. &
+            thisMatrix%blockOffset==0    .AND. &
+            thisMatrix%nLocalBlocks==2   .AND. &
+            thisMatrix%blockMask==.FALSE.)
+    ASSERT(bool, 'banded%init')
+  ELSE
+    bool = (ALLOCATED(thisMatrix%blocks) .AND. &
+            SIZE(thisMatrix%blocks)==2   .AND. &
+            thisMatrix%blockOffset==2    .AND. &
+            thisMatrix%nLocalBlocks==2   .AND. &
+            thisMatrix%blockMask==.FALSE.)
+    ASSERT(bool, 'banded%init')
+  ENDIF
+
+  CALL thisMatrix%clear()
+
+  !check matvec functionality
+  ![1 2 0 0 0 0]
+  ![0 3 0 0 0 0]
+  ![0 0 5 6 0 0]
+  ![0 9 0 7 0 0]
+  ![0 0 0 0 1 0]
+  ![0 0 0 0 0 1]
+
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',6_SNK)
+  CALL plist%add('MatrixType->blockSize',2_SNK)
+  CALL pList%add('MatrixType->nnz',1_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  WRITE(*,*) "matrix set calls"
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
+  CALL thisMatrix%set(4,2,9._SRK)
+  CALL thisMatrix%set(5,5,1._SRK)
+  CALL thisMatrix%set(6,6,1._SRK)
+  CALL thisMatrix%assemble()
+  IF(ALLOCATED(distrVec1)) DEALLOCATE(distrVec1)
+  IF(ALLOCATED(distrVec2)) DEALLOCATE(distrVec2)
+  ALLOCATE(NativeDistributedVectorType :: distrVec1)
+  ALLOCATE(NativeDistributedVectorType :: distrVec2)
+
+  CALL distVecPList%clear()
+  CALL distVecPList%add('VectorType->n',6)
+  CALL distVecPList%add('VectorType->chunkSize',2)
+  CALL distVecPList%add('VectorType->MPI_Comm_ID',PE_COMM_WORLD)
+  WRITE(*,*) "Vec init"
+  CALL distrVec1%init(distVecPList)
+  CALL distrVec2%init(distVecPList)
+
+  ! Check zero vector
+  distrVec1%b = 0.0_SRK
+  distrVec2%b = 0.0_SRK
+
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,ALPHA=1.0_SRK,beta=0.0_SRK)
+  bool = ALL(ABS(distrVec2%b) < 1E-6)
+  ASSERT(bool, 'banded%matvec(...)')
+
+  ! Check for non-trivial vector
+  IF (rank == 0) THEN
+    distrVec1%b = (/1._SRK,2._SRK,3._SRK,4._SRK/)
+  ELSE
+    distrVec1%b = (/1.0_SRK,1.0_SRK/)
+  END IF
+
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,alpha=1.0_SRK,beta=0.0_SRK)
+  IF (rank == 0) THEN
+    bool = distrVec2%b(1) == 5._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(2) == 6._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(3) == 39._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(4) == 46._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+  ELSE
+    ASSERT(ALL(ABS(distrVec2%b-1) < 1E-6),'banded%matvec(...)')
+  END IF
+
+  WRITE(*,*) '  Passed: CALL banded%matvec(...)'
+  DEALLOCATE(thisMatrix)
+  CALL pList%clear()
+#endif
+ENDSUBROUTINE testDistrBlockBandMatrix
 ENDPROGRAM testMatrixTypesParallel

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -429,8 +429,6 @@ SUBROUTINE testPetscMatrix()
   INTEGER(SIK) :: rank,nproc,mpierr
   CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
   REAL(SRK) :: val
-  REAL(SRK),ALLOCATABLE :: dummyvec(:)
-  LOGICAL(SBK) :: bool
 
   CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
   CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -55,7 +55,8 @@ CALL e%setQuietMode(.TRUE.)
 CALL eParams%addSurrogate(e)
 CALL eMatrixType%addSurrogate(e)
 
-!REGISTER_SUBTEST("Distributed Banded Matrix",testDistrBandMatrix)
+REGISTER_SUBTEST("PETSc Matrix",testPetscMatrix)
+REGISTER_SUBTEST("Distributed Banded Matrix",testDistrBandMatrix)
 REGISTER_SUBTEST("Distributed Block-Banded Matrix",testDistrBlockBandMatrix)
 
 
@@ -79,7 +80,6 @@ SUBROUTINE testDistrBandMatrix()
   CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
   TYPE(NativeDistributedVectorType),ALLOCATABLE :: distrVec1, distrVec2
   REAL(SRK),ALLOCATABLE :: dummyvec(:),dummyvec2(:)
-  REAL(SRK) :: val
   LOGICAL(SBK) :: bool
 
 
@@ -89,6 +89,8 @@ SUBROUTINE testDistrBandMatrix()
   ASSERT(nproc==2, 'nproc valid')
 !Test for distributed banded matrices
   ALLOCATE(DistributedBandedMatrixType :: thisMatrix)
+
+  COMPONENT_TEST("distBand%clear")
   SELECTTYPE(thisMatrix)
     TYPE IS(DistributedBandedMatrixType)
     !test clear
@@ -106,20 +108,23 @@ SUBROUTINE testDistrBandMatrix()
   ENDSELECT
   CALL thisMatrix%clear()
   SELECT TYPE(thisMatrix)
-    TYPE IS(DistributedBandedMatrixType)
-      bool = (.NOT.(thisMatrix%isInit).AND.(thisMatrix%n == 0)) &
-          .AND.(thisMatrix%m == 0) &
-          .AND.(thisMatrix%nLocal == 0) &
-          .AND.(thisMatrix%isCreated == .FALSE.) &
-          .AND.(thisMatrix%isAssembled == .FALSE.) &
-          .AND.(thisMatrix%comm == MPI_COMM_NULL) &
-          .AND.(thisMatrix%m == 0) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%chunks)) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%jOffsets)) &
-          .AND.(.NOT.ALLOCATED(thisMatrix%iOffsets))
-      ASSERT(bool, 'DistributedBandedMatrixType%clear()')
+  TYPE IS(DistributedBandedMatrixType)
+    bool = (thisMatrix%isInit == .FALSE. &
+        .AND.(thisMatrix%n == 0) &
+        .AND.(thisMatrix%m == 0) &
+        .AND.(thisMatrix%nLocal == 0) &
+        .AND.(thisMatrix%isCreated == .FALSE.) &
+        .AND.(thisMatrix%isAssembled == .FALSE.) &
+        .AND.(thisMatrix%comm == MPI_COMM_NULL) &
+        .AND.(thisMatrix%m == 0) &
+        .AND.(.NOT.ALLOCATED(thisMatrix%chunks)) &
+        .AND.(.NOT.ALLOCATED(thisMatrix%jOffsets)) &
+        .AND.(.NOT.ALLOCATED(thisMatrix%iOffsets)))
+    ASSERT(bool, 'DistributedBandedMatrixType%clear()')
   END SELECT
+
   !check init
+  COMPONENT_TEST("distrBand%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',10_SNK)
   CALL pList%add('MatrixType->m',15_SNK)
@@ -129,33 +134,33 @@ SUBROUTINE testDistrBandMatrix()
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
   SELECT TYPE(thisMatrix)
-    TYPE IS(DistributedBandedMatrixType)
-      bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
-          .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 9))
-      ASSERT(bool, 'banded%init(...)')
-      IF(rank == 0) THEN
-        bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
-                ALLOCATED(thisMatrix%jTmp) .AND. &
-                ALLOCATED(thisMatrix%elemTmp) .AND. &
-                ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
-                ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
-                thisMatrix%nLocal == 0 .AND. &
-                .NOT.ALLOCATED(thisMatrix%chunks))
-        ASSERT(bool, 'banded%init')
-      ELSE
-        bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
-                ALLOCATED(thisMatrix%jTmp) .AND. &
-                ALLOCATED(thisMatrix%elemTmp) .AND. &
-                thisMatrix%nLocal == 0 .AND. &
-                ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
-                ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
-                .NOT.ALLOCATED(thisMatrix%chunks))
-        ASSERT(bool, 'banded%init')
-      ENDIF
+  TYPE IS(DistributedBandedMatrixType)
+    bool = (( thisMatrix%isInit).AND.(thisMatrix%n == 10)) &
+        .AND.((thisMatrix%m == 15).AND.(thisMatrix%nnz == 9))
+    ASSERT(bool, 'banded%init(...)')
+    IF(rank == 0) THEN
+      bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
+              ALLOCATED(thisMatrix%jTmp) .AND. &
+              ALLOCATED(thisMatrix%elemTmp) .AND. &
+              ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
+              ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
+              thisMatrix%nLocal == 0 .AND. &
+              .NOT.ALLOCATED(thisMatrix%chunks))
+      ASSERT(bool, 'banded%init')
+    ELSE
+      bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
+              ALLOCATED(thisMatrix%jTmp) .AND. &
+              ALLOCATED(thisMatrix%elemTmp) .AND. &
+              thisMatrix%nLocal == 0 .AND. &
+              ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
+              ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
+              .NOT.ALLOCATED(thisMatrix%chunks))
+      ASSERT(bool, 'banded%init')
+    ENDIF
   ENDSELECT
   CALL thisMatrix%clear()
+
   !test with double init (isInit==true on 2nd try)
-  WRITE(*,*) "Beginning double init"
   CALL thisMatrix%init(pList)
   SELECTTYPE(thisMatrix)
     TYPE IS(DistributedBandedMatrixType); thisMatrix%m=1
@@ -200,9 +205,9 @@ SUBROUTINE testDistrBandMatrix()
   bool = .NOT.thisMatrix%isInit
   ASSERT(bool, 'banded%init(...)')
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%init(...)'
 
   !check set
+  COMPONENT_TEST("distBand%set")
   !test normal use case (split diagonal)
   !want to build:
   ![3 0 7 0 0]
@@ -227,34 +232,293 @@ SUBROUTINE testDistrBandMatrix()
   CALL thisMatrix%set(3,5,9._SRK)
   CALL thisMatrix%assemble()
   SELECTTYPE(thisMatrix)
-    TYPE IS(DistributedBandedMatrixType)
-      IF(rank == 0) THEN
-        bool = SIZE(thisMatrix%chunks) == 2
-        bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 2
-        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 2
-        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 3
-        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(2) == 4
-        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(2)%elem) == 1
-        bool = bool .AND. thisMatrix%chunks(1)%bands(2)%elem(1) == 7
-        bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
-        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 2
-        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 1
-        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(2) == 2
-        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
-        bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 5
-        ASSERT(bool, 'banded%set(...)')
-      ELSE
-        bool = SIZE(thisMatrix%chunks) == 2
-        bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 1
-        bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 1
-        bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 8
-        bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
-        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 1
-        bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 6
-        bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
-        bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 9
-        ASSERT(bool, 'banded%set(...)')
+  TYPE IS(DistributedBandedMatrixType)
+    IF(rank == 0) THEN
+      bool = SIZE(thisMatrix%chunks) == 2
+      bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 2
+      bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 2
+      bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 3
+      bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(2) == 4
+      bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(2)%elem) == 1
+      bool = bool .AND. thisMatrix%chunks(1)%bands(2)%elem(1) == 7
+      bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
+      bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 2
+      bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 1
+      bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(2) == 2
+      bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
+      bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 5
+      ASSERT(bool, 'banded%set(...)')
+    ELSE
+      bool = SIZE(thisMatrix%chunks) == 2
+      bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 1
+      bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 1
+      bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 8
+      bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
+      bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 1
+      bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 6
+      bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
+      bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 9
+      ASSERT(bool, 'banded%set(...)')
+    ENDIF
+  ENDSELECT
+  CALL thisMatrix%clear()
+
+  !check get functionality
+  COMPONENT_TEST("distBand%get")
+  ![3 0 7 0 0]
+  ![0 4 0 8 0]
+  ![1 0 5 0 9]
+  ![0 2 0 6 0]
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',5_SNK)
+  CALL pList%add('MatrixType->nnz',9_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(3,1,1._SRK)
+  CALL thisMatrix%set(4,2,2._SRK)
+  CALL thisMatrix%set(1,1,3._SRK)
+  CALL thisMatrix%set(2,2,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(4,4,6._SRK)
+  CALL thisMatrix%set(1,3,7._SRK)
+  CALL thisMatrix%set(2,4,8._SRK)
+  CALL thisMatrix%set(3,5,9._SRK)
+  CALL thisMatrix%assemble()
+  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+  ALLOCATE(dummyvec(8))
+  IF(ALLOCATED(dummyvec2)) DEALLOCATE(dummyvec2)
+  ALLOCATE(dummyvec2(8))
+  dummyvec=0.0_SRK
+  IF (rank==0) THEN
+    CALL thisMatrix%get(1,1,dummyvec(1))
+    CALL thisMatrix%get(1,2,dummyvec(2))
+    CALL thisMatrix%get(1,3,dummyvec(3))
+    CALL thisMatrix%get(2,2,dummyvec(4))
+    CALL thisMatrix%get(3,1,dummyvec(5))
+    CALL thisMatrix%get(3,2,dummyvec(6))
+    CALL thisMatrix%get(3,3,dummyvec(7))
+    CALL thisMatrix%get(4,2,dummyvec(8))
+    dummyvec2 = (/3.0,0.0,7.0,4.0,1.0,0.0,5.0,2.0/)
+    ASSERT(ALL(dummyvec(1:8) .EQ. dummyvec2(1:8)), 'banded%get(...)')
+  ELSE
+    CALL thisMatrix%get(2,4,dummyvec(1))
+    CALL thisMatrix%get(2,5,dummyvec(2))
+    CALL thisMatrix%get(3,5,dummyvec(3))
+    CALL thisMatrix%get(4,4,dummyvec(4))
+    CALL thisMatrix%get(4,5,dummyvec(5))
+    dummyvec2(1:5) = (/8.0,0.0,9.0,6.0,0.0/)
+    ASSERT(ALL(dummyvec(1:5) .EQ. dummyvec2(1:5)), 'banded%get(...)')
+  ENDIF
+  DEALLOCATE(dummyvec2)
+
+  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+  CALL thisMatrix%clear()
+
+  !check zero_entries functionality
+  COMPONENT_TEST("distBand%zero")
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',5_SNK)
+  CALL pList%add('MatrixType->nnz',7_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(2,3,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
+  CALL thisMatrix%assemble()
+  CALL thisMatrix%zeroentries()
+  SELECTTYPE(thisMatrix)
+  TYPE IS(DistributedBandedMatrixType)
+    DO i=1,SIZE(thisMatrix%chunks(1)%bands)
+      ! The rank1 chunk1 will not be initialized, so skip
+      IF(rank==0) THEN
+        DO j=1,SIZE(thisMatrix%chunks(1)%bands(i)%elem)
+          bool=(thisMatrix%chunks(1)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
+          ASSERT(bool,"banded%zero()")
+        ENDDO
       ENDIF
+    ENDDO
+    DO i=1,SIZE(thisMatrix%chunks(2)%bands)
+      DO j=1,SIZE(thisMatrix%chunks(2)%bands(i)%elem)
+        bool=(thisMatrix%chunks(2)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
+        ASSERT(bool,"banded%zero()")
+      ENDDO
+    ENDDO
+  ENDSELECT
+  CALL thisMatrix%clear()
+
+  !check matvec functionality
+  COMPONENT_TEST("distBand%matvec")
+  ![1 2 0 0]
+  ![0 3 0 0]
+  ![0 0 5 6]
+  ![0 9 0 7]
+
+  CALL thisMatrix%clear()
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->m',4_SNK)
+  CALL pList%add('MatrixType->nnz',7_SNK)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%validate(pList,optListMat)
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
+  CALL thisMatrix%set(4,2,9._SRK)
+  CALL thisMatrix%assemble()
+  IF(ALLOCATED(distrVec1)) DEALLOCATE(distrVec1)
+  IF(ALLOCATED(distrVec2)) DEALLOCATE(distrVec2)
+  ALLOCATE(NativeDistributedVectorType :: distrVec1)
+  ALLOCATE(NativeDistributedVectorType :: distrVec2)
+
+  CALL distVecPList%clear()
+  CALL distVecPList%add('VectorType->n',4)
+  CALL distVecPList%add('VectorType->MPI_Comm_ID',PE_COMM_WORLD)
+  CALL distrVec1%init(distVecPList)
+  CALL distrVec2%init(distVecPList)
+
+  ! Check zero vector
+  distrVec1%b = 0.0_SRK
+  distrVec2%b = 0.0_SRK
+
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
+  DO i=1,2
+    bool = ALL(ABS(distrVec2%b) < 1E-6)
+    ASSERT(bool, 'banded%matvec(...)')
+  ENDDO
+  ! Check for non-trivial vector
+  IF (rank == 0) THEN
+    distrVec1%b = (/1._SRK,2._SRK/)
+  ELSE
+    distrVec1%b = (/3._SRK,4._SRK/)
+  ENDIF
+  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,alpha=1.0_SRK,beta=0.0_SRK)
+  IF (rank == 0) THEN
+    bool = distrVec2%b(1) == 5._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(2) == 6._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+  ELSE
+    bool = distrVec2%b(3) == 39._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+    bool = distrVec2%b(4) == 46._SRK
+    ASSERT(bool, 'banded%matvec(...)')
+  ENDIF
+  DEALLOCATE(thisMatrix)
+
+  CALL pList%clear()
+#endif
+ENDSUBROUTINE testDistrBandMatrix
+
+SUBROUTINE testPetscMatrix()
+#ifdef FUTILITY_HAVE_PETSC
+  IMPLICIT NONE
+
+  TYPE(ParamType) :: pList
+  INTEGER(SIK) :: rank,nproc,mpierr
+  CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
+  REAL(SRK) :: val
+
+  CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
+  CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)
+
+  ASSERT(nproc==2, 'nproc valid')
+  ALLOCATE(PETScMatrixType::thisMatrix)
+
+  COMPONENT_TEST("petsc%init")
+  ! Create matrix that looks like this
+  ! 1 0 2 0
+  ! 0 3 0 4
+  ! 0 0 5 0
+  ! 6 7 0 0
+  ! Rank 0 owns rows 1 and 2
+  ! Rank 1 owns rows 3 and 4
+
+  CALL pList%clear()
+  CALL pList%add('MatrixType->n',4_SNK)
+  CALL pList%add('MatrixType->nLocal',2_SNK)
+  CALL pList%add('MatrixType->nnz',2_SNK)
+  CALL pList%add('MatrixType->onz',2_SNK)
+  CALL pList%add('MatrixType->matType',SPARSE)
+  CALL pList%add('MatrixType->isSym',.FALSE.)
+  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL thisMatrix%init(pList)
+  !Perform test of init function
+  ASSERT(thisMatrix%isInit, "init")
+  ASSERT(thisMatrix%n==4, "global size")
+
+  ! Test setting/getting single elements at a time
+  COMPONENT_TEST("petsc%set")
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,3,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(2,4,4._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(4,1,6._SRK)
+  CALL thisMatrix%set(4,2,7._SRK)
+
+  IF(rank==0) THEN
+    CALL thisMatrix%get(1,1,val)
+    ASSERT(val .APPROXEQ. 1._SRK, "getOne")
+    CALL thisMatrix%get(1,3,val)
+    ASSERT(val .APPROXEQ. 2._SRK, "getOne")
+    CALL thisMatrix%get(2,2,val)
+    ASSERT(val .APPROXEQ. 3._SRK, "getOne")
+    CALL thisMatrix%get(2,4,val)
+    ASSERT(val .APPROXEQ. 4._SRK, "getOne")
+  ELSE
+    bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
+            ALLOCATED(thisMatrix%jTmp) .AND. &
+            ALLOCATED(thisMatrix%elemTmp) .AND. &
+            thisMatrix%nLocal == 0 .AND. &
+            ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
+            ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
+            .NOT.ALLOCATED(thisMatrix%chunks))
+    ASSERT(bool, 'banded%init')
+  ENDIF
+
+  ! Test setting row all at once
+  COMPONENT_TEST("petsc%setRow")
+  CALL thisMatrix%setRow(1,[1, 3],[10._SRK, 11._SRK])
+  CALL thisMatrix%setRow(2,[2, 4],[12._SRK, 13._SRK])
+  CALL thisMatrix%setRow(3,[3],[14._SRK])
+  CALL thisMatrix%setRow(4,[1, 2],[15._SRK, 16._SRK])
+
+  IF(rank==0) THEN
+    CALL thisMatrix%get(1,1,val)
+    ASSERT(val .APPROXEQ. 10._SRK, "getOne")
+    CALL thisMatrix%get(1,3,val)
+    ASSERT(val .APPROXEQ. 11._SRK, "getOne")
+    CALL thisMatrix%get(2,2,val)
+    ASSERT(val .APPROXEQ. 12._SRK, "getOne")
+    CALL thisMatrix%get(2,4,val)
+    ASSERT(val .APPROXEQ. 13._SRK, "getOne")
+  ELSE
+    bool = SIZE(thisMatrix%chunks) == 2
+    bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 1
+    bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 1
+    bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 8
+    bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
+    bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 1
+    bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 6
+    bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
+    bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 9
+    ASSERT(bool, 'banded%set(...)')
+  ENDIF
+
   ENDSELECT
   CALL thisMatrix%clear()
   WRITE(*,*) '  Passed: CALL banded%set(...)'
@@ -489,87 +753,20 @@ SUBROUTINE testDistrBandMatrix()
   CALL pList%add('MatrixType->isSym',.FALSE.)
   CALL pList%add('MatrixType->MPI_COMM_ID',MPI_COMM_WORLD)
 
-#ifdef FUTILITY_HAVE_PETSC
-  ALLOCATE(PETScMatrixType::thisMatrix)
-
-  CALL thisMatrix%init(pList)
-
-
-  !Perform test of init function
-  ASSERT(thisMatrix%isInit, "init")
-  ASSERT(thisMatrix%n==4, "global size")
-
-  ! Test setting/getting single elements at a time
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,3,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  CALL thisMatrix%set(2,4,4._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(4,1,6._SRK)
-  CALL thisMatrix%set(4,2,7._SRK)
-
-  IF(rank==0) THEN
-    CALL thisMatrix%get(1,1,val)
-    ASSERT(val .APPROXEQ. 1._SRK, "getOne")
-    CALL thisMatrix%get(1,3,val)
-    ASSERT(val .APPROXEQ. 2._SRK, "getOne")
-    CALL thisMatrix%get(2,2,val)
-    ASSERT(val .APPROXEQ. 3._SRK, "getOne")
-    CALL thisMatrix%get(2,4,val)
-    ASSERT(val .APPROXEQ. 4._SRK, "getOne")
-  ELSE
-    CALL thisMatrix%get(3,3,val)
-    ASSERT(val .APPROXEQ. 5._SRK, "getOne")
-    CALL thisMatrix%get(4,1,val)
-    ASSERT(val .APPROXEQ. 6._SRK, "getOne")
-    CALL thisMatrix%get(4,2,val)
-    ASSERT(val .APPROXEQ. 7._SRK, "getOne")
-  ENDIF
-
-  ! Test setting row all at once
-  CALL thisMatrix%setRow(1,[1, 3],[10._SRK, 11._SRK])
-  CALL thisMatrix%setRow(2,[2, 4],[12._SRK, 13._SRK])
-  CALL thisMatrix%setRow(3,[3],[14._SRK])
-  CALL thisMatrix%setRow(4,[1, 2],[15._SRK, 16._SRK])
-
-  IF(rank==0) THEN
-    CALL thisMatrix%get(1,1,val)
-    ASSERT(val .APPROXEQ. 10._SRK, "getOne")
-    CALL thisMatrix%get(1,3,val)
-    ASSERT(val .APPROXEQ. 11._SRK, "getOne")
-    CALL thisMatrix%get(2,2,val)
-    ASSERT(val .APPROXEQ. 12._SRK, "getOne")
-    CALL thisMatrix%get(2,4,val)
-    ASSERT(val .APPROXEQ. 13._SRK, "getOne")
-  ELSE
-    CALL thisMatrix%get(3,3,val)
-    ASSERT(val .APPROXEQ. 14._SRK, "getOne")
-    CALL thisMatrix%get(4,1,val)
-    ASSERT(val .APPROXEQ. 15._SRK, "getOne")
-    CALL thisMatrix%get(4,2,val)
-    ASSERT(val .APPROXEQ. 16._SRK, "getOne")
-  ENDIF
-
   CALL thisMatrix%clear()
   DEALLOCATE(thisMatrix)
-#endif
   CALL pList%clear()
-
 #endif
-ENDSUBROUTINE testDistrBandMatrix
+ENDSUBROUTINE testPetscMatrix
 
 SUBROUTINE testDistrBlockBandMatrix()
 #ifdef HAVE_MPI
   IMPLICIT NONE
-
   TYPE(ParamType) :: pList,optListMat,distVecPList
-  INTEGER(SIK) :: rank,nproc,mpierr,i,j
+  INTEGER(SIK) :: rank,nproc,mpierr
   TYPE(DistributedBlockBandedMatrixType),ALLOCATABLE :: thisMatrix
-  TYPE(NativeDistributedVectorType),ALLOCATABLE :: distrVec1, distrVec2
-  REAL(SRK),ALLOCATABLE :: dummyvec(:),dummyvec2(:)
-  REAL(SRK) :: val
+  TYPE(NativeDistributedVectorType),ALLOCATABLE :: distrvec1,distrvec2
   LOGICAL(SBK) :: bool
-
 
   CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
   CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)
@@ -579,6 +776,7 @@ SUBROUTINE testDistrBlockBandMatrix()
   ALLOCATE(DistributedBlockBandedMatrixType :: thisMatrix)
 
   !check init
+  COMPONENT_TEST("distBlockBand%init")
   CALL pList%clear()
   CALL pList%add('MatrixType->n',12_SNK)
   CALL pList%add('MatrixType->nnz',9_SNK)
@@ -608,6 +806,7 @@ SUBROUTINE testDistrBlockBandMatrix()
   CALL thisMatrix%clear()
 
   !check matvec functionality
+  COMPONENT_TEST("distBlockBand%matvec")
   ![1 2 0 0 0 0]
   ![0 3 0 0 0 0]
   ![0 0 5 6 0 0]
@@ -618,11 +817,13 @@ SUBROUTINE testDistrBlockBandMatrix()
   CALL pList%clear()
   CALL pList%add('MatrixType->n',6_SNK)
   CALL plist%add('MatrixType->blockSize',2_SNK)
-  CALL pList%add('MatrixType->nnz',1_SNK)
+  CALL pList%add('MatrixType->nnz',10_SNK)
   CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
+  CALL pList%edit(6)
   CALL pList%validate(pList,optListMat)
   CALL thisMatrix%init(pList)
-  WRITE(*,*) "matrix set calls"
+  WRITE(*,*) "Init status",thisMatrix%isInit
+
   CALL thisMatrix%set(1,1,1._SRK)
   CALL thisMatrix%set(1,2,2._SRK)
   CALL thisMatrix%set(2,2,3._SRK)
@@ -642,7 +843,6 @@ SUBROUTINE testDistrBlockBandMatrix()
   CALL distVecPList%add('VectorType->n',6)
   CALL distVecPList%add('VectorType->chunkSize',2)
   CALL distVecPList%add('VectorType->MPI_Comm_ID',PE_COMM_WORLD)
-  WRITE(*,*) "Vec init"
   CALL distrVec1%init(distVecPList)
   CALL distrVec2%init(distVecPList)
 
@@ -659,7 +859,7 @@ SUBROUTINE testDistrBlockBandMatrix()
     distrVec1%b = (/1._SRK,2._SRK,3._SRK,4._SRK/)
   ELSE
     distrVec1%b = (/1.0_SRK,1.0_SRK/)
-  END IF
+  ENDIF
 
   CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,alpha=1.0_SRK,beta=0.0_SRK)
   IF (rank == 0) THEN
@@ -673,9 +873,8 @@ SUBROUTINE testDistrBlockBandMatrix()
     ASSERT(bool, 'banded%matvec(...)')
   ELSE
     ASSERT(ALL(ABS(distrVec2%b-1) < 1E-6),'banded%matvec(...)')
-  END IF
+  ENDIF
 
-  WRITE(*,*) '  Passed: CALL banded%matvec(...)'
   DEALLOCATE(thisMatrix)
   CALL pList%clear()
 #endif

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -425,12 +425,12 @@ ENDSUBROUTINE testDistrBandMatrix
 
 SUBROUTINE testPetscMatrix()
 #ifdef FUTILITY_HAVE_PETSC
-  IMPLICIT NONE
-
   TYPE(ParamType) :: pList
   INTEGER(SIK) :: rank,nproc,mpierr
   CLASS(DistributedMatrixType),ALLOCATABLE :: thisMatrix
   REAL(SRK) :: val
+  REAL(SRK),ALLOCATABLE :: dummyvec(:)
+  LOGICAL(SBK) :: bool
 
   CALL MPI_Comm_rank(PE_COMM_WORLD,rank,mpierr)
   CALL MPI_Comm_size(PE_COMM_WORLD,nproc,mpierr)
@@ -480,14 +480,12 @@ SUBROUTINE testPetscMatrix()
     CALL thisMatrix%get(2,4,val)
     ASSERT(val .APPROXEQ. 4._SRK, "getOne")
   ELSE
-    bool = (ALLOCATED(thisMatrix%iTmp) .AND. &
-            ALLOCATED(thisMatrix%jTmp) .AND. &
-            ALLOCATED(thisMatrix%elemTmp) .AND. &
-            thisMatrix%nLocal == 0 .AND. &
-            ALL(thisMatrix%jOffsets .EQ. (/0_SIK,8_SIK,15_SIK/)) .AND. &
-            ALL(thisMatrix%iOffsets .EQ. (/0_SIK,5_SIK,10_SIK/)) .AND. &
-            .NOT.ALLOCATED(thisMatrix%chunks))
-    ASSERT(bool, 'banded%init')
+    CALL thisMatrix%get(3,3,val)
+    ASSERT(val .APPROXEQ. 5._SRK, "getOne")
+    CALL thisMatrix%get(4,1,val)
+    ASSERT(val .APPROXEQ. 6._SRK, "getOne")
+    CALL thisMatrix%get(4,2,val)
+    ASSERT(val .APPROXEQ. 7._SRK, "getOne")
   ENDIF
 
   ! Test setting row all at once
@@ -507,255 +505,14 @@ SUBROUTINE testPetscMatrix()
     CALL thisMatrix%get(2,4,val)
     ASSERT(val .APPROXEQ. 13._SRK, "getOne")
   ELSE
-    bool = SIZE(thisMatrix%chunks) == 2
-    bool = SIZE(thisMatrix%chunks(1)%bandIdx) == 1
-    bool = bool .AND. SIZE(thisMatrix%chunks(1)%bands(1)%elem) == 1
-    bool = bool .AND. thisMatrix%chunks(1)%bands(1)%elem(1) == 8
-    bool = SIZE(thisMatrix%chunks(2)%bandIdx) == 2
-    bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(1)%elem) == 1
-    bool = bool .AND. thisMatrix%chunks(2)%bands(1)%elem(1) == 6
-    bool = bool .AND. SIZE(thisMatrix%chunks(2)%bands(2)%elem) == 1
-    bool = bool .AND. thisMatrix%chunks(2)%bands(2)%elem(1) == 9
-    ASSERT(bool, 'banded%set(...)')
+    CALL thisMatrix%get(3,3,val)
+    ASSERT(val .APPROXEQ. 14._SRK, "getOne")
+    CALL thisMatrix%get(4,1,val)
+    ASSERT(val .APPROXEQ. 15._SRK, "getOne")
+    CALL thisMatrix%get(4,2,val)
+    ASSERT(val .APPROXEQ. 16._SRK, "getOne")
   ENDIF
-
-  ENDSELECT
   CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%set(...)'
-  !check get functionality
-  ![3 0 7 0 0]
-  ![0 4 0 8 0]
-  ![1 0 5 0 9]
-  ![0 2 0 6 0]
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->m',5_SNK)
-  CALL pList%add('MatrixType->nnz',9_SNK)
-  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(3,1,1._SRK)
-  CALL thisMatrix%set(4,2,2._SRK)
-  CALL thisMatrix%set(1,1,3._SRK)
-  CALL thisMatrix%set(2,2,4._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(4,4,6._SRK)
-  CALL thisMatrix%set(1,3,7._SRK)
-  CALL thisMatrix%set(2,4,8._SRK)
-  CALL thisMatrix%set(3,5,9._SRK)
-  CALL thisMatrix%assemble()
-  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-  ALLOCATE(dummyvec(13))
-  dummyvec=0
-  CALL thisMatrix%get(1,1,dummyvec(1))
-  CALL thisMatrix%get(1,2,dummyvec(2))
-  CALL thisMatrix%get(1,3,dummyvec(3))
-  CALL thisMatrix%get(2,2,dummyvec(4))
-  CALL thisMatrix%get(2,4,dummyvec(5))
-  CALL thisMatrix%get(2,5,dummyvec(6))
-  CALL thisMatrix%get(3,1,dummyvec(7))
-  CALL thisMatrix%get(3,2,dummyvec(8))
-  CALL thisMatrix%get(3,3,dummyvec(9))
-  CALL thisMatrix%get(3,5,dummyvec(10))
-  CALL thisMatrix%get(4,2,dummyvec(11))
-  CALL thisMatrix%get(4,4,dummyvec(12))
-  CALL thisMatrix%get(4,5,dummyvec(13))
-
-  bool = .TRUE.
-  bool = bool .AND. dummyvec(1) == 3._SRK
-  bool = bool .AND. dummyvec(2) == 0._SRK
-  bool = bool .AND. dummyvec(3) == 7._SRK
-  bool = bool .AND. dummyvec(4) == 4._SRK
-  bool = bool .AND. dummyvec(5) == 8._SRK
-  bool = bool .AND. dummyvec(6) == 0._SRK
-  bool = bool .AND. dummyvec(7) == 1._SRK
-  bool = bool .AND. dummyvec(8) == 0._SRK
-  bool = bool .AND. dummyvec(9) == 5._SRK
-  bool = bool .AND. dummyvec(10) == 9._SRK
-  bool = bool .AND. dummyvec(11) == 2._SRK
-  bool = bool .AND. dummyvec(12) == 6._SRK
-  bool = bool .AND. dummyvec(13) == 0._SRK
-  ASSERT(bool, 'banded%get(...)')
-
-  IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-  CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%get(...)'
-  !check transpose functionality
-  ![1 2 0 0 0]
-  ![0 3 4 0 0]
-  ![0 0 5 6 0]
-  ![0 0 0 7 0]
-  !with main diagonal split [1,3],[5,7]
-  !to
-  ![1 0 0 0]
-  ![2 3 0 0]
-  ![0 4 5 0]
-  ![0 0 6 7]
-  ![0 0 0 0]
-  ! CALL thisMatrix%clear()
-  ! CALL pList%clear()
-  ! CALL pList%add('MatrixType->n',4_SNK)
-  ! CALL pList%add('MatrixType->m',5_SNK)
-  ! CALL pList%add('MatrixType->nnz',7_SNK)
-  ! CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
-  ! CALL pList%validate(pList,optListMat)
-  ! CALL thisMatrix%init(pList)
-  ! CALL thisMatrix%set(1,1,1._SRK)
-  ! CALL thisMatrix%set(1,2,2._SRK)
-  ! CALL thisMatrix%set(2,2,3._SRK)
-  ! CALL thisMatrix%set(2,3,4._SRK)
-  ! CALL thisMatrix%set(3,3,5._SRK)
-  ! CALL thisMatrix%set(3,4,6._SRK)
-  ! CALL thisMatrix%set(4,4,7._SRK)
-  ! CALL thisMatrix%assemble()
-  ! CALL thisMatrix%transpose()
-  !
-  ! ALLOCATE(dummyvec(7))
-  ! CALL thisMatrix%get(1,1,dummyvec(1))
-  ! CALL thisMatrix%get(2,1,dummyvec(2))
-  ! CALL thisMatrix%get(2,2,dummyvec(3))
-  ! CALL thisMatrix%get(3,2,dummyvec(4))
-  ! CALL thisMatrix%get(3,3,dummyvec(5))
-  ! CALL thisMatrix%get(4,3,dummyvec(6))
-  ! CALL thisMatrix%get(4,4,dummyvec(7))
-  !
-  ! bool = .TRUE.
-  ! bool = bool .AND. dummyvec(1) == 1
-  ! bool = bool .AND. dummyvec(2) == 2
-  ! bool = bool .AND. dummyvec(3) == 3
-  ! bool = bool .AND. dummyvec(4) == 4
-  ! bool = bool .AND. dummyvec(5) == 5
-  ! bool = bool .AND. dummyvec(6) == 6
-  ! bool = bool .AND. dummyvec(7) == 7
-  ! ASSERT(bool,"banded%transpose()")
-  !
-  ! CALL thisMatrix%clear()
-  ! WRITE(*,*) '  Passed: CALL banded%transpose(...)'
-
-  !check zero_entries functionality
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->m',5_SNK)
-  CALL pList%add('MatrixType->nnz',7_SNK)
-  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  CALL thisMatrix%set(2,3,4._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(3,4,6._SRK)
-  CALL thisMatrix%set(4,4,7._SRK)
-  CALL thisMatrix%assemble()
-  CALL thisMatrix%zeroentries()
-  SELECTTYPE(thisMatrix)
-    TYPE IS(DistributedBandedMatrixType)
-      DO i=1,SIZE(thisMatrix%chunks(1)%bands)
-        ! The rank1 chunk1 will not be initialized, so skip
-        IF(rank==0) THEN
-          DO j=1,SIZE(thisMatrix%chunks(1)%bands(i)%elem)
-            bool=(thisMatrix%chunks(1)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
-            ASSERT(bool,"banded%zero()")
-          ENDDO
-        END IF
-      ENDDO
-      DO i=1,SIZE(thisMatrix%chunks(2)%bands)
-        DO j=1,SIZE(thisMatrix%chunks(2)%bands(i)%elem)
-          bool=(thisMatrix%chunks(2)%bands(i)%elem(j) .APPROXEQ. 0.0_SRK)
-          ASSERT(bool,"banded%zero()")
-        ENDDO
-      ENDDO
-  ENDSELECT
-  CALL thisMatrix%clear()
-  WRITE(*,*) '  Passed: CALL banded%zero(...)'
-
-  !check matvec functionality
-  ![1 2 0 0]
-  ![0 3 0 0]
-  ![0 0 5 6]
-  ![0 9 0 7]
-
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->m',4_SNK)
-  CALL pList%add('MatrixType->nnz',7_SNK)
-  CALL pList%add('MatrixType->MPI_COMM_ID',PE_COMM_WORLD)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList)
-  CALL thisMatrix%set(1,1,1._SRK)
-  CALL thisMatrix%set(1,2,2._SRK)
-  CALL thisMatrix%set(2,2,3._SRK)
-  CALL thisMatrix%set(3,3,5._SRK)
-  CALL thisMatrix%set(3,4,6._SRK)
-  CALL thisMatrix%set(4,4,7._SRK)
-  CALL thisMatrix%set(4,2,9._SRK)
-  CALL thisMatrix%assemble()
-  IF(ALLOCATED(distrVec1)) DEALLOCATE(distrVec1)
-  IF(ALLOCATED(distrVec2)) DEALLOCATE(distrVec2)
-  ALLOCATE(NativeDistributedVectorType :: distrVec1)
-  ALLOCATE(NativeDistributedVectorType :: distrVec2)
-
-  CALL distVecPList%clear()
-  CALL distVecPList%add('VectorType->n',4)
-  CALL distVecPList%add('VectorType->MPI_Comm_ID',PE_COMM_WORLD)
-  CALL distrVec1%init(distVecPList)
-  CALL distrVec2%init(distVecPList)
-
-  ! Check zero vector
-  distrVec1%b = 0.0_SRK
-  distrVec2%b = 0.0_SRK
-
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
-  DO i=1,2
-    bool = ALL(ABS(distrVec2%b) < 1E-6)
-    ASSERT(bool, 'banded%matvec(...)')
-  ENDDO
-  ! Check for non-trivial vector
-  IF (rank == 0) THEN
-    distrVec1%b = (/1._SRK,2._SRK/)
-  ELSE
-    distrVec1%b = (/3._SRK,4._SRK/)
-  END IF
-  CALL BLAS_matvec(THISMATRIX=thisMatrix,X=distrVec1,Y=distrVec2,alpha=1.0_SRK,beta=0.0_SRK)
-  IF (rank == 0) THEN
-    bool = distrVec2%b(1) == 5._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-    bool = distrVec2%b(2) == 6._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-  ELSE
-    bool = distrVec2%b(1) == 39._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-    bool = distrVec2%b(2) == 46._SRK
-    ASSERT(bool, 'banded%matvec(...)')
-  END IF
-
-  WRITE(*,*) '  Passed: CALL banded%matvec(...)'
-  DEALLOCATE(thisMatrix)
-
-  ! Create matrix that looks like this
-  ! 1 0 2 0
-  ! 0 3 0 4
-  ! 0 0 5 0
-  ! 6 7 0 0
-  ! Rank 0 owns rows 1 and 2
-  ! Rank 1 owns rows 3 and 4
-
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',4_SNK)
-  CALL pList%add('MatrixType->nLocal',2_SNK)
-  CALL pList%add('MatrixType->nnz',2_SNK)
-  CALL pList%add('MatrixType->onz',2_SNK)
-  CALL pList%add('MatrixType->matType',SPARSE)
-  CALL pList%add('MatrixType->isSym',.FALSE.)
-  CALL pList%add('MatrixType->MPI_COMM_ID',MPI_COMM_WORLD)
-
-  CALL thisMatrix%clear()
-  DEALLOCATE(thisMatrix)
-  CALL pList%clear()
 #endif
 ENDSUBROUTINE testPetscMatrix
 

--- a/unit_tests/testSorting/testSorting.f90
+++ b/unit_tests/testSorting/testSorting.f90
@@ -585,12 +585,11 @@ ENDSUBROUTINE testRealSort
         iVal = (i-1)/4+1
         jVal = MOD(i-1,4)+1
         diagRank(i) = INT(jVal - 1 + ((3-iVal+jVal)*(4-iVal+jVal))/2,8)
-      END DO
+      ENDDO
 
       CALL sort(diagRank, idxOrig)
 
-      bool=ALL(idxOrig .EQ. (/13_SIK,9_SIK,14_SIK,5_SIK,10_SIK,15_SIK,1_SIK,6_SIK,11_SIK,16_SIK,2_SIK,7_SIK,12_SIK,3_SIK,8_SIK,4_SIK/))
-      WRITE(*,*) idxOrig
+      bool=ALL(idxOrig .EQ. (/13,9,14,5,10,15,1,6,11,16,2,7,12,3,8,4/))
       ASSERT(bool,'Diagonal Matrix Sort')
 
     END SUBROUTINE testKeySort

--- a/unit_tests/testSorting/testSorting.f90
+++ b/unit_tests/testSorting/testSorting.f90
@@ -25,9 +25,17 @@ REGISTER_SUBTEST('sort Real',testRealSort)
 REGISTER_SUBTEST('bubble sort',testBubbleSort)
 REGISTER_SUBTEST('insertion sort',testInsertSort)
 
+<<<<<<< HEAD
 REGISTER_SUBTEST('Speed Test - sort int',testSpeedInt)
 REGISTER_SUBTEST('Speed Test - sort real',testSpeedReal)
 FINALIZE_TEST()
+=======
+  REGISTER_SUBTEST('Speed Test - sort int',testSpeedInt)
+  REGISTER_SUBTEST('Speed Test - sort real',testSpeedReal)
+
+  REGISTER_SUBTEST('Sort Long-Key Int-Val', testKeySort)
+  FINALIZE_TEST()
+>>>>>>> Brought in changes from bandMat_pGMRES_rsor branch pertaining to datatypes
 !
 !
 !===============================================================================
@@ -518,6 +526,7 @@ SUBROUTINE testInt2DSort()
 ENDSUBROUTINE testInt2DSort
 !
 !-------------------------------------------------------------------------------
+<<<<<<< HEAD
 SUBROUTINE testRealSort()
   LOGICAL(SBK) :: bool
   REAL(SRK) :: tmprealarray(10)
@@ -539,5 +548,52 @@ SUBROUTINE testRealSort()
       20.0_SRK,20.0_SRK,45.0_SRK,60.0_SRK,100.0_SRK/))
   ASSERT(bool,'1-D real array qsort')
 ENDSUBROUTINE testRealSort
+=======
+    SUBROUTINE testRealSort()
+      LOGICAL(SBK) :: bool
+      REAL(SRK) :: tmprealarray(10)
+
+      tmprealarray(1)=100.0_SRK
+      tmprealarray(2)=-5.0_SRK
+      tmprealarray(3)=60.0_SRK
+      tmprealarray(4)=10.0_SRK
+      tmprealarray(5)=45.0_SRK
+      tmprealarray(6)=-10.0_SRK
+      tmprealarray(7)=20.0_SRK
+      tmprealarray(8)=5.0_SRK
+      tmprealarray(9)=-30.0_SRK
+      tmprealarray(10)=20.0_SRK
+
+      CALL sort(tmprealarray)
+
+      bool=ALL(tmprealarray .APPROXEQ. (/-30.0_SRK,-10.0_SRK,-5.0_SRK,5.0_SRK,10.0_SRK, &
+        20.0_SRK,20.0_SRK,45.0_SRK,60.0_SRK,100.0_SRK/))
+      ASSERT(bool,'1-D real array qsort')
+    ENDSUBROUTINE testRealSort
+
+    SUBROUTINE testKeySort()
+      LOGICAL(SBK) :: bool
+      INTEGER(SIK) :: idxOrig(16), i,iVal,jVal
+      INTEGER(SLK) :: diagRank(16)
+
+      ! 1  2  3  4
+      ! 5  6  7  8
+      ! 9  10 11 12
+      ! 13 14 15 16
+      DO i=1,16
+        idxOrig(i) = i
+        iVal = (i-1)/4+1
+        jVal = MOD(i-1,4)+1
+        diagRank(i) = INT(jVal - 1 + ((3-iVal+jVal)*(4-iVal+jVal))/2,8)
+      END DO
+
+      CALL sort(diagRank, idxOrig)
+
+      bool=ALL(idxOrig .EQ. (/13_SIK,9_SIK,14_SIK,5_SIK,10_SIK,15_SIK,1_SIK,6_SIK,11_SIK,16_SIK,2_SIK,7_SIK,12_SIK,3_SIK,8_SIK,4_SIK/))
+      WRITE(*,*) idxOrig
+      ASSERT(bool,'Diagonal Matrix Sort')
+
+    END SUBROUTINE testKeySort
+>>>>>>> Brought in changes from bandMat_pGMRES_rsor branch pertaining to datatypes
 !
 ENDPROGRAM testSorting

--- a/unit_tests/testSorting/testSorting.f90
+++ b/unit_tests/testSorting/testSorting.f90
@@ -25,17 +25,11 @@ REGISTER_SUBTEST('sort Real',testRealSort)
 REGISTER_SUBTEST('bubble sort',testBubbleSort)
 REGISTER_SUBTEST('insertion sort',testInsertSort)
 
-<<<<<<< HEAD
 REGISTER_SUBTEST('Speed Test - sort int',testSpeedInt)
 REGISTER_SUBTEST('Speed Test - sort real',testSpeedReal)
-FINALIZE_TEST()
-=======
-  REGISTER_SUBTEST('Speed Test - sort int',testSpeedInt)
-  REGISTER_SUBTEST('Speed Test - sort real',testSpeedReal)
 
-  REGISTER_SUBTEST('Sort Long-Key Int-Val', testKeySort)
-  FINALIZE_TEST()
->>>>>>> Brought in changes from bandMat_pGMRES_rsor branch pertaining to datatypes
+REGISTER_SUBTEST('Sort Long-Key Int-Val', testKeySort)
+FINALIZE_TEST()
 !
 !
 !===============================================================================
@@ -526,7 +520,6 @@ SUBROUTINE testInt2DSort()
 ENDSUBROUTINE testInt2DSort
 !
 !-------------------------------------------------------------------------------
-<<<<<<< HEAD
 SUBROUTINE testRealSort()
   LOGICAL(SBK) :: bool
   REAL(SRK) :: tmprealarray(10)
@@ -545,54 +538,31 @@ SUBROUTINE testRealSort()
   CALL sort(tmprealarray)
 
   bool=ALL(tmprealarray .APPROXEQ. (/-30.0_SRK,-10.0_SRK,-5.0_SRK,5.0_SRK,10.0_SRK, &
-      20.0_SRK,20.0_SRK,45.0_SRK,60.0_SRK,100.0_SRK/))
+    20.0_SRK,20.0_SRK,45.0_SRK,60.0_SRK,100.0_SRK/))
   ASSERT(bool,'1-D real array qsort')
 ENDSUBROUTINE testRealSort
-=======
-    SUBROUTINE testRealSort()
-      LOGICAL(SBK) :: bool
-      REAL(SRK) :: tmprealarray(10)
 
-      tmprealarray(1)=100.0_SRK
-      tmprealarray(2)=-5.0_SRK
-      tmprealarray(3)=60.0_SRK
-      tmprealarray(4)=10.0_SRK
-      tmprealarray(5)=45.0_SRK
-      tmprealarray(6)=-10.0_SRK
-      tmprealarray(7)=20.0_SRK
-      tmprealarray(8)=5.0_SRK
-      tmprealarray(9)=-30.0_SRK
-      tmprealarray(10)=20.0_SRK
+SUBROUTINE testKeySort()
+  LOGICAL(SBK) :: bool
+  INTEGER(SIK) :: idxOrig(16), i,iVal,jVal
+  INTEGER(SLK) :: diagRank(16)
 
-      CALL sort(tmprealarray)
+  ! 1  2  3  4
+  ! 5  6  7  8
+  ! 9  10 11 12
+  ! 13 14 15 16
+  DO i=1,16
+    idxOrig(i) = i
+    iVal = (i-1)/4+1
+    jVal = MOD(i-1,4)+1
+    diagRank(i) = INT(jVal - 1 + ((3-iVal+jVal)*(4-iVal+jVal))/2,8)
+  ENDDO
 
-      bool=ALL(tmprealarray .APPROXEQ. (/-30.0_SRK,-10.0_SRK,-5.0_SRK,5.0_SRK,10.0_SRK, &
-        20.0_SRK,20.0_SRK,45.0_SRK,60.0_SRK,100.0_SRK/))
-      ASSERT(bool,'1-D real array qsort')
-    ENDSUBROUTINE testRealSort
+  CALL sort(diagRank, idxOrig)
 
-    SUBROUTINE testKeySort()
-      LOGICAL(SBK) :: bool
-      INTEGER(SIK) :: idxOrig(16), i,iVal,jVal
-      INTEGER(SLK) :: diagRank(16)
+  bool=ALL(idxOrig .EQ. (/13,9,14,5,10,15,1,6,11,16,2,7,12,3,8,4/))
+  ASSERT(bool,'Diagonal Matrix Sort')
 
-      ! 1  2  3  4
-      ! 5  6  7  8
-      ! 9  10 11 12
-      ! 13 14 15 16
-      DO i=1,16
-        idxOrig(i) = i
-        iVal = (i-1)/4+1
-        jVal = MOD(i-1,4)+1
-        diagRank(i) = INT(jVal - 1 + ((3-iVal+jVal)*(4-iVal+jVal))/2,8)
-      ENDDO
-
-      CALL sort(diagRank, idxOrig)
-
-      bool=ALL(idxOrig .EQ. (/13,9,14,5,10,15,1,6,11,16,2,7,12,3,8,4/))
-      ASSERT(bool,'Diagonal Matrix Sort')
-
-    END SUBROUTINE testKeySort
->>>>>>> Brought in changes from bandMat_pGMRES_rsor branch pertaining to datatypes
+END SUBROUTINE testKeySort
 !
 ENDPROGRAM testSorting

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -179,9 +179,11 @@ SUBROUTINE testNativeVectorType()
   INTEGER(SIK) :: rank, nproc, mpierr, i
   REAL(SRK) :: val
   REAL(SRK),ALLOCATABLE :: getval(:)
+
   CALL MPI_Comm_rank(MPI_COMM_WORLD,rank,mpierr)
   CALL MPI_Comm_size(MPI_COMM_WORLD,nproc,mpierr)
   ASSERT(nproc==2, 'nproc valid')
+
   !Perform test of init function
   !first check intended init path (m provided)
   CALL pList%clear()
@@ -195,19 +197,14 @@ SUBROUTINE testNativeVectorType()
       !check for success
       bool = thisVector%isInit.AND.thisVector%n == 20
       ASSERT(bool, 'NativeDistributedVectorType%init(...)')
-      !WRITE(*,*) SIZE(thisVector%b)
       ASSERT(SIZE(thisVector%b) == 10, 'NativeDistributedVectorType%init(...)')
   ENDSELECT
 
   ! Test setting/getting single elements at a time
-  CALL thisVector%set(1,1._SRK)
-  CALL thisVector%set(2,2._SRK)
-  CALL thisVector%set(3,3._SRK)
-  CALL thisVector%set(18,18._SRK)
-  CALL thisVector%set(19,19._SRK)
-  CALL thisVector%set(20,20._SRK)
-
   IF(rank==0) THEN
+    CALL thisVector%set(1,1._SRK)
+    CALL thisVector%set(2,2._SRK)
+    CALL thisVector%set(3,3._SRK)
     CALL thisVector%get(1,val)
     ASSERT(val==1._SRK, "getOne")
     CALL thisVector%get(2,val)
@@ -215,6 +212,9 @@ SUBROUTINE testNativeVectorType()
     CALL thisVector%get(3,val)
     ASSERT(val==3._SRK, "getOne")
   ELSE
+    CALL thisVector%set(18,18._SRK)
+    CALL thisVector%set(19,19._SRK)
+    CALL thisVector%set(20,20._SRK)
     CALL thisVector%get(18,val)
     ASSERT(val==18._SRK, "getOne")
     CALL thisVector%get(19,val)
@@ -233,7 +233,6 @@ SUBROUTINE testNativeVectorType()
      CALL thisVector%get([(i, i=11, 20)], getval)
      ASSERT(ALL(getval==[(REAL(i, SRK), i=11, 20)]), 'getAll')
   ENDIF
-
 
   ! Use getAll with same data
   CALL thisVector%get(getval)


### PR DESCRIPTION
This branch is the first in a series of 3, split off from the bandMat_pGMRES_rsor branch.

These changes pertain to the creation of new parallel datatypes (3 banded matrix types and 1 distributed vector type) with the associated MatVec/dot/norm routines.