### PR TITLE
Revert "Making the maxnsr output argument optional."

### DIFF
--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -1726,34 +1726,31 @@ MODULE PartitionGraph
 !> @param ecut the total weight of edges cut
 !> @param comm the total weight of communication between groups
 !>
-    SUBROUTINE calcDecompMetrics_PartitionGraph(thisGraph,mmr,srms,ecut,comm,maxnsr)
+    SUBROUTINE calcDecompMetrics_PartitionGraph(thisGraph,maxnsr,mmr,srms,ecut,comm)
       CHARACTER(LEN=*),PARAMETER :: myName='calcDecompMetrics'
       CLASS(PartitionGraphType),INTENT(IN) :: thisGraph
-      REAL(SRK),INTENT(OUT) :: mmr,srms,ecut,comm
-      REAL(SRK),INTENT(OUT),OPTIONAL :: maxnsr
+      REAL(SRK),INTENT(OUT) :: maxnsr,mmr,srms,ecut,comm
       INTEGER(SIK) :: ig,igstt,igstp,in,ineigh,iv,ivert,neighGrp
       REAL(SRK) :: wtSum,wtGrp,lgroup,sgroup,optSize,wtDif,gwt
       INTEGER(SIK),ALLOCATABLE :: grpMap(:),uniqueGrps(:)
 
-      IF(PRESENT(maxnsr)) maxnsr=0.0_SRK
+      maxnsr=0.0_SRK
       mmr=0.0_SRK
       srms=0.0_SRK
       ecut=0.0_SRK
       comm=0.0_SRK
       IF(ALLOCATED(thisGraph%groupIdx)) THEN
         !Compute the max number of source regions
-        IF(PRESENT(maxnsr)) THEN
-          DO ig=1,thisGraph%nGroups
-            igstt=thisGraph%groupIdx(ig)
-            igstp=thisGraph%groupIdx(ig+1)-1
-            gwt=0.0_SRK
-            DO iv=igstt,igstp
-              gwt=gwt+thisGraph%wts(thisGraph%groupList(iv))
-            ENDDO
-            maxnsr=MAX(maxnsr,REAL(gwt,SRK))
+        DO ig=1,thisGraph%nGroups
+          igstt=thisGraph%groupIdx(ig)
+          igstp=thisGraph%groupIdx(ig+1)-1
+          gwt=0.0_SRK
+          DO iv=igstt,igstp
+            gwt=gwt+thisGraph%wts(thisGraph%groupList(iv))
           ENDDO
-          maxnsr=maxnsr/SUM(thisGraph%wts)
-        ENDIF
+          maxnsr=MAX(maxnsr,REAL(gwt,SRK))
+        ENDDO
+        maxnsr=maxnsr/SUM(thisGraph%wts)
 
         !Compute the min/max ratio and rms difference from optimal
         lgroup=0.0_SRK
@@ -1824,9 +1821,7 @@ MODULE PartitionGraph
           ' - graph is not partitioned!')
       ENDIF
 
-      IF(PRESENT(maxnsr)) THEN
-        ENSURE((maxnsr > 0.0_SRK) .AND. (maxnsr <= 1.0_SRK))
-      ENDIF
+      ENSURE((maxnsr > 0.0_SRK) .AND. (maxnsr <= 1.0_SRK))
       ENSURE(mmr > 0.0_SRK)
       ENSURE((srms > 0.0_SRK) .AND. (srms <= 100.0_SRK))
       ENSURE(ecut >= 0.0_SRK)

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -848,23 +848,7 @@ PROGRAM testPartitionGraph
              11, 12, 13, 14, 15, 17, 18, 23, 24, &
              16, 19, 20, 21, 22, 25, 26, 27, 28/))
       !Calculate the metrics
-      CALL testPG%metrics(mmr,srms,ecut,comm)
-
-      !Test values
-      bool=(mmr .APPROXEQ. 1.0588235294117647_SRK)
-      ASSERT(bool,'max-min ratio')
-      FINFO() mmr
-      bool=(srms .APPROXEQ. 2.7196414661021060_SRK)
-      ASSERT(bool, 'group size rms (from optimal)')
-      FINFO() srms
-      bool=(ecut .APPROXEQ. 10.0_SRK)
-      ASSERT(bool, 'edges cut')
-      FINFO() ecut
-      bool=(comm .APPROXEQ. 18.0_SRK)
-      ASSERT(bool, 'communication')
-      FINFO() comm
-      !Calculate the metrics
-      CALL testPG%metrics(mmr,srms,ecut,comm,maxnsr)
+      CALL testPG%metrics(maxnsr,mmr,srms,ecut,comm)
 
       !Test values
       bool=(maxnsr .APPROXEQ. 0.34615384615384615_SRK)


### PR DESCRIPTION
This reverts commit 7e5dc27878a7464cb03a5dda16117d82836b838d.

This broke everything in MPACT.