### PR TITLE
Updating Partition Graph %metrics routine and adding %wtfactor

### DIFF
--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -36,6 +36,8 @@
 !>
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 MODULE PartitionGraph
+#include "Futility_DBC.h"
+  USE Futility_DBC
   USE IntrType
   USE Allocs
   USE Strings
@@ -111,6 +113,8 @@ MODULE PartitionGraph
     INTEGER(SIK) :: nGroups=0
     !> Number of partitioning methods
     INTEGER(SIK) :: nPart=0
+    !> Weighting factor used when normalizing computational weights
+    REAL(SRK) :: wtfactor=0.0_SRK
     !> Starting index of each group. Size [nGroup+1]
     INTEGER(SIK),ALLOCATABLE :: groupIdx(:)
     !> Vertex indices belonging to each group.
@@ -215,6 +219,8 @@ MODULE PartitionGraph
 !>        If only 1 is specified it will be used for all (sub)graph sizes
 !>    - Conditions (1D INTEGER)
 !>        List of minimum size(nvert) for each partitioning algorithm.
+!>    - wtfactor   (REAL)
+!>        Weighting factor used to normalize vertex weights.
 !>    - wts        (1D REAL)
 !>        Weight of each vertex.
 !>    - neighwts   (2D REAL)
@@ -226,6 +232,7 @@ MODULE PartitionGraph
       TYPE(ParamType),INTENT(IN) :: params
       INTEGER(SIK) :: nerror,nvert,maxneigh,nGroups,nPart,dim
       INTEGER(SIK) :: ipart,pcond,iv
+      REAL(SRK) :: wtfactor
       TYPE(StringType) :: algName
       INTEGER(SIK),ALLOCATABLE :: neigh(:,:), cond(:)
       REAL(SRK),ALLOCATABLE :: wts(:),neighwts(:,:),coord(:,:)
@@ -339,6 +346,15 @@ MODULE PartitionGraph
               ' - invalid number of refinement algorithms specified!')
           ENDIF
         ENDIF
+        !Check vertex weight factor (optional)
+        IF(params%has('PartitionGraph -> wtfactor')) THEN
+          CALL params%get('PartitionGraph -> wtfactor', wtfactor)
+          IF(wtfactor < 0.0_SRK) &
+            CALL ePartitionGraph%raiseError(modName//'::'//myName// &
+              ' - invalid vertex weighting factor, value must be positive!')
+        ELSE
+          wtfactor=1.0_SRK
+        ENDIF
 
         !Check vertex weights (optional)
         IF(params%has('PartitionGraph -> wts')) THEN
@@ -401,6 +417,7 @@ MODULE PartitionGraph
         thisGraph%maxneigh=maxneigh
         thisGraph%nGroups=nGroups
         thisGraph%nPart=nPart
+        thisGraph%wtfactor=wtfactor
 
         !Move allocated data onto the type
         CALL MOVE_ALLOC(neigh,thisGraph%neigh)
@@ -488,6 +505,7 @@ MODULE PartitionGraph
       thisGraph%maxneigh=0
       thisGraph%nGroups=0
       thisGraph%nPart=0
+      thisGraph%wtfactor=0.0_SRK
       IF(ALLOCATED(thisGraph%groupIdx)) DEALLOCATE(thisGraph%groupIdx)
       IF(ALLOCATED(thisGraph%groupList)) DEALLOCATE(thisGraph%groupList)
       IF(ALLOCATED(thisGraph%wts)) DEALLOCATE(thisGraph%wts)
@@ -1706,23 +1724,39 @@ MODULE PartitionGraph
 !> @param ecut the total weight of edges cut
 !> @param comm the total weight of communication between groups
 !>
-    SUBROUTINE calcDecompMetrics_PartitionGraph(thisGraph,mmr,srms,ecut,comm)
+    SUBROUTINE calcDecompMetrics_PartitionGraph(thisGraph,mmr,srms,ecut,comm,maxnsr)
       CHARACTER(LEN=*),PARAMETER :: myName='calcDecompMetrics'
       CLASS(PartitionGraphType),INTENT(IN) :: thisGraph
       REAL(SRK),INTENT(OUT) :: mmr,srms,ecut,comm
+      REAL(SRK),INTENT(OUT),OPTIONAL :: maxnsr
       INTEGER(SIK) :: ig,igstt,igstp,in,ineigh,iv,ivert,neighGrp
-      REAL(SRK) :: wtSum,wtGrp,lgroup,sgroup,optSize,wtDif
+      REAL(SRK) :: wtSum,wtGrp,lgroup,sgroup,optSize,wtDif,gwt
       INTEGER(SIK),ALLOCATABLE :: grpMap(:),uniqueGrps(:)
 
+      IF(PRESENT(maxnsr)) maxnsr=0.0_SRK
       mmr=0.0_SRK
       srms=0.0_SRK
       ecut=0.0_SRK
       comm=0.0_SRK
       IF(ALLOCATED(thisGraph%groupIdx)) THEN
+        !Compute the max number of source regions
+        IF(PRESENT(maxnsr)) THEN
+          DO ig=1,thisGraph%nGroups
+            igstt=thisGraph%groupIdx(ig)
+            igstp=thisGraph%groupIdx(ig+1)-1
+            gwt=0.0_SRK
+            DO iv=igstt,igstp
+              gwt=gwt+thisGraph%wts(thisGraph%groupList(iv))
+            ENDDO
+            maxnsr=MAX(maxnsr,REAL(gwt,SRK))
+          ENDDO
+          maxnsr=maxnsr/SUM(thisGraph%wts)
+        ENDIF
+
         !Compute the min/max ratio and rms difference from optimal
         lgroup=0.0_SRK
         sgroup=HUGE(1.0_SRK)
-        wtSum=SUM(thisGraph%wts)
+        wtSum=SUM(thisGraph%wts)*thisGraph%wtfactor
         optSize=wtSum/REAL(thisGraph%nGroups,SRK)
         DO ig=1,thisGraph%nGroups
 
@@ -1731,6 +1765,7 @@ MODULE PartitionGraph
           DO iv=thisGraph%groupIdx(ig),thisGraph%groupIdx(ig+1)-1
             wtGrp=wtGrp+thisGraph%wts(thisGraph%groupList(iv))
           ENDDO !iv
+          wtGrp=wtGrp*thisGraph%wtfactor
           !Determine min/max weights
           IF(wtGrp > lgroup) lgroup=wtGrp
           IF(wtGrp < sgroup) sgroup=wtGrp
@@ -1786,6 +1821,13 @@ MODULE PartitionGraph
         CALL ePartitionGraph%raiseError(modName//'::'//myName// &
           ' - graph is not partitioned!')
       ENDIF
+      IF(PRESENT(maxnsr)) THEN
+        ENSURE((maxnsr > 0.0_SRK) .AND. (maxnsr <= 1.0_SRK))
+      ENDIF
+      ENSURE(mmr >= 0.0_SRK)
+      ENSURE((srms >= 0.0_SRK) .AND. (srms <= 100.0_SRK))
+      ENSURE(ecut >= 0.0_SRK)
+      ENSURE(comm >= 0.0_SRK)
     ENDSUBROUTINE calcDecompMetrics_PartitionGraph
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -819,10 +819,13 @@ PROGRAM testPartitionGraph
 !-------------------------------------------------------------------------------
     SUBROUTINE testMetrics()
       LOGICAL(SBK) :: bool
-      REAL(SRK) :: mmr,srms,ecut,comm
+      REAL(SRK) :: mmr,srms,ecut,comm,maxnsr
 
       !Initialize the graph
+      CALL refG3Params%set('PartitionGraph->wtfactor',2000.0_SRK)
       CALL testPG%initialize(refG3Params)
+      CALL refG3Params%set('PartitionGraph->wtfactor',1.0_SRK)
+
       !Partition the graph manually
       CALL testPG%setGroups( &
           (/1,11,20,29/), & !GroupIdx
@@ -845,6 +848,27 @@ PROGRAM testPartitionGraph
       bool=(comm .APPROXEQ. 18.0_SRK)
       ASSERT(bool, 'communication')
       FINFO() comm
+
+      !Calculate the metrics
+      CALL testPG%metrics(mmr,srms,ecut,comm,maxnsr)
+
+      !Test values
+      bool=(maxnsr .APPROXEQ. 0.34615384615384615_SRK)
+      ASSERT(bool,'max-nsr ratio')
+      FINFO() maxnsr
+      bool=(mmr .APPROXEQ. 1.0588235294117647_SRK)
+      ASSERT(bool,'max-min ratio')
+      FINFO() mmr
+      bool=(srms .APPROXEQ. 2.7196414661021060_SRK)
+      ASSERT(bool, 'group size rms (from optimal)')
+      FINFO() srms
+      bool=(ecut .APPROXEQ. 10.0_SRK)
+      ASSERT(bool, 'edges cut')
+      FINFO() ecut
+      bool=(comm .APPROXEQ. 18.0_SRK)
+      ASSERT(bool, 'communication')
+      FINFO() comm
+
       !Clear
       CALL testPG%clear()
     ENDSUBROUTINE testMetrics
@@ -939,6 +963,7 @@ PROGRAM testPartitionGraph
                   5, 0, 0, 0/),(/4,6/)))
       CALL refInitParams%add('PartitionGraph -> wts', &
         (/1.0_SRK, 2.0_SRK, 3.0_SRK, 2.0_SRK, 1.0_SRK, 1.0_SRK/))
+      CALL refInitParams%add('PartitionGraph->wtfactor',1.0_SRK)
       CALL refInitParams%add('PartitionGraph -> neighwts', &
         RESHAPE((/1.0_SRK, 0.0_SRK, 0.0_SRK, 0.0_SRK, &
                   1.0_SRK, 2.0_SRK, 3.0_SRK, 0.0_SRK, &
@@ -1010,6 +1035,7 @@ PROGRAM testPartitionGraph
                          2,2,1,0,0,0, &
                          2,2,1,0,0,0/),(/6,6/)),SRK)
       CALL map2Graph(map,refG3Params)
+      CALL refG3Params%add('PartitionGraph->wtfactor',1.0_SRK)
       CALL refG3Params%add('PartitionGraph -> nGroups',3)
       CALL refG3Params%add('PartitionGraph -> Algorithms',refAlgNames(1:1))
       DEALLOCATE(map)


### PR DESCRIPTION
Description:
Adding %wtfactor attribute used to scale the %wts in the input.  The
default is 1.0.
Adding optional argument to %metrics() routine for the max number of
source regions ratio for the given decomposition.