### PR TITLE
Removing boundCheck as it relies on non-standard functionality (#6172)

### DIFF
--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -31,7 +31,6 @@ MODULE ArrayUtils
   PUBLIC :: findNUnique
   PUBLIC :: getUnion
   PUBLIC :: findIndex
-  PUBLIC :: boundCheck
   !PUBLIC :: findIntersection
   !Need a routine in here that compares a 1-D array to a 2-D array for a given dimension
   !to see if the 1-D array exists in the 2-D array...
@@ -998,20 +997,5 @@ MODULE ArrayUtils
         val=tmp(ind)
       ENDIF
     ENDFUNCTION findUpBound_1DReal
-!
-!-------------------------------------------------------------------------------
-!> @brief This function checks if an index is within the allocated domain of a
-!>        1D array of unspecified type. Currently can only be used for 1D arrays
-!>        until assumed-shape polymorphic arrays are supported.
-!> @param array the 1D array to be checked
-!> @param idx the index to check
-!>
-    PURE FUNCTION boundCheck(array,idx) RESULT(res)
-      CLASS(*),INTENT(IN) :: array(:)
-      INTEGER(SIK),INTENT(IN) :: idx
-      LOGICAL(SBK) :: res
-      res=.FALSE.
-      IF(LBOUND(array,DIM=1) <= idx .AND. idx <= UBOUND(array,DIM=1)) res=.TRUE.
-    ENDFUNCTION boundCheck
 !
 ENDMODULE ArrayUtils

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -376,14 +376,6 @@ PROGRAM testArrayUtils
       ASSERT(findIndex(tmprealarray,0.0_SRK,.TRUE.,INCL=2) == 2,'index == 2')
       ASSERT(findIndex(tmprealarray,65.0_SRK,.TRUE.,INCL=2) == -2,'index == -2')
 
-      COMPONENT_TEST('boundCheck 1-D Reals')
-      ASSERT(boundCheck(tmprealarray,3),'in bounds not-allocatable')
-      ASSERT(.NOT.boundCheck(tmprealarray,13),'out of bounds not-allocatable')
-      IF(ALLOCATED(tmpr)) DEALLOCATE(tmpr)
-      ALLOCATE(tmpr(-5:10))
-      ASSERT(boundCheck(tmpr,-3),'in bounds allocatable')
-      ASSERT(.NOT.boundCheck(tmpr,-8),'out of bounds allocatable')
-      DEALLOCATE(tmpr)
     ENDSUBROUTINE test1DReals
 !
 !-------------------------------------------------------------------------------
@@ -470,14 +462,6 @@ PROGRAM testArrayUtils
       CALL getUnique(tmpintarray(1:0),tmpi)
       ASSERT(.NOT. ALLOCATED(tmpi),'getUnique, size 0 array')
 
-      COMPONENT_TEST('boundCheck 1-D Ints')
-      ASSERT(boundCheck(tmpintarray,3),'in bounds not-allocatable')
-      ASSERT(.NOT.boundCheck(tmpintarray,13),'out of bounds not-allocatable')
-      IF(ALLOCATED(tmpi)) DEALLOCATE(tmpi)
-      ALLOCATE(tmpi(-8:-2))
-      ASSERT(boundCheck(tmpi,-2),'in bounds allocatable')
-      ASSERT(.NOT.boundCheck(tmpi,1),'out of bounds allocatable')
-      DEALLOCATE(tmpi)
     ENDSUBROUTINE test1DInts
 !
 !-------------------------------------------------------------------------------
@@ -538,14 +522,6 @@ PROGRAM testArrayUtils
         tmps1(5) == 'seven' .AND. tmps1(6) == 'eight' .AND. tmps1(7) == 'nine'
       ASSERT(bool,'3 duplicates unique array')
 
-      COMPONENT_TEST('boundCheck 1-D StringType')
-      ASSERT(boundCheck(tmpstr1a,3),'in bounds not-allocatable')
-      ASSERT(.NOT.boundCheck(tmpstr1a,13),'out of bounds not-allocatable')
-      IF(ALLOCATED(tmps1)) DEALLOCATE(tmps1)
-      ALLOCATE(tmps1(5:10))
-      ASSERT(boundCheck(tmps1,7),'in bounds allocatable')
-      ASSERT(.NOT.boundCheck(tmps1,2),'out of bounds allocatable')
-      DEALLOCATE(tmps1)
     ENDSUBROUTINE test1DStrings
 !
 !-------------------------------------------------------------------------------


### PR DESCRIPTION
Per Issue #125, GCC 7+ does resets bounds of native arrays when passed through an interface.  `checkBound` relies on this functionality, so the checking of bounds is being deferred to clients.