### PR TITLE
Implements string replace method and testing

### DIFF
--- a/src/FileType_HDF5.f90
+++ b/src/FileType_HDF5.f90
@@ -5673,7 +5673,7 @@ MODULE FileType_HDF5
         ELSE
           vals=valsc(1)(1:length_max)
         ENDIF
-        CALL strrep(vals,C_NULL_CHAR,'')
+        vals = vals%replace(C_NULL_CHAR,'')
       ENDIF
       CALL postRead(thisHDF5File,path,dset_id,dspace_id,error)
 
@@ -5812,7 +5812,7 @@ MODULE FileType_HDF5
 
         !Find replace C_NULL_CHARs from HDF5
         DO i=1,SIZE(vals)
-          CALL strrep(vals(i),C_NULL_CHAR,'')
+          vals(i) = vals(i)%replace(C_NULL_CHAR,'')
         ENDDO
       ENDIF
       CALL postRead(thisHDF5File,path,dset_id,dspace_id,error)
@@ -5969,7 +5969,7 @@ MODULE FileType_HDF5
         !Find replace C_NULL_CHARs from HDF5
         DO j=1,SIZE(vals,DIM=2)
           DO i=1,SIZE(vals,DIM=1)
-            CALL strrep(vals(i,j),C_NULL_CHAR,'')
+            vals(i,j) = vals(i,j)%replace(C_NULL_CHAR,'')
           ENDDO
         ENDDO
       ENDIF
@@ -6133,7 +6133,7 @@ MODULE FileType_HDF5
         DO k=1,SIZE(vals,DIM=3)
           DO j=1,SIZE(vals,DIM=2)
             DO i=1,SIZE(vals,DIM=1)
-              CALL strrep(vals(i,j,k),C_NULL_CHAR,'')
+              vals(i,j,k) = vals(i,j,k)%replace(C_NULL_CHAR,'')
             ENDDO
           ENDDO
         ENDDO
@@ -6266,7 +6266,7 @@ MODULE FileType_HDF5
 
       ! Create root directory
       baseh5path=TRIM(dsetname)
-      CALL strrep(baseh5path,'->','/')
+      baseh5path = baseh5path%replace('->','/')
       baseh5path='/'//baseh5path
       !Check to make sure there are objects/groups to be read
       CALL ls_HDF5FileType(thisHDF5File,dsetname,lsobjs)
@@ -6280,7 +6280,7 @@ MODULE FileType_HDF5
           IF(isgrp_HDF5FileType(thisHDF5File,CHAR(h5path))) THEN
             plpath=h5path//REPEAT(' ',nmatchstr(CHAR(h5path),'/'))
             !Convert back to PL style pathing
-            CALL strrep(plpath,'/','->')
+            plpath = plpath%replace('/','->')
             !Skip the first arrow that will be there
             h5path = plpath%substr(3)
             CALL read_pList(thisHDF5File,CHAR(h5path),vals)
@@ -6322,7 +6322,7 @@ MODULE FileType_HDF5
       TYPE(StringType),ALLOCATABLE :: st1(:),st2(:,:),st3(:,:,:)
 
       tmpstr=h5path//REPEAT(' ',nmatchstr(CHAR(h5path),'/'))
-      CALL strrep(tmpstr,'/','->')
+      tmpstr = tmpstr%replace('/','->')
       plpath = tmpstr%substr(3)
       !Open the dataset so we can get the precision
       CALL h5dopen_f(thisHDF5File%file_id,CHAR(h5path),dset_id,error)
@@ -6419,7 +6419,7 @@ MODULE FileType_HDF5
             !Get the string, then check if it's a boolean.
             CALL read_st0_helper(thisHDF5File,CHAR(plpath),st0)
             !Find replace C_NULL_CHARs from HDF5
-            CALL strrep(st0,C_NULL_CHAR,'')
+            st0 = st0%replace(C_NULL_CHAR,'')
             isbool=(st0 == 'T') .OR. (st0 == 'F')
             IF(isbool) THEN
               CALL read_b0(thisHDF5File,CHAR(plpath),l0)
@@ -6432,7 +6432,7 @@ MODULE FileType_HDF5
             CALL read_st1_helper(thisHDF5File,CHAR(plpath),st1)
             !Find replace C_NULL_CHARs from HDF5
             DO i=1,SIZE(st1)
-              CALL strrep(st1(i),C_NULL_CHAR,'')
+              st1(i) = st1(i)%replace(C_NULL_CHAR,'')
             ENDDO
             isbool=.TRUE.
             DO i=1,SIZE(st1)
@@ -6451,7 +6451,7 @@ MODULE FileType_HDF5
             !Find replace C_NULL_CHARs from HDF5
             DO j=1,SIZE(st2,DIM=2)
               DO i=1,SIZE(st2,DIM=1)
-                CALL strrep(st2(i,j),C_NULL_CHAR,'')
+                st2(i,j) = st2(i,j)%replace(C_NULL_CHAR,'')
               ENDDO
             ENDDO
             isbool=.TRUE.
@@ -6479,7 +6479,7 @@ MODULE FileType_HDF5
             DO k=1,SIZE(st3,DIM=3)
               DO j=1,SIZE(st3,DIM=2)
                 DO i=1,SIZE(st3,DIM=1)
-                  CALL strrep(st3(i,j,k),C_NULL_CHAR,'')
+                  st3(i,j,k) = st3(i,j,k)%replace(C_NULL_CHAR,'')
                 ENDDO
               ENDDO
             ENDDO
@@ -6544,8 +6544,12 @@ MODULE FileType_HDF5
       CHARACTER(LEN=LEN(path)+1) :: newPath
       TYPE(StringType) :: tmp
       tmp=TRIM(path)
-      CALL strrep(tmp,'->','/')
-      newPath='/'//tmp
+      tmp = tmp%replace('->','/')
+      IF(INDEX(tmp,'/') /= 1) THEN
+        newPath='/'//tmp
+      ELSE
+        newPath = trim(tmp)
+      ENDIF
     ENDFUNCTION convertPath
 #ifdef FUTILITY_HAVE_HDF5
 !

--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -1130,7 +1130,7 @@ MODULE IO_Strings
         ENDIF
       ENDIF
       DO i=istt,istp,incr
-        bool = INDEX(string(i),pattern) > 0
+        bool=strmatch(string(i),pattern)
         IF(bool) THEN
           ind=i
           EXIT

--- a/src/IO_Strings.f90
+++ b/src/IO_Strings.f90
@@ -107,8 +107,6 @@ MODULE IO_Strings
   PUBLIC :: isChar
   PUBLIC :: isCharCap
   PUBLIC :: isCharLow
-  !
-  !PUBLIC :: charToStringArray
 
   !> Character representing a space symbol
   CHARACTER(LEN=*),PARAMETER :: BLANK=" "
@@ -387,19 +385,13 @@ MODULE IO_Strings
 !>
     PURE SUBROUTINE stripComment_char(string)
       CHARACTER(LEN=*),INTENT(INOUT) :: string
-      INTEGER(SIK) :: stt,stp
-      INTEGER(SIK),ALLOCATABLE :: bangloc(:)
+      INTEGER(SIK) :: stp,bangloc
 
-      stt=1
-      stp=LEN(string)
-      IF(strmatch(string,BANG)) THEN
-        !Determine the location of the first '!' character and remove all
-        !text after this character (including the '!' character)
-        CALL strfind(string,BANG,bangloc)
-        stp=bangloc(1)-1
-        DEALLOCATE(bangloc)
-      ENDIF
-      string = string(stt:stp)
+      !Determine the location of the first '!' character and remove all
+      !text after this character (including the '!' character)
+      bangloc = INDEX(string,BANG)
+      stp = MERGE(bangloc-1,LEN(string),bangloc > 0)
+      string = string(1:stp)
     ENDSUBROUTINE stripComment_char
 !
 !-------------------------------------------------------------------------------
@@ -408,19 +400,13 @@ MODULE IO_Strings
 !>
     PURE SUBROUTINE stripComment_string(string)
       TYPE(StringType),INTENT(INOUT) :: string
-      INTEGER(SIK) :: stt,stp
-      INTEGER(SIK),ALLOCATABLE :: bangloc(:)
+      INTEGER(SIK) :: stp,bangloc
 
-      stt=1
-      stp=LEN(string)
-      IF(strmatch(string,BANG)) THEN
-        !Determine the location of the first '!' character and remove all
-        !text after this character (including the '!' character)
-        CALL strfind(CHAR(string),BANG,bangloc)
-        stp=bangloc(1)-1
-        DEALLOCATE(bangloc)
-      ENDIF
-      string = string%substr(stt,stp)
+      !Determine the location of the first '!' character and remove all
+      !text after this character (including the '!' character)
+      bangloc = INDEX(string,BANG)
+      stp = MERGE(bangloc-1,LEN(string),bangloc > 0)
+      string = string%substr(1,stp)
     ENDSUBROUTINE stripComment_string
 !
 !-------------------------------------------------------------------------------
@@ -605,7 +591,7 @@ MODULE IO_Strings
       CHARACTER(LEN=*),INTENT(IN) :: aline
       INTEGER(SIK) :: i,multidcol,n,ncol,nmult,ioerr
       LOGICAL(SIK) :: nonblankd,nonblank,multidata,inQuotes
-!
+
       !Check for single-quoted strings, if the number of single quotes is odd
       !then return with a value of -1 to signal an error
       IF(MOD(nmatchstr(TRIM(aline),"'"),2) /= 0) THEN
@@ -1144,7 +1130,7 @@ MODULE IO_Strings
         ENDIF
       ENDIF
       DO i=istt,istp,incr
-        bool=strmatch(string(i),pattern)
+        bool = INDEX(string(i),pattern) > 0
         IF(bool) THEN
           ind=i
           EXIT

--- a/src/Strings.f90
+++ b/src/Strings.f90
@@ -132,10 +132,18 @@ MODULE Strings
       GENERIC :: substr => substr_str
       !> copybrief StringType::replace_slice
       !> copydetails StringType::replace_slice
-      PROCEDURE,PASS :: replace => replace_slice
+      PROCEDURE,PASS :: replace_slice
+      !> copybrief StringType::replace_pattern
+      !> copydetails StringType::replace_pattern
+      PROCEDURE,PASS :: replace_pattern
+      GENERIC :: replace => replace_slice,replace_pattern
       !> copybrief StringType:: split_string
       !> copydetails StringType:: split_string
-      PROCEDURE,PASS :: split =>  split_string
+      PROCEDURE,PASS :: split_string
+      !> copybrief StringType::split_string_space
+      !> copydetails StringType::split_string_space
+      PROCEDURE,PASS :: split_string_space
+      GENERIC :: split => split_string, split_string_space
       !> copybrief StringType::assign_char_to_StringType
       !> copydetails StringType::assign_char_to_StringType
       PROCEDURE,PASS :: assign_char_to_StringType
@@ -175,10 +183,9 @@ MODULE Strings
       !> copybrief StringType::isNumeric_str
       !> copydetails StringType::isNumeric_str
       PROCEDURE,PASS :: isNumeric => isNumeric_str
-      !TODO deferred on account of a strange error with TAU_Stubs
-      !!> copybrief StringType::clean_str
-      !!> copydetails StringType::clean_str
-      !FINAL :: clean_str
+      !> copybrief StringType::clean_str
+      !> copydetails StringType::clean_str
+      PROCEDURE,PASS :: clear => clear_str
   ENDTYPE StringType
 
   !> @brief Overloads the Fortran intrinsic procedure CHAR() so
@@ -321,15 +328,15 @@ MODULE Strings
 !
 !===============================================================================
   CONTAINS
-!!
-!!-------------------------------------------------------------------------------
-!!> @brief cleans up string objects
-!!> @param this the StringType being garbaged collected
-!!>
-!SUBROUTINE clean_str(this)
-!  TYPE(StringType),INTENT(INOUT) :: this
-!  IF(ALLOCATED(this%s)) DEALLOCATE(this%s)
-!ENDSUBROUTINE clean_str
+!
+!-------------------------------------------------------------------------------
+!> @brief cleans up string objects
+!> @param this the StringType being garbaged collected
+!>
+SUBROUTINE clear_str(this)
+  CLASS(StringType),INTENT(INOUT) :: this
+  IF(ALLOCATED(this%s)) DEALLOCATE(this%s)
+ENDSUBROUTINE clear_str
 !
 !-------------------------------------------------------------------------------
 !> @brief Assigns an intrinsic character array to a string
@@ -364,79 +371,164 @@ MODULE Strings
   ENDFUNCTION cchar_to_fchar
 !
 !-------------------------------------------------------------------------------
+!> @brief splits a StringType using a single space as the delimiter. This
+!> routine consumes consecutive spaces as a if they were a single space. The
+!> returned array of strings is will not contain any empty strings. If the
+!> string being split is empty the returned array will be size 0. If there were
+!> no separators found to split on the array will be size 1, and contain the
+!> original string.
+!>
+FUNCTION split_string_space(this) RESULT(sub_str)
+  CLASS(StringType),INTENT(IN) :: this
+  TYPE(StringType),ALLOCATABLE :: sub_str(:)
+  !
+  CHARACTER(LEN=:),ALLOCATABLE :: separator
+  INTEGER(SIK) :: iSplit,nSplits,stt,stp,sepLoc
+
+  separator = ' '
+  stp = LEN(this%s)
+  sepLoc = MERGE(INDEX(this%s,separator),0,stp > 1)
+  IF(sepLoc == 0) THEN
+    !This indicates that either the string or the separator were empty, or
+    !the separator was not found in the string.
+    ALLOCATE(sub_str(1))
+    sub_str(1) = this%s
+    RETURN !For these conditions the original string is returned
+  ENDIF
+
+  ! Search until the delimiter isn't found
+  nSplits = 0
+  stt = 1
+  DO WHILE(sepLoc > 0)
+  ! If the index is greater than 1 then the first character must be a string
+    IF(sepLoc > 1) THEN
+      ! Count the string
+      nSplits = nSplits + 1
+    ENDIF
+    ! Increment to the next delimiter
+    stt = stt + sepLoc
+    sepLoc = INDEX(this%s(stt:stp),separator)
+  ENDDO
+  !Account for strings that don't end in a delimiter
+  IF(stt <= stp) nSplits = nSplits + 1
+  ALLOCATE(sub_str(nSplits))
+
+  ! Split along delimiters and store in the provided array
+  stt = 1
+  iSplit = 0
+  sepLoc = INDEX(this%s(stt:stp),separator)
+  DO WHILE(sepLoc > 0)
+    IF(sepLoc > 1) THEN
+      iSplit = iSplit + 1
+      ! Strip out the string...subtract 2 (1 for exclusive, 1 for delimiter)
+      sub_str(iSplit) = &
+          this%s(stt:stt+INDEX(this%s(stt:stp),separator) - 2)
+    ENDIF
+    stt = stt + sepLoc
+    sepLoc = INDEX(this%s(stt:stp),separator)
+  ENDDO
+  ! If the string ends with a word, then it wasn't snatched out before
+  IF(.NOT.(this%s(stp:stp) == separator)) THEN
+    sub_str(nSplits) = &
+        this%s(INDEX(this%s(1:stp),separator,.TRUE.)+1:stp)
+  ENDIF
+ENDFUNCTION split_string_space
+!
+!-------------------------------------------------------------------------------
 !> @brief splits a StringType at specified delimiter and returns the substrings
-!> in an array of StringTypes. If the delimiter is not found or the supplied
-!> string is empty, the returned array is size 0 with an empty string type inside
+!> in an array of StringTypes.
 !> @param this the string to be split
 !> @param sub_str the returned array of substrings
-!> @param delim the delimiter for split locations, OPTIONAL:default " "
+!> @param separator the delimiter for split locations
 !>
-! The idea of this routine is to mirror the python .split() method as closely
-! as possible, currently consecutive delimiters will be treated as one
-  FUNCTION split_string(this,delim) RESULT(sub_str)
+  FUNCTION split_string(this,separator) RESULT(sub_str)
     CLASS(StringType),INTENT(IN) :: this
-    CHARACTER(LEN=*),OPTIONAL,INTENT(IN) :: delim
+    CHARACTER(LEN=*),INTENT(IN) :: separator 
     TYPE(StringType),ALLOCATABLE :: sub_str(:)
     !
-    CHARACTER(LEN=:),ALLOCATABLE :: separator
-    INTEGER(SIK) :: iSplit,nSplits,stt,stp
+    INTEGER(SIK) :: iSplit,nSplits,stt,stp,sepLoc
 
-    ! Use user supplied delimiter if provided. DEFAULT = " "
-    IF(PRESENT(delim)) THEN
-      ALLOCATE(CHARACTER(LEN(delim)) :: separator)
-      separator = delim
-    ELSE
-      ALLOCATE(CHARACTER(1) :: separator)
-      separator = " "
+    stp = LEN(this%s)
+    sepLoc = MERGE(INDEX(this%s,separator),0,stp > 1 .OR. LEN(separator) > 0)
+    IF(sepLoc == 0) THEN
+      !This indicates that either the string or the separator were empty, or
+      !the separator was not found in the string.
+      ALLOCATE(sub_str(1))
+      sub_str(1) = this%s
+      RETURN !For these conditions the original string is returned
     ENDIF
 
     ! Count the number of splits
     nSplits = 0
     stt = 1
-    stp = LEN(this%s)
-    IF(stp < 1) THEN
-      ALLOCATE(sub_str(0))
-      RETURN
-    ENDIF
-    ! Search until the delimiter isn't found
-    DO WHILE(INDEX(this%s(stt:stp),separator) > 0)
-    ! If the index is greater than 1 then the first character must be a string
-      IF(INDEX(this%s(stt:stp),separator) > 1) THEN
-        ! Count the string
-        nSplits = nSplits + 1
-        ! Increment to the next delimiter
-        stt = stt + INDEX(this%s(stt:stp),separator) + LEN(separator) - 1
-      ELSE
-        ! The first character was the delimiter so skip past it
-        stt = stt + LEN(separator)
-      ENDIF
-    ENDDO
-    ! If the string ends with a word, then it wasn't counted before
-    IF(.NOT.(this%s(stp-LEN(separator)+1:stp) == separator)) THEN
+    DO WHILE(sepLoc > 0)
       nSplits = nSplits + 1
-    ENDIF
+      stt = stt + sepLoc + LEN(separator) - 1
+      sepLoc = INDEX(this%s(stt:stp),separator)
+    ENDDO
+    !Account for strings that don't end in a delimiter
+    IF(stt <= stp) nSplits = nSplits + 1
     ALLOCATE(sub_str(nSplits))
 
-    ! Split along delimiters and store in the provided array
     stt = 1
     iSplit = 0
-    DO WHILE(INDEX(this%s(stt:stp),separator) > 0)
-      IF(INDEX(this%s(stt:stp),separator) > 1) THEN
-        iSplit = iSplit + 1
-        ! Strip out the string...subtract 2 (1 for exclusive, 1 for delimiter)
-        sub_str(iSplit) = &
-            this%s(stt:stt+INDEX(this%s(stt:stp),separator) - 2)
-        stt = stt + INDEX(this%s(stt:stp),separator) + LEN(separator) - 1
-      ELSE
-        stt = stt + LEN(separator)
-      ENDIF
+    sepLoc = INDEX(this%s(stt:stp),separator)
+    DO WHILE(sepLoc > 0)
+      iSplit = iSplit + 1
+      sub_str(iSplit) = this%s(stt:stt+sepLoc-2)
+      stt = stt + sepLoc + LEN(separator) - 1
+      sepLoc = INDEX(this%s(stt:stp),separator)
     ENDDO
     ! If the string ends with a word, then it wasn't snatched out before
-    IF(.NOT.(this%s(stp-LEN(separator)+1:stp) == separator)) THEN
+    IF(iSplit < nSplits) THEN
       sub_str(nSplits) = &
           this%s(INDEX(this%s(1:stp),separator,.TRUE.)+LEN(separator):stp)
     ENDIF
   ENDFUNCTION split_string
+!
+!-------------------------------------------------------------------------------
+!> @brief returns a copy of the string with every occurrence of a specified
+!> search pattern with the designated replacement pattern. This routine will
+!> automatically account for size changes of the underlying character array. If
+!> the search pattern is not found, then the original string is returned
+!>
+FUNCTION replace_pattern(this,oldPat,newPat) RESULT(retStr)
+  CLASS(StringType),INTENT(IN) :: this
+  CHARACTER(LEN=*),INTENT(IN) :: oldPat
+  CHARACTER(LEN=*),INTENT(IN) :: newPat
+  CHARACTER(LEN=:),ALLOCATABLE :: retStr
+  !
+  TYPE(StringType),ALLOCATABLE :: tokens(:)
+  INTEGER(SIK) :: iToken
+
+  !Split out the parts to be retained
+  tokens = this%split(oldPat)
+
+  !Set-up the new string
+  IF(SIZE(tokens) > 1) THEN
+    retStr = ''
+  ELSEIF(SIZE(tokens) == 1) THEN
+    retStr = char(tokens(1))
+    RETURN
+  ELSE
+    retStr = ''
+    RETURN
+  ENDIF
+
+  DO iToken=1,SIZE(tokens)-1
+    IF(tokens(iToken) == '') THEN
+      retStr = retStr//newPat
+    ELSE
+      retStr = retStr//tokens(iToken)//newPat
+    ENDIF
+  ENDDO
+  IF(tokens(SIZE(tokens)) /= '') THEN
+    retStr = retStr//tokens(SIZE(tokens))
+  ELSE
+    retStr = retStr//newPat
+  ENDIF
+
+ENDFUNCTION replace_pattern
 !
 !-------------------------------------------------------------------------------
 !> @brief replaces a slice from a string with the designated character(s). If
@@ -447,7 +539,7 @@ MODULE Strings
 !> @param stp the end of the slice to be replaced
 !> @param in_char the characters that will be subbed in
 !>
-  SUBROUTINE replace_slice(this,stt,stp,in_char)
+  FUNCTION replace_slice(this,stt,stp,in_char) RESULT(retStr)
     CLASS(StringType),INTENT(INOUT) :: this
     INTEGER(SIK),INTENT(IN) :: stt
     INTEGER(SIK),INTENT(IN) :: stp
@@ -455,6 +547,7 @@ MODULE Strings
     !
     CHARACTER(LEN=stp-stt+1) :: tmp_str
     INTEGER(SIK) :: full,part,step
+    CHARACTER(LEN=:),ALLOCATABLE :: retStr
 
     IF((stt <= stp) .AND. (stt > 0) .AND. (stp <= LEN(this))) THEN
       ! Find the number of characters being replaced
@@ -474,9 +567,12 @@ MODULE Strings
       ENDIF
 
       ! Direct substitution of characters
-      this%s(stt:stp) = tmp_str(1:step)
+      retStr = this%s
+      retStr(stt:stp) = tmp_str(1:step)
+    ELSE
+      retStr =this%s
     ENDIF
-  ENDSUBROUTINE replace_slice
+  ENDFUNCTION replace_slice
 !
 !-------------------------------------------------------------------------------
 !> @brief Returns the character at the index provided, if the index is out of
@@ -1270,35 +1366,31 @@ MODULE Strings
     LOGICAL(SBK) :: bool
     INTEGER(SIK) :: stt,dec_pos,exp_pos,pos_neg_exp
 
-    ! Look for '+' and '-'
-    stt = MAX(INDEX(this%s,'+'),INDEX(this%s,'-'))
-    ! Find the decimal if there is one
-    dec_pos = INDEX(this%s,'.')
-    ! Look for Currently acceptable exponents
-    exp_pos = MAX(INDEX(this%s,'e'),INDEX(this%s,'E'),INDEX(this%s,'d'))
-    pos_neg_exp = MAX(INDEX(this%s,'-'),INDEX(this%s,'+'))
-
+    bool = .FALSE.
     ! Enforce that a decimal is required in order to be a float
+    dec_pos = INDEX(this%s,'.')
     IF(dec_pos > 0) THEN
-      ! Check potential number leading up to decimal
-      bool = isNumeric(this%s(stt+1:dec_pos-1))
-      ! There is a possible exponent
-      IF(exp_pos > 0) THEN
-        ! Check number between decimal and exponent
-        bool = bool .AND. isNumeric(this%s(dec_pos+1:exp_pos-1))
-        ! Account for any sign on the exponent
-        IF(pos_neg_exp > 0) THEN
-          bool = bool .AND. isNumeric(this%s(pos_neg_exp+1:LEN(this%s)))
+      ! Look for leading '+' and '-'
+      stt = MAX(INDEX(this%s(1:dec_pos),'+'),INDEX(this%s(1:dec_pos),'-'))
+      ! Check that the leading characters are numeric
+      IF(isNumeric(this%s(stt+1:dec_pos-1))) THEN
+        ! Look for Currently acceptable exponents
+        exp_pos = MAX(INDEX(this%s,'e'),INDEX(this%s,'E'),INDEX(this%s,'d'))
+        IF(exp_pos > 0) THEN
+          ! Account for sign on exponent
+          pos_neg_exp = exp_pos + MAX(INDEX(this%s(exp_pos+1:LEN(this%s)),'-'),INDEX(this%s(exp_pos+1:LEN(this%s)),'+'))
+          IF(pos_neg_exp > 0) THEN
+            bool = isNumeric(this%s(dec_pos+1:exp_pos-1)) .AND. &
+                isNumeric(this%s(pos_neg_exp+1:LEN(this%s)))
+          ELSE
+            bool = isNumeric(this%s(dec_pos+1:exp_pos-1)) .AND. &
+                isNumeric(this%s(exp_pos+1:LEN(this%s)))
+          ENDIF
         ELSE
-          bool = bool .AND. isNumeric(this%s(exp_pos+1:LEN(this%s)))
+          ! No exponent check decimal to end
+          bool = isNumeric(this%s(dec_pos+1:LEN(this%s)))
         ENDIF
-      ELSE
-        ! No exponent check decimal to end
-        bool = bool .AND. isNumeric(this%s(dec_pos+1:LEN(this%s)))
       ENDIF
-    ELSE
-      ! If there isn't a decimal then it isn't a float
-      bool = .FALSE.
     ENDIF
   ENDFUNCTION isFloat
 !
@@ -1310,13 +1402,7 @@ MODULE Strings
   FUNCTION isNumeric_str(this) RESULT(bool)
     CLASS(StringType),INTENT(IN) :: this
     LOGICAL(SBK) :: bool
-
-    IF(this%isInteger()) THEN
-      bool = .TRUE.
-      RETURN
-    ELSE
-      bool = this%isFloat()
-    ENDIF
+    bool = this%isInteger() .OR. this%isFloat()
   ENDFUNCTION isNumeric_str
 !
 ENDMODULE Strings

--- a/src/Strings.f90
+++ b/src/Strings.f90
@@ -116,138 +116,138 @@ MODULE Strings
     !> The stored intrinsic character string
     CHARACTER(LEN=:),ALLOCATABLE,PRIVATE :: s
     CONTAINS
-      !> copybrief StringType::toupper_string
-      !> copydetails StringType::toupper_string
+      !> copybrief Strings::toupper_string
+      !> copydetails Strings::toupper_string
       PROCEDURE,PASS :: upper => toupper_string
-      !> copybrief StringType::toLower_string
-      !> copydetails StringType::toLower_string
+      !> copybrief Strings::toLower_string
+      !> copydetails Strings::toLower_string
       PROCEDURE,PASS :: lower => toLower_string
-      !> copybrief StringType::at_string
-      !> copydetails StringType::at_string
+      !> copybrief Strings::at_string
+      !> copydetails Strings::at_string
       PROCEDURE,PASS :: at => at_string
-      !> copybrief StringType::substr_str
-      !> copydetails StringType::substr_str
+      !> copybrief Strings::substr_str
+      !> copydetails Strings::substr_str
       PROCEDURE,PASS :: substr => substr_str
-      !> copybrief StringType::replace_slice
-      !> copydetails StringType::replace_slice
+      !> copybrief Strings::replace_slice
+      !> copydetails Strings::replace_slice
       PROCEDURE,PASS,PRIVATE :: replace_slice
-      !> copybrief StringType::replace_pattern
-      !> copydetails StringType::replace_pattern
+      !> copybrief Strings::replace_pattern
+      !> copydetails Strings::replace_pattern
       PROCEDURE,PASS,PRIVATE :: replace_pattern
       GENERIC :: replace => replace_slice,replace_pattern
-      !> copybrief StringType:: split_string
-      !> copydetails StringType:: split_string
+      !> copybrief Strings:: split_string
+      !> copydetails Strings:: split_string
       PROCEDURE,PASS,PRIVATE :: split_string
-      !> copybrief StringType::split_string_space
-      !> copydetails StringType::split_string_space
+      !> copybrief Strings::split_string_space
+      !> copydetails Strings::split_string_space
       PROCEDURE,PASS,PRIVATE :: split_string_space
       GENERIC :: split => split_string, split_string_space
-      !> copybrief StringType::assign_char_to_StringType
-      !> copydetails StringType::assign_char_to_StringType
+      !> copybrief Strings::assign_char_to_StringType
+      !> copydetails Strings::assign_char_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_char_to_StringType
-      !> @copybrief StringType::assign_Short_Integer_to_StringType
-      !> @copydetails StringType::assign_Short_Integer_to_StringType
+      !> @copybrief Strings::assign_Short_Integer_to_StringType
+      !> @copydetails Strings::assign_Short_Integer_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_Short_Integer_to_StringType
-      !> @copybrief StringType::assign_Long_Integer_to_StringType
-      !> @copydetails StringType::assign_Long_Integer_to_StringType
+      !> @copybrief Strings::assign_Long_Integer_to_StringType
+      !> @copydetails Strings::assign_Long_Integer_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_Long_Integer_to_StringType
-      !> @copybrief StringType::assign_Single_Real_to_StringType
-      !> @copydetails StringType::assign_Single_Real_to_StringType
+      !> @copybrief Strings::assign_Single_Real_to_StringType
+      !> @copydetails Strings::assign_Single_Real_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_Single_Real_to_StringType
-      !> @copybrief StringType::assign_Double_Real_to_StringType
-      !> @copydetails StringType::assign_Double_Real_to_StringType
+      !> @copybrief Strings::assign_Double_Real_to_StringType
+      !> @copydetails Strings::assign_Double_Real_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_Double_Real_to_StringType
-      !> copybrief StringType::assign_Logical_to_StringType
-      !> copydetails StringType::assign_Logical_to_StringType
+      !> copybrief Strings::assign_Logical_to_StringType
+      !> copydetails Strings::assign_Logical_to_StringType
       PROCEDURE,PASS,PRIVATE :: assign_Logical_to_StringType
       GENERIC :: ASSIGNMENT(=) => assign_char_to_StringType, &
           assign_Logical_to_StringType,assign_Single_Real_to_StringType, &
           assign_Double_Real_to_StringType,assign_Short_Integer_to_StringType, &
           assign_Long_Integer_to_StringType
-      !> copybrief StringType::str_to_sik
-      !> copydetails StringType::str_to_sik
+      !> copybrief Strings::str_to_sik
+      !> copydetails Strings::str_to_sik
       PROCEDURE,PASS :: str_to_sik
       GENERIC :: stoi => str_to_sik
-      !> copybrief StringType::str_to_srk
-      !> copydetails StringType::str_to_srk
+      !> copybrief Strings::str_to_srk
+      !> copydetails Strings::str_to_srk
       PROCEDURE,PASS :: str_to_srk
       GENERIC :: stof => str_to_srk
-      !> copybrief StringType::isInteger
-      !> copydetails StringType::isInteger
+      !> copybrief Strings::isInteger
+      !> copydetails Strings::isInteger
       PROCEDURE,PASS :: isInteger
-      !> copybrief StringType::isFloat
-      !> copydetails StringType::isFloat
+      !> copybrief Strings::isFloat
+      !> copydetails Strings::isFloat
       PROCEDURE,PASS :: isFloat
-      !> copybrief StringType::isNumeric_str
-      !> copydetails StringType::isNumeric_str
+      !> copybrief Strings::isNumeric_str
+      !> copydetails Strings::isNumeric_str
       PROCEDURE,PASS :: isNumeric => isNumeric_str
-      !> copybrief StringType::clean_str
-      !> copydetails StringType::clean_str
+      !> copybrief Strings::clean_str
+      !> copydetails Strings::clean_str
       PROCEDURE,PASS :: clear => clear_str
   ENDTYPE StringType
 
   !> @brief Overloads the Fortran intrinsic procedure CHAR() so
   !> a string type argument may be passed.
   INTERFACE CHAR
-    !> @copybrief StringType::CHAR_StringType
-    !> @copydetails StringType::CHAR_StringType
+    !> @copybrief Strings::CHAR_StringType
+    !> @copydetails Strings::CHAR_StringType
     MODULE PROCEDURE CHAR_StringType
-    !> copybrief StringType::cchar_to_fchar
-    !> copydetails StringType::cchar_to_fchar
+    !> copybrief Strings::cchar_to_fchar
+    !> copydetails Strings::cchar_to_fchar
     MODULE PROCEDURE cchar_to_fchar
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure LEN() so
   !> a string type argument may be passed.
   INTERFACE LEN
-    !> @copybrief StringType::LEN_StringType
-    !> @copydetails StringType::LEN_StringType
+    !> @copybrief Strings::LEN_StringType
+    !> @copydetails Strings::LEN_StringType
     MODULE PROCEDURE LEN_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure LEN_TRIM() so
   !> a string type argument may be passed.
   INTERFACE LEN_TRIM
-    !> @copybrief StringType::LEN_TRIM_StringType
-    !> @copydetails StringType::LEN_TRIM_StringType
+    !> @copybrief Strings::LEN_TRIM_StringType
+    !> @copydetails Strings::LEN_TRIM_StringType
     MODULE PROCEDURE LEN_TRIM_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure TRIM() so
   !> a string type argument may be passed.
   INTERFACE TRIM
-    !> @copybrief StringType::TRIM_StringType
-    !> @copydetails StringType::TRIM_StringType
+    !> @copybrief Strings::TRIM_StringType
+    !> @copydetails Strings::TRIM_StringType
     MODULE PROCEDURE TRIM_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure ADJUSTL() so
   !> a string type argument may be passed.
   INTERFACE ADJUSTL
-    !> @copybrief StringType::ADJUSTL_StringType
-    !> @copydetails StringType::ADJUSTL_StringType
+    !> @copybrief Strings::ADJUSTL_StringType
+    !> @copydetails Strings::ADJUSTL_StringType
     MODULE PROCEDURE ADJUSTL_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure ADJUSTR() so
   !> a string type argument may be passed.
   INTERFACE ADJUSTR
-    !> @copybrief StringType::ADJUSTR_StringType
-    !> @copydetails StringType::ADJUSTR_StringType
+    !> @copybrief Strings::ADJUSTR_StringType
+    !> @copydetails Strings::ADJUSTR_StringType
     MODULE PROCEDURE ADJUSTR_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure INDEX() so
   !> string type arguments may be passed.
   INTERFACE INDEX
-    !> @copybrief StringType::INDEX_StringType_char
-    !> @copydetails StringType::INDEX_StringType_char
+    !> @copybrief Strings::INDEX_StringType_char
+    !> @copydetails Strings::INDEX_StringType_char
     MODULE PROCEDURE INDEX_StringType_char
-    !> @copybrief StringType::INDEX_char_StringType
-    !> @copydetails StringType::INDEX_char_StringType
+    !> @copybrief Strings::INDEX_char_StringType
+    !> @copydetails Strings::INDEX_char_StringType
     MODULE PROCEDURE INDEX_char_StringType
-    !> @copybrief StringType::INDEX_StringType_StringType
-    !> @copydetails StringType::INDEX_StringType_StringType
+    !> @copybrief Strings::INDEX_StringType_StringType
+    !> @copydetails Strings::INDEX_StringType_StringType
     MODULE PROCEDURE INDEX_StringType_StringType
   ENDINTERFACE
 
@@ -285,42 +285,42 @@ MODULE Strings
   !> @brief Overloads the Fortran intrinsic operator for concatenating
   !> character strings.
   INTERFACE OPERATOR(//)
-    !> @copybrief StringType::concatenate_char_onto_StringType
-    !> @copydetails StringType::concatenate_char_onto_StringType
+    !> @copybrief Strings::concatenate_char_onto_StringType
+    !> @copydetails Strings::concatenate_char_onto_StringType
     MODULE PROCEDURE concatenate_char_onto_StringType
-    !> @copybrief StringType::concatenate_StringType_onto_char
-    !> @copydetails StringType::concatenate_StringType_onto_char
+    !> @copybrief Strings::concatenate_StringType_onto_char
+    !> @copydetails Strings::concatenate_StringType_onto_char
     MODULE PROCEDURE concatenate_StringType_onto_char
-    !> @copybrief StringType::concatenate_StringType_onto_StringType
-    !> @copydetails StringType::concatenate_StringType_onto_StringType
+    !> @copybrief Strings::concatenate_StringType_onto_StringType
+    !> @copydetails Strings::concatenate_StringType_onto_StringType
     MODULE PROCEDURE concatenate_StringType_onto_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic operator for comparing
   !> two variables to see if they are equal
   INTERFACE OPERATOR(==)
-    !> @copybrief StringType::equalto_char_StringType
-    !> @copydetails StringType::equalto_char_StringType
+    !> @copybrief Strings::equalto_char_StringType
+    !> @copydetails Strings::equalto_char_StringType
     MODULE PROCEDURE equalto_char_StringType
-    !> @copybrief StringType::equalto_StringType_char
-    !> @copydetails StringType::equalto_StringType_char
+    !> @copybrief Strings::equalto_StringType_char
+    !> @copydetails Strings::equalto_StringType_char
     MODULE PROCEDURE equalto_StringType_char
-    !> @copybrief StringType::equalto_StringType_StringType
-    !> @copydetails StringType::equalto_StringType_StringType
+    !> @copybrief Strings::equalto_StringType_StringType
+    !> @copydetails Strings::equalto_StringType_StringType
     MODULE PROCEDURE equalto_StringType_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic operator for comparing
   !> two variables to see if they are not equal
   INTERFACE OPERATOR(/=)
-    !> @copybrief StringType::notequalto_char_StringType
-    !> @copydetails StringType::notequalto_char_StringType
+    !> @copybrief Strings::notequalto_char_StringType
+    !> @copydetails Strings::notequalto_char_StringType
     MODULE PROCEDURE notequalto_char_StringType
-    !> @copybrief StringType::notequalto_StringType_char
-    !> @copydetails StringType::notequalto_StringType_char
+    !> @copybrief Strings::notequalto_StringType_char
+    !> @copydetails Strings::notequalto_StringType_char
     MODULE PROCEDURE notequalto_StringType_char
-    !> @copybrief StringType::notequalto_StringType_StringType
-    !> @copydetails StringType::notequalto_StringType_StringType
+    !> @copybrief Strings::notequalto_StringType_StringType
+    !> @copydetails Strings::notequalto_StringType_StringType
     MODULE PROCEDURE notequalto_StringType_StringType
   ENDINTERFACE
 !
@@ -374,7 +374,7 @@ ENDSUBROUTINE clear_str
 !> @param this the StringType being split
 !> @returns sub_str an array of substings
 !>
-!> The returned array of strings is will not contain any empty strings. If the
+!> The returned array of strings will not contain any empty strings. If the
 !> string being split is empty the returned array will be size 0. If there were
 !> no separators found to split on the array will be size 1, and contain the
 !> original string.
@@ -383,12 +383,10 @@ FUNCTION split_string_space(this) RESULT(sub_str)
   CLASS(StringType),INTENT(IN) :: this
   TYPE(StringType),ALLOCATABLE :: sub_str(:)
   !
-  CHARACTER(LEN=:),ALLOCATABLE :: separator
   INTEGER(SIK) :: iSplit,nSplits,stt,stp,sepLoc
 
-  separator = ' '
   stp = LEN(this%s)
-  sepLoc = MERGE(INDEX(this%s,separator),0,stp > 1)
+  sepLoc = MERGE(INDEX(this%s,' '),0,stp > 1)
   IF(sepLoc == 0) THEN
     !This indicates that either the string or the separator were empty, or
     !the separator was not found in the string.
@@ -408,7 +406,7 @@ FUNCTION split_string_space(this) RESULT(sub_str)
     ENDIF
     ! Increment to the next delimiter
     stt = stt + sepLoc
-    sepLoc = INDEX(this%s(stt:stp),separator)
+    sepLoc = INDEX(this%s(stt:stp),' ')
   ENDDO
   !Account for strings that don't end in a delimiter
   IF(stt <= stp) nSplits = nSplits + 1
@@ -417,21 +415,20 @@ FUNCTION split_string_space(this) RESULT(sub_str)
   ! Split along delimiters and store in the provided array
   stt = 1
   iSplit = 0
-  sepLoc = INDEX(this%s(stt:stp),separator)
+  sepLoc = INDEX(this%s(stt:stp),' ')
   DO WHILE(sepLoc > 0)
     IF(sepLoc > 1) THEN
       iSplit = iSplit + 1
       ! Strip out the string...subtract 2 (1 for exclusive, 1 for delimiter)
-      sub_str(iSplit) = &
-          this%s(stt:stt+INDEX(this%s(stt:stp),separator) - 2)
+      sub_str(iSplit) = this%s(stt:stt+sepLoc-2)
     ENDIF
     stt = stt + sepLoc
-    sepLoc = INDEX(this%s(stt:stp),separator)
+    sepLoc = INDEX(this%s(stt:stp),' ')
   ENDDO
   ! If the string ends with a word, then it wasn't snatched out before
-  IF(.NOT.(this%s(stp:stp) == separator)) THEN
+  IF(.NOT.(this%s(stp:stp) == ' ')) THEN
     sub_str(nSplits) = &
-        this%s(INDEX(this%s(1:stp),separator,.TRUE.)+1:stp)
+        this%s(INDEX(this%s(1:stp),' ',.TRUE.)+1:stp)
   ENDIF
 ENDFUNCTION split_string_space
 !
@@ -513,11 +510,8 @@ FUNCTION replace_pattern(this,oldPat,newPat) RESULT(retStr)
   !Set-up the new string
   IF(SIZE(tokens) > 1) THEN
     retStr = ''
-  ELSEIF(SIZE(tokens) == 1) THEN
-    retStr = char(tokens(1))
-    RETURN
   ELSE
-    retStr = ''
+    retStr = char(tokens(1))
     RETURN
   ENDIF
 

--- a/src/Strings.f90
+++ b/src/Strings.f90
@@ -124,44 +124,42 @@ MODULE Strings
       PROCEDURE,PASS :: lower => toLower_string
       !> copybrief StringType::at_string
       !> copydetails StringType::at_string
-      PROCEDURE,PASS :: at_string
-      GENERIC :: at => at_string
+      PROCEDURE,PASS :: at => at_string
       !> copybrief StringType::substr_str
       !> copydetails StringType::substr_str
-      PROCEDURE,PASS :: substr_str
-      GENERIC :: substr => substr_str
+      PROCEDURE,PASS :: substr => substr_str
       !> copybrief StringType::replace_slice
       !> copydetails StringType::replace_slice
-      PROCEDURE,PASS :: replace_slice
+      PROCEDURE,PASS,PRIVATE :: replace_slice
       !> copybrief StringType::replace_pattern
       !> copydetails StringType::replace_pattern
-      PROCEDURE,PASS :: replace_pattern
+      PROCEDURE,PASS,PRIVATE :: replace_pattern
       GENERIC :: replace => replace_slice,replace_pattern
       !> copybrief StringType:: split_string
       !> copydetails StringType:: split_string
-      PROCEDURE,PASS :: split_string
+      PROCEDURE,PASS,PRIVATE :: split_string
       !> copybrief StringType::split_string_space
       !> copydetails StringType::split_string_space
-      PROCEDURE,PASS :: split_string_space
+      PROCEDURE,PASS,PRIVATE :: split_string_space
       GENERIC :: split => split_string, split_string_space
       !> copybrief StringType::assign_char_to_StringType
       !> copydetails StringType::assign_char_to_StringType
-      PROCEDURE,PASS :: assign_char_to_StringType
-      !> @copybrief Strings::assign_Short_Integer_to_StringType
-      !> @copydetails Strings::assign_Short_Integer_to_StringType
-      PROCEDURE assign_Short_Integer_to_StringType
-      !> @copybrief Strings::assign_Long_Integer_to_StringType
-      !> @copydetails Strings::assign_Long_Integer_to_StringType
-      PROCEDURE assign_Long_Integer_to_StringType
-      !> @copybrief Strings::assign_Single_Real_to_StringType
-      !> @copydetails Strings::assign_Single_Real_to_StringType
-      PROCEDURE assign_Single_Real_to_StringType
-      !> @copybrief Strings::assign_Double_Real_to_StringType
-      !> @copydetails Strings::assign_Double_Real_to_StringType
-      PROCEDURE assign_Double_Real_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_char_to_StringType
+      !> @copybrief StringType::assign_Short_Integer_to_StringType
+      !> @copydetails StringType::assign_Short_Integer_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_Short_Integer_to_StringType
+      !> @copybrief StringType::assign_Long_Integer_to_StringType
+      !> @copydetails StringType::assign_Long_Integer_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_Long_Integer_to_StringType
+      !> @copybrief StringType::assign_Single_Real_to_StringType
+      !> @copydetails StringType::assign_Single_Real_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_Single_Real_to_StringType
+      !> @copybrief StringType::assign_Double_Real_to_StringType
+      !> @copydetails StringType::assign_Double_Real_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_Double_Real_to_StringType
       !> copybrief StringType::assign_Logical_to_StringType
       !> copydetails StringType::assign_Logical_to_StringType
-      PROCEDURE assign_Logical_to_StringType
+      PROCEDURE,PASS,PRIVATE :: assign_Logical_to_StringType
       GENERIC :: ASSIGNMENT(=) => assign_char_to_StringType, &
           assign_Logical_to_StringType,assign_Single_Real_to_StringType, &
           assign_Double_Real_to_StringType,assign_Short_Integer_to_StringType, &
@@ -191,65 +189,65 @@ MODULE Strings
   !> @brief Overloads the Fortran intrinsic procedure CHAR() so
   !> a string type argument may be passed.
   INTERFACE CHAR
-    !> @copybrief Strings::CHAR_StringType
-    !> @copydetails Strings::CHAR_StringType
+    !> @copybrief StringType::CHAR_StringType
+    !> @copydetails StringType::CHAR_StringType
     MODULE PROCEDURE CHAR_StringType
-    !> copybrief Strings::cchar_to_fchar
-    !> copydetails Strings::cchar_to_fchar
+    !> copybrief StringType::cchar_to_fchar
+    !> copydetails StringType::cchar_to_fchar
     MODULE PROCEDURE cchar_to_fchar
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure LEN() so
   !> a string type argument may be passed.
   INTERFACE LEN
-    !> @copybrief Strings::LEN_StringType
-    !> @copydetails Strings::LEN_StringType
+    !> @copybrief StringType::LEN_StringType
+    !> @copydetails StringType::LEN_StringType
     MODULE PROCEDURE LEN_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure LEN_TRIM() so
   !> a string type argument may be passed.
   INTERFACE LEN_TRIM
-    !> @copybrief Strings::LEN_TRIM_StringType
-    !> @copydetails Strings::LEN_TRIM_StringType
+    !> @copybrief StringType::LEN_TRIM_StringType
+    !> @copydetails StringType::LEN_TRIM_StringType
     MODULE PROCEDURE LEN_TRIM_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure TRIM() so
   !> a string type argument may be passed.
   INTERFACE TRIM
-    !> @copybrief Strings::TRIM_StringType
-    !> @copydetails Strings::TRIM_StringType
+    !> @copybrief StringType::TRIM_StringType
+    !> @copydetails StringType::TRIM_StringType
     MODULE PROCEDURE TRIM_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure ADJUSTL() so
   !> a string type argument may be passed.
   INTERFACE ADJUSTL
-    !> @copybrief Strings::ADJUSTL_StringType
-    !> @copydetails Strings::ADJUSTL_StringType
+    !> @copybrief StringType::ADJUSTL_StringType
+    !> @copydetails StringType::ADJUSTL_StringType
     MODULE PROCEDURE ADJUSTL_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure ADJUSTR() so
   !> a string type argument may be passed.
   INTERFACE ADJUSTR
-    !> @copybrief Strings::ADJUSTR_StringType
-    !> @copydetails Strings::ADJUSTR_StringType
+    !> @copybrief StringType::ADJUSTR_StringType
+    !> @copydetails StringType::ADJUSTR_StringType
     MODULE PROCEDURE ADJUSTR_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic procedure INDEX() so
   !> string type arguments may be passed.
   INTERFACE INDEX
-    !> @copybrief Strings::INDEX_StringType_char
-    !> @copydetails Strings::INDEX_StringType_char
+    !> @copybrief StringType::INDEX_StringType_char
+    !> @copydetails StringType::INDEX_StringType_char
     MODULE PROCEDURE INDEX_StringType_char
-    !> @copybrief Strings::INDEX_char_StringType
-    !> @copydetails Strings::INDEX_char_StringType
+    !> @copybrief StringType::INDEX_char_StringType
+    !> @copydetails StringType::INDEX_char_StringType
     MODULE PROCEDURE INDEX_char_StringType
-    !> @copybrief Strings::INDEX_StringType_StringType
-    !> @copydetails Strings::INDEX_StringType_StringType
+    !> @copybrief StringType::INDEX_StringType_StringType
+    !> @copydetails StringType::INDEX_StringType_StringType
     MODULE PROCEDURE INDEX_StringType_StringType
   ENDINTERFACE
 
@@ -287,42 +285,42 @@ MODULE Strings
   !> @brief Overloads the Fortran intrinsic operator for concatenating
   !> character strings.
   INTERFACE OPERATOR(//)
-    !> @copybrief Strings::concatenate_char_onto_StringType
-    !> @copydetails Strings::concatenate_char_onto_StringType
+    !> @copybrief StringType::concatenate_char_onto_StringType
+    !> @copydetails StringType::concatenate_char_onto_StringType
     MODULE PROCEDURE concatenate_char_onto_StringType
-    !> @copybrief Strings::concatenate_StringType_onto_char
-    !> @copydetails Strings::concatenate_StringType_onto_char
+    !> @copybrief StringType::concatenate_StringType_onto_char
+    !> @copydetails StringType::concatenate_StringType_onto_char
     MODULE PROCEDURE concatenate_StringType_onto_char
-    !> @copybrief Strings::concatenate_StringType_onto_StringType
-    !> @copydetails Strings::concatenate_StringType_onto_StringType
+    !> @copybrief StringType::concatenate_StringType_onto_StringType
+    !> @copydetails StringType::concatenate_StringType_onto_StringType
     MODULE PROCEDURE concatenate_StringType_onto_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic operator for comparing
   !> two variables to see if they are equal
   INTERFACE OPERATOR(==)
-    !> @copybrief Strings::equalto_char_StringType
-    !> @copydetails Strings::equalto_char_StringType
+    !> @copybrief StringType::equalto_char_StringType
+    !> @copydetails StringType::equalto_char_StringType
     MODULE PROCEDURE equalto_char_StringType
-    !> @copybrief Strings::equalto_StringType_char
-    !> @copydetails Strings::equalto_StringType_char
+    !> @copybrief StringType::equalto_StringType_char
+    !> @copydetails StringType::equalto_StringType_char
     MODULE PROCEDURE equalto_StringType_char
-    !> @copybrief Strings::equalto_StringType_StringType
-    !> @copydetails Strings::equalto_StringType_StringType
+    !> @copybrief StringType::equalto_StringType_StringType
+    !> @copydetails StringType::equalto_StringType_StringType
     MODULE PROCEDURE equalto_StringType_StringType
   ENDINTERFACE
 
   !> @brief Overloads the Fortran intrinsic operator for comparing
   !> two variables to see if they are not equal
   INTERFACE OPERATOR(/=)
-    !> @copybrief Strings::notequalto_char_StringType
-    !> @copydetails Strings::notequalto_char_StringType
+    !> @copybrief StringType::notequalto_char_StringType
+    !> @copydetails StringType::notequalto_char_StringType
     MODULE PROCEDURE notequalto_char_StringType
-    !> @copybrief Strings::notequalto_StringType_char
-    !> @copydetails Strings::notequalto_StringType_char
+    !> @copybrief StringType::notequalto_StringType_char
+    !> @copydetails StringType::notequalto_StringType_char
     MODULE PROCEDURE notequalto_StringType_char
-    !> @copybrief Strings::notequalto_StringType_StringType
-    !> @copydetails Strings::notequalto_StringType_StringType
+    !> @copybrief StringType::notequalto_StringType_StringType
+    !> @copydetails StringType::notequalto_StringType_StringType
     MODULE PROCEDURE notequalto_StringType_StringType
   ENDINTERFACE
 !
@@ -373,7 +371,10 @@ ENDSUBROUTINE clear_str
 !-------------------------------------------------------------------------------
 !> @brief splits a StringType using a single space as the delimiter. This
 !> routine consumes consecutive spaces as a if they were a single space. The
-!> returned array of strings is will not contain any empty strings. If the
+!> @param this the StringType being split
+!> @returns sub_str an array of substings
+!>
+!> The returned array of strings is will not contain any empty strings. If the
 !> string being split is empty the returned array will be size 0. If there were
 !> no separators found to split on the array will be size 1, and contain the
 !> original string.
@@ -438,8 +439,8 @@ ENDFUNCTION split_string_space
 !> @brief splits a StringType at specified delimiter and returns the substrings
 !> in an array of StringTypes.
 !> @param this the string to be split
-!> @param sub_str the returned array of substrings
 !> @param separator the delimiter for split locations
+!> @returns sub_str the returned array of substrings
 !>
   FUNCTION split_string(this,separator) RESULT(sub_str)
     CLASS(StringType),INTENT(IN) :: this
@@ -488,9 +489,14 @@ ENDFUNCTION split_string_space
 !
 !-------------------------------------------------------------------------------
 !> @brief returns a copy of the string with every occurrence of a specified
-!> search pattern with the designated replacement pattern. This routine will
-!> automatically account for size changes of the underlying character array. If
-!> the search pattern is not found, then the original string is returned
+!> search pattern with the designated replacement pattern.
+!> @param this the StringType being operated on
+!> @param oldPat the pattern being replaced
+!> @param newPat the pattern being inserted
+!> @returns retStr the newly formed string
+!> This routine will automatically account for size changes of the underlying
+!> character array. If the search pattern is not found, then the original string
+!> is returned
 !>
 FUNCTION replace_pattern(this,oldPat,newPat) RESULT(retStr)
   CLASS(StringType),INTENT(IN) :: this
@@ -538,6 +544,7 @@ ENDFUNCTION replace_pattern
 !> @param stt the start of the slice to be replaced
 !> @param stp the end of the slice to be replaced
 !> @param in_char the characters that will be subbed in
+!> @returns retStr the newly formed string
 !>
   FUNCTION replace_slice(this,stt,stp,in_char) RESULT(retStr)
     CLASS(StringType),INTENT(INOUT) :: this
@@ -579,6 +586,7 @@ ENDFUNCTION replace_pattern
 !> or the string is not allocated then the ascii null character is returned.
 !> @param this the string being indexed into
 !> @param pos the index the character should be taken from
+!> @returns letter the character being returned
 !>
   PURE FUNCTION at_string(this,pos) RESULT(letter)
     CLASS(StringType),INTENT(IN) :: this
@@ -598,6 +606,7 @@ ENDFUNCTION replace_pattern
 !> @param this the string being sliced
 !> @param stt the first index of the slice
 !> @param stp the last index of the slice OPTIONAL: Default = LEN(this)
+!> @returns slice the character(s) being returned
 !
   PURE FUNCTION substr_str(this,stt,stp) RESULT(slice)
     CLASS(StringType),INTENT(IN) :: this
@@ -622,16 +631,17 @@ ENDFUNCTION replace_pattern
 !> @brief Utility function takes a string and converts all upper case letters to
 !> lower case letters.
 !> @param word input is a string, output has all lower case letters
+!> @lower_str the lower cased version of this
 !>
-    PURE FUNCTION toLower_string(word) RESULT(upper_str)
+    PURE FUNCTION toLower_string(word) RESULT(lower_str)
       CLASS(StringType),INTENT(IN) :: word
       INTEGER(SIK) :: i
       !
-      TYPE(StringType) :: upper_str
-      upper_str = word
+      TYPE(StringType) :: lower_str
+      lower_str = word
       DO i=1,LEN(word)
         IF('A' <= word%s(i:i) .AND. word%s(i:i) <= 'Z') &
-          upper_str%s(i:i)=ACHAR(IACHAR(word%s(i:i))+32)
+          lower_str%s(i:i)=ACHAR(IACHAR(word%s(i:i))+32)
       ENDDO
     ENDFUNCTION toLower_string
 !
@@ -639,16 +649,17 @@ ENDFUNCTION replace_pattern
 !> @brief Utility function takes a string and converts all lower case letters to
 !> upper case letters.
 !> @param word input is a string, output has all upper case letters
+!> @upper_str the upper cased version of this
 !>
-    PURE FUNCTION toupper_string(word) RESULT(lower_str)
+    PURE FUNCTION toupper_string(word) RESULT(upper_str)
       CLASS(StringType),INTENT(IN) :: word
       INTEGER(SIK) :: i
       !
-      TYPE(StringType) :: lower_str
-      lower_str = word
+      TYPE(StringType) :: upper_str
+      upper_str = word
       DO i=1,LEN(word)
         IF('a' <= word%s(i:i) .AND. word%s(i:i) <= 'z') &
-          lower_str%s(i:i)=ACHAR(IACHAR(word%s(i:i))-32)
+          upper_str%s(i:i)=ACHAR(IACHAR(word%s(i:i))-32)
       ENDDO
     ENDFUNCTION toupper_string
 !
@@ -700,10 +711,7 @@ ENDFUNCTION replace_pattern
 !> @brief Returns the contents of the string excluding all trailing whitespace
 !> as an intrinsic character type variable.
 !> @param this the string object
-!> @returns str the character string
-!>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c TRIM does for character variables.
+!> @returns str this trimmed of trailing whitespace
 !>
     PURE FUNCTION TRIM_StringType(this) RESULT(str)
       CLASS(StringType),INTENT(IN) :: this
@@ -719,10 +727,7 @@ ENDFUNCTION replace_pattern
 !> @brief Returns the contents of the string as an intrinsic character type
 !> variable with all preceding whitespace moved to the end.
 !> @param thisStr the string object
-!> @returns s the character string
-!>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c ADJUSTL does for character variables.
+!> @returns s left aligned version of this
 !>
     PURE FUNCTION ADJUSTL_StringType(thisStr) RESULT(s)
       CLASS(StringType),INTENT(IN) :: thisStr
@@ -734,10 +739,7 @@ ENDFUNCTION replace_pattern
 !> @brief Returns the contents of the string as an intrinsic character type
 !> variable with all trailing whitespace moved to the beginning.
 !> @param thisStr the string object
-!> @returns s the character string
-!>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c ADJUSTR does for character variables.
+!> @returns s right aligned version of this
 !>
     PURE FUNCTION ADJUSTR_StringType(thisStr) RESULT(s)
       CLASS(StringType),INTENT(IN) :: thisStr
@@ -753,9 +755,6 @@ ENDFUNCTION replace_pattern
 !> @param back a logical indicating whether or not to return the position of
 !>        the first or last instance of the @c substring within @c string
 !> @returns ipos the position in @c string of the @c substring
-!>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c INDEX does for character variables.
 !>
     ELEMENTAL FUNCTION INDEX_StringType_char(string,substring,back) RESULT(ipos)
       CLASS(StringType),INTENT(IN) :: string
@@ -774,9 +773,6 @@ ENDFUNCTION replace_pattern
 !>        the first or last instance of the @c substring within @c string
 !> @returns ipos the position in @c string of the @c substring
 !>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c INDEX does for character variables.
-!>
     ELEMENTAL FUNCTION INDEX_char_StringType(string,substring,back) RESULT(ipos)
       CHARACTER(LEN=*),INTENT(IN) :: string
       CLASS(StringType),INTENT(IN) :: substring
@@ -793,9 +789,6 @@ ENDFUNCTION replace_pattern
 !> @param back a logical indicating whether or not to return the position of
 !>        the first or last instance of the @c substring within @c string
 !> @returns ipos the position in @c string of the @c substring
-!>
-!> The intent is that this behaves exactly the same way as the intrinsic
-!> function @c INDEX does for character variables.
 !>
     ELEMENTAL FUNCTION INDEX_StringType_StringType(string,substring,back) RESULT(ipos)
       CLASS(StringType),INTENT(IN) :: string
@@ -1059,77 +1052,65 @@ ENDFUNCTION replace_pattern
 !-------------------------------------------------------------------------------
 !> @brief Assigns a short integer to a StringType.
 !> @param lhs the string object
-!> @param i short integer
+!> @param rhs short integer
 !>
-!> The intent is that this will overload the assignment operator so a short
-!> (32-bit) integer can be assigned to a StringType.
-!>
-    ELEMENTAL SUBROUTINE assign_Short_Integer_to_StringType(lhs,i)
+    ELEMENTAL SUBROUTINE assign_Short_Integer_to_StringType(lhs,rhs)
       CLASS(StringType),INTENT(INOUT) :: lhs
-      INTEGER(SNK),INTENT(IN) :: i
+      INTEGER(SNK),INTENT(IN) :: rhs
       CHARACTER(LEN=11) :: l
-      WRITE(l,'(i11)') i
+      WRITE(l,'(i11)') rhs
       lhs = TRIM(ADJUSTL(l))
     ENDSUBROUTINE assign_Short_Integer_to_StringType
 !
 !-------------------------------------------------------------------------------
 !> @brief Assigns a long integer to a StringType.
-!> @param hs the string object
-!> @param i long integer
+!> @param lhs the string object
+!> @param rhs long integer
 !>
-!> The intent is that this will overload the assignment operator so a long
-!> (64-bit) integer can be assigned to a StringType.
-!>
-    ELEMENTAL SUBROUTINE assign_Long_Integer_to_StringType(lhs,i)
+    ELEMENTAL SUBROUTINE assign_Long_Integer_to_StringType(lhs,rhs)
       CLASS(StringType),INTENT(INOUT) ::lhs
-      INTEGER(SLK),INTENT(IN) :: i
+      INTEGER(SLK),INTENT(IN) :: rhs
       CHARACTER(LEN=20) :: l
-      WRITE(l,'(i20)') i
+      WRITE(l,'(i20)') rhs
       lhs = TRIM(ADJUSTL(l))
     ENDSUBROUTINE assign_Long_Integer_to_StringType
 !
 !-------------------------------------------------------------------------------
 !> @brief Assigns a single real to a StringType.
 !> @param lhs the string object
-!> @param r single real
+!> @param rhs single real
 !>
-!> The intent is that this will overload the assignment operator so a single
-!> (32-bit) real can be assigned to a StringType.
-!>
-    ELEMENTAL SUBROUTINE assign_Single_Real_to_StringType(lhs,r)
+    ELEMENTAL SUBROUTINE assign_Single_Real_to_StringType(lhs,rhs)
       CLASS(StringType),INTENT(INOUT) :: lhs
-      REAL(SSK),INTENT(IN) :: r
+      REAL(SSK),INTENT(IN) :: rhs
       CHARACTER(LEN=15) :: l
-      WRITE(l,'(es15.5)') r
+      WRITE(l,'(es15.5)') rhs
       lhs = TRIM(ADJUSTL(l))
     ENDSUBROUTINE assign_Single_Real_to_StringType
 !
 !-------------------------------------------------------------------------------
 !> @brief Assigns a double real to a StringType.
 !> @param lhs the string object
-!> @param r double real
+!> @param rhs double real
 !>
-!> The intent is that this will overload the assignment operator so a double
-!> (64-bit) real can be assigned to a StringType.
-!>
-    ELEMENTAL SUBROUTINE assign_Double_Real_to_StringType(lhs,r)
+    ELEMENTAL SUBROUTINE assign_Double_Real_to_StringType(lhs,rhs)
       CLASS(StringType),INTENT(INOUT) :: lhs
-      REAL(SDK),INTENT(IN) :: r
+      REAL(SDK),INTENT(IN) :: rhs
       CHARACTER(LEN=22) :: l
-      WRITE(l,'(es22.15)') r
+      WRITE(l,'(es22.15)') rhs
       lhs = TRIM(ADJUSTL(l))
     ENDSUBROUTINE assign_Double_Real_to_StringType
 !
 !-------------------------------------------------------------------------------
 !> @brief Assigns a logical to a StringType.
 !> @param lhs the string object
-!> @param bool the logical to be written
+!> @param rhs the logical to be written
 !>
-  SUBROUTINE assign_Logical_to_StringType(lhs,bool)
+  SUBROUTINE assign_Logical_to_StringType(lhs,rhs)
     CLASS(StringType),INTENT(INOUT) :: lhs
-    LOGICAL(SBK),INTENT(IN) :: bool
+    LOGICAL(SBK),INTENT(IN) :: rhs
     CHARACTER(LEN=1) :: tmp
-    WRITE(tmp,'(L1)') bool
+    WRITE(tmp,'(L1)') rhs
     lhs = tmp
   ENDSUBROUTINE assign_Logical_to_StringType
 !
@@ -1140,9 +1121,6 @@ ENDFUNCTION replace_pattern
 !> @param s the length of the string
 !> @returns newstring a character string that is a concatenation of a
 !> @c StringType and character string
-!>
-!> The intent is that this will overload the // operator so a
-!> @c CHARACTER type can be concatenated with a @c StringType.
 !>
     PURE FUNCTION concatenate_StringType_onto_char(lhs,rhs) RESULT(out_str)
       CHARACTER(LEN=*),INTENT(IN) :: lhs
@@ -1159,9 +1137,6 @@ ENDFUNCTION replace_pattern
 !> @returns newstring a character string that is a concatenation of a
 !> @c StringType and character string
 !>
-!> The intent is that this will overload the // operator so a
-!> @c CHARACTER type can be concatenated with a @c StringType.
-!>
     PURE FUNCTION concatenate_char_onto_StringType(lhs,rhs) RESULT(out_str)
       CLASS(StringType),INTENT(IN) :: lhs
       CHARACTER(LEN=*),INTENT(IN) :: rhs
@@ -1175,9 +1150,6 @@ ENDFUNCTION replace_pattern
 !> @param s2 the string object
 !> @returns newstring a character string that is a concatenation of a
 !> two @c StringTypes
-!>
-!> The intent is that this will overload the // operator so a
-!> @c StringType can be concatenated with a @c StringType.
 !>
     PURE FUNCTION concatenate_StringType_onto_StringType(lhs,rhs) RESULT(out_str)
       CLASS(StringType),INTENT(IN) :: lhs
@@ -1193,9 +1165,6 @@ ENDFUNCTION replace_pattern
 !> @param rhs a @c StringType object
 !> @returns bool the result of the == operation
 !>
-!> The intent is that this will overload the == operator so a
-!> @c CHARACTER type can compared with a @c StringType.
-!>
     ELEMENTAL FUNCTION equalto_char_StringType(lhs,rhs) RESULT(bool)
       CHARACTER(LEN=*),INTENT(IN) :: lhs
       CLASS(StringType),INTENT(IN) ::rhs
@@ -1209,9 +1178,6 @@ ENDFUNCTION replace_pattern
 !> @param lhs a @c StringType object
 !> @param rhs a @c CHARACTER type
 !> @returns bool the result of the == operation
-!>
-!> The intent is that this will overload the == operator so a
-!> @c CHARACTER type can compared with a @c StringType.
 !>
     ELEMENTAL FUNCTION equalto_StringType_char(lhs,rhs) RESULT(bool)
       CLASS(StringType),INTENT(IN) ::lhs
@@ -1227,9 +1193,6 @@ ENDFUNCTION replace_pattern
 !> @param rhs another @c StringType object
 !> @returns bool the result of the == operation
 !>
-!> The intent is that this will overload the == operator so a
-!> @c StringType type can compared with a @c StringType.
-!>
     ELEMENTAL FUNCTION equalto_StringType_StringType(lhs,rhs) RESULT(bool)
       CLASS(StringType),INTENT(IN) :: lhs
       CLASS(StringType),INTENT(IN) :: rhs
@@ -1243,9 +1206,6 @@ ENDFUNCTION replace_pattern
 !> @param lhs a @c CHARACTER type
 !> @param rhs a @c StringType object
 !> @returns bool the result of the /= operation
-!>
-!> The intent is that this will overload the /= operator so a
-!> @c CHARACTER type can compared with a @c StringType.
 !>
     ELEMENTAL FUNCTION notequalto_char_StringType(lhs,rhs) RESULT(bool)
       CHARACTER(LEN=*),INTENT(IN) :: lhs
@@ -1261,9 +1221,6 @@ ENDFUNCTION replace_pattern
 !> @param rhs a @c CHARACTER type
 !> @returns bool the result of the /= operation
 !>
-!> The intent is that this will overload the /= operator so a
-!> @c CHARACTER type can compared with a @c StringType.
-!>
     ELEMENTAL FUNCTION notequalto_StringType_char(lhs,rhs) RESULT(bool)
       CLASS(StringType),INTENT(IN) :: lhs
       CHARACTER(LEN=*),INTENT(IN) :: rhs
@@ -1278,9 +1235,6 @@ ENDFUNCTION replace_pattern
 !> @param rhs another @c StringType object
 !> @returns bool the result of the /= operation
 !>
-!> The intent is that this will overload the /= operator so a
-!> @c StringType type can compared with a @c StringType.
-!>
     ELEMENTAL FUNCTION notequalto_StringType_StringType(lhs,rhs) RESULT(bool)
       CLASS(StringType),INTENT(IN) :: lhs
       CLASS(StringType),INTENT(IN) :: rhs
@@ -1291,9 +1245,9 @@ ENDFUNCTION replace_pattern
 !-------------------------------------------------------------------------------
 !> @brief convert a string to an int
 !> @param this the string being converted
-!> @param i the integer that will be output
 !> @param stt position for starting conversion
 !> @param stp end of conversion
+!> @returns i the integer that will be output
 !>
   FUNCTION str_to_sik(this,stt,stp) RESULT(i)
     CLASS(StringType),INTENT(IN) :: this
@@ -1319,7 +1273,9 @@ ENDFUNCTION replace_pattern
 !-------------------------------------------------------------------------------
 !> @brief convert a string to a float
 !> @param this the string being converted
-!> @param i the integer that will be output
+!> @param stt position for starting conversion
+!> @param stp end of conversion
+!> @returns i the integer that will be output
 !>
   FUNCTION str_to_srk(this,stt,stp) RESULT(i)
     CLASS(StringType),INTENT(IN) :: this

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -109,9 +109,6 @@ PROGRAM testIOutil
       string='testing'
       CALL strrep(string,'t','TT')
       ASSERT_EQ(TRIM(string),'TTesTTing','testing')
-      tmpStr='testing  '
-      CALL strrep(tmpStr,'t','TT')
-      ASSERT_EQ(TRIM(tmpStr),'TTesTTing','testing')
       string='A->B->C->D->EFGH'
       CALL strrep(string,'->','/')
       ASSERT_EQ(TRIM(string),'A/B/C/D/EFGH','-> to /')

--- a/unit_tests/testIOutil/testIOutil.f90
+++ b/unit_tests/testIOutil/testIOutil.f90
@@ -109,6 +109,9 @@ PROGRAM testIOutil
       string='testing'
       CALL strrep(string,'t','TT')
       ASSERT_EQ(TRIM(string),'TTesTTing','testing')
+      tmpStr='testing  '
+      CALL strrep(tmpStr,'t','TT')
+      ASSERT_EQ(TRIM(tmpStr),'TTesTTing','testing')
       string='A->B->C->D->EFGH'
       CALL strrep(string,'->','/')
       ASSERT_EQ(TRIM(string),'A/B/C/D/EFGH','-> to /')

--- a/unit_tests/testStrings/testStrings.f90
+++ b/unit_tests/testStrings/testStrings.f90
@@ -59,6 +59,11 @@ SUBROUTINE testAssign_chars()
   ASSERT_EQ(LEN(testString),0,'LEN(testString) (zero-length)')
   ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (zero-length)')
   ASSERT_EQ(TRIM(testString),'','TRIM(testString) (zero-length)')
+  CALL testString%clear()
+  ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
+  ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
+  ASSERT_EQ(CHAR(testString),'','CHAR(testString) (uninit)')
+  ASSERT_EQ(TRIM(testString),'','TRIM(testString) (uninit)')
 
   !Test assigning a non-empty character to a string
   testString='constant '

--- a/unit_tests/testStrings/testStrings.f90
+++ b/unit_tests/testStrings/testStrings.f90
@@ -8,83 +8,88 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testStrings
 #include "UnitTest.h"
-  USE ISO_C_BINDING
-  USE UnitTest
-  USE IntrType
-  USE Strings
+USE ISO_C_BINDING
+USE UnitTest
+USE IntrType
+USE Strings
 
-  IMPLICIT NONE
+IMPLICIT NONE
 
-  CREATE_TEST('TEST STRINGS')
-  REGISTER_SUBTEST('Un-Iniitialized State',testUnInit)
-  REGISTER_SUBTEST('Character Assignments',testAssign_chars)
-  REGISTER_SUBTEST('Numberal Assignments',testAssign_nums)
-  REGISTER_SUBTEST('Array Assignments',testAssign_arrays)
-  REGISTER_SUBTEST('Intrinsics',testIntrinsic)
-  REGISTER_SUBTEST('string_functs',testStrFunct)
-  FINALIZE_TEST()
+CREATE_TEST('TEST STRINGS')
+REGISTER_SUBTEST('Un-Iniitialized State',testUnInit)
+REGISTER_SUBTEST('Character Assignments',testAssign_chars)
+REGISTER_SUBTEST('Numberal Assignments',testAssign_nums)
+REGISTER_SUBTEST('Array Assignments',testAssign_arrays)
+REGISTER_SUBTEST('Intrinsics',testIntrinsic)
+REGISTER_SUBTEST('string_functs',testStrFunct)
+FINALIZE_TEST()
 !
 !-------------------------------------------------------------------------------
 CONTAINS
 !
 !-------------------------------------------------------------------------------
 !>
-  SUBROUTINE testUnInit()
-    TYPE(StringType) :: testString
-    COMPONENT_TEST('Test Unitialized')
-    !Test methods for uninitialized state
-    ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
-    ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
-    ASSERT_EQ(CHAR(testString),'','CHAR(testString) (uninit)')
-    ASSERT_EQ(TRIM(testString),'','TRIM(testString) (uninit)')
-  ENDSUBROUTINE testUnInit
+SUBROUTINE testUnInit()
+  TYPE(StringType) :: testString
+  COMPONENT_TEST('Test Unitialized')
+  !Test methods for uninitialized state
+  ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
+  ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
+  ASSERT_EQ(CHAR(testString),'','CHAR(testString) (uninit)')
+  ASSERT_EQ(TRIM(testString),'','TRIM(testString) (uninit)')
+
+  COMPONENT_TEST('Test Clear')
+  CALL testString%clear()
+  ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
+  ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
+  ASSERT_EQ(CHAR(testString),'','CHAR(testString) (uninit)')
+  ASSERT_EQ(TRIM(testString),'','TRIM(testString) (uninit)')
+ENDSUBROUTINE testUnInit
 !
 !-------------------------------------------------------------------------------
 !>
-  SUBROUTINE testAssign_chars()
-    TYPE(StringType) :: testString,testString2
-    CHARACTER(LEN=:),ALLOCATABLE :: char_str
+SUBROUTINE testAssign_chars()
+  TYPE(StringType) :: testString,testString2
+  CHARACTER(LEN=:),ALLOCATABLE :: char_str
 
-    COMPONENT_TEST('Assignment Char to String Scalar')
-    !Test assigning a zero length character to a string
-    testString=""
-    ASSERT_EQ(CHAR(testString),"",'CHAR(testString) (zero-length)')
-    ASSERT_EQ(LEN(testString),0,'LEN(testString) (zero-length)')
-    ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (zero-length)')
-    ASSERT_EQ(TRIM(testString),'','TRIM(testString) (zero-length)')
+  COMPONENT_TEST('Assignment Char to String Scalar')
+  !Test assigning a zero length character to a string
+  testString=""
+  ASSERT_EQ(CHAR(testString),"",'CHAR(testString) (zero-length)')
+  ASSERT_EQ(LEN(testString),0,'LEN(testString) (zero-length)')
+  ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (zero-length)')
+  ASSERT_EQ(TRIM(testString),'','TRIM(testString) (zero-length)')
 
-    !Test assigning a non-empty character to a string from a constant
-    testString='constant'
-    WRITE(*,*) CHAR(testString)
-    ASSERT_EQ(CHAR(testString),'constant','CHAR(testString) (=''constant'')')
-    ASSERT_EQ(testString%at(1),'c','CHAR(testString,1,1) (=''constant'')')
-    ASSERT_EQ(testString%substr(2,3),'on','CHAR(testString,2,3) (=''constant'')')
-    !ASSERT(testString%at(-1,100) == 'constant','CHAR(testString,-1,100) (=''constant'')')
-    ASSERT_EQ(LEN(testString),8,'LEN(testString) (=''constant'')')
-    ASSERT_EQ(LEN_TRIM(testString),8,'LEN_TRIM(testString) (=''constant'')')
-    ASSERT_EQ(TRIM(testString),'constant','TRIM(testString) (=''constant'')')
+  !Test assigning a non-empty character to a string
+  testString='constant '
+  ASSERT_EQ(CHAR(testString),'constant ','CHAR(testString) (="constant")')
+  ASSERT_EQ(testString%at(1),'c','%at(1) return 1st character')
+  ASSERT_EQ(testString%at(-1),'','%at(-1) return null string')
+  ASSERT_EQ(testString%substr(2,3),'on','%substr(2,3) return 2nd and 3rd char')
+  ASSERT_EQ(LEN(testString),9,'LEN(testString) (=''constant'')')
+  ASSERT_EQ(LEN_TRIM(testString),8,'LEN_TRIM(testString) (=''constant'')')
+  ASSERT_EQ(TRIM(testString),'constant','TRIM(testString) (=''constant'')')
 
-    !Test assigning a non-empty character to a string from a variable
-    ALLOCATE(CHARACTER(10) :: char_str)
-    char_str='variable  '
-    testString=char_str
-    ASSERT_EQ(CHAR(testString),'variable  ','CHAR(testString) (=''variable'')')
-    ASSERT_EQ(LEN(testString),10,'LEN(testString) (=''variable'')')
-    ASSERT_EQ(LEN_TRIM(testString),8,'LEN_TRIM(testString) (=''variable'')')
-    ASSERT_EQ(TRIM(testString),'variable','TRIM(testString) (=''variable'')')
-    DEALLOCATE(char_str)
+  !Test assigning a non-empty character to a string from a variable
+  ALLOCATE(CHARACTER(10) :: char_str)
+  char_str='variable  '
+  testString=char_str
+  ASSERT_EQ(CHAR(testString),'variable  ','CHAR(testString) (=''variable'')')
+  ASSERT_EQ(LEN(testString),10,'LEN(testString) (=''variable'')')
+  ASSERT_EQ(LEN_TRIM(testString),8,'LEN_TRIM(testString) (=''variable'')')
+  ASSERT_EQ(TRIM(testString),'variable','TRIM(testString) (=''variable'')')
+  DEALLOCATE(char_str)
 
-    !Test assigning a string to a character
-    COMPONENT_TEST('Assignment String Scalar to Char')
-    char_str=CHAR(testString)
-    ASSERT_EQ(char_str,'variable','char_str')
+  !Test assigning a string to a character
+  COMPONENT_TEST('Assignment String Scalar to Char')
+  char_str=CHAR(testString)
+  ASSERT_EQ(char_str,'variable','char_str')
 
-    !Test assigning a string to a string
-    COMPONENT_TEST('Assignment String Scalar to String Scalar')
-    testString2='testString2'
-    testString2=testString
-    ASSERT_EQ(CHAR(testString2),'variable','variable')
-  ENDSUBROUTINE testAssign_chars
+  !Test assigning a string to a string
+  COMPONENT_TEST('Assignment String Scalar to String Scalar')
+  testString2=testString
+  ASSERT_EQ(CHAR(testString2),'variable','variable')
+ENDSUBROUTINE testAssign_chars
 !
 !-------------------------------------------------------------------------------
 !>
@@ -452,11 +457,6 @@ CONTAINS
     ASSERT(.NOT.ALL(test3a,test3a2),'ALL 3-D & 3-D')
     ASSERT(ALL(test3a,test3a2,.TRUE.),'ALL 3-D & 3-D, w/ NOT=T')
     ASSERT(.NOT.ALL(test3a,test3a2,.FALSE.),'ALL 3-D & 3-D, w/ NOT=F')
-
-    !Test replacing characters in a string
-    testString="this_and_that"
-    CALL testString%replace(1,4,"that")
-    ASSERT_EQ(CHAR(testString),"that_and_that","replace this")
    
   ENDSUBROUTINE testIntrinsic
 !
@@ -466,6 +466,17 @@ CONTAINS
     TYPE(StringType) :: str
     TYPE(StringType), ALLOCATABLE :: str_list(:),ref_list(:)
     INTEGER(SIK) :: iWord
+    COMPONENT_TEST('String Split')
+    str = "the"
+    str_list = str%split()
+    ASSERT_EQ(SIZE(str_list),1,"splits count")
+    ASSERT_EQ(CHAR(str_list(1)),'the',"splits")
+
+    str = "the"
+    str_list = str%split('the')
+    ASSERT_EQ(SIZE(str_list),1,"splits count")
+    ASSERT_EQ(CHAR(str_list(1)),'',"splits")
+
     ALLOCATE(ref_list(9))
     ref_list(1) = "The"
     ref_list(2) = "quick"
@@ -478,17 +489,154 @@ CONTAINS
     ref_list(9) = "dog."
 
     str = "The quick brown fox jumped over a lazy dog."
+    str_list = str%split(' ')
+    ASSERT_EQ(SIZE(str_list),9,"splits count")
+    DO iWord=1,SIZE(str_list)
+      ASSERT_EQ(CHAR(str_list(iWord)),CHAR(ref_list(iWord)),"splits")
+    ENDDO
+    DEALLOCATE(str_list)
     str_list = str%split()
     ASSERT_EQ(SIZE(str_list),9,"splits count")
     DO iWord=1,SIZE(str_list)
       ASSERT_EQ(CHAR(str_list(iWord)),CHAR(ref_list(iWord)),"splits")
     ENDDO
-    str = "    The   quick   brown   fox   jumped    over a lazy   dog.   "
+    DEALLOCATE(str_list)
+
+    str = "   The   quick   brown   fox   jumped   over   a   lazy   dog.   "
     str_list = str%split()
+    ASSERT_EQ(SIZE(str_list),9,"splits count")
     DO iWord=1,SIZE(str_list)
       ASSERT_EQ(CHAR(str_list(iWord)),CHAR(ref_list(iWord)),"splits2")
     ENDDO
+    DEALLOCATE(ref_list)
+    ALLOCATE(ref_list(12))
+    ref_list(1) = ""
+    ref_list(2) = "The"
+    ref_list(3) = "quick"
+    ref_list(4) = "brown"
+    ref_list(5) = "fox"
+    ref_list(6) = "jumped"
+    ref_list(7) = "over"
+    ref_list(8) = "a"
+    ref_list(9) = "lazy"
+    ref_list(10) = ""
+    ref_list(11) = ""
+    ref_list(12) = "dog."
+    str = " The quick brown fox jumped over a lazy   dog. "
+    str_list = str%split(' ')
+    ASSERT_EQ(SIZE(str_list),12,"splits count")
+    DO iWord=1,SIZE(str_list)
+      ASSERT_EQ(CHAR(str_list(iWord)),CHAR(ref_list(iWord)),"splits2")
+    ENDDO
+    DEALLOCATE(str_list)
+
+    COMPONENT_TEST('%isInteger')
+    str = ''
+    ASSERT(.NOT.str%isInteger(),'empty')
+    str = '13579'
+    ASSERT(str%isInteger(),'13579')
+    str = '03579'
+    ASSERT(str%isInteger(),'with 0')
+    str = '+13579'
+    ASSERT(str%isInteger(),'with +')
+    str = '-13579'
+    ASSERT(str%isInteger(),'with -')
+    str = 'e13579'
+    ASSERT(.NOT.str%isInteger(),'with e')
+    str = '$13579'
+    ASSERT(.NOT.str%isInteger(),'with $')
+
+    COMPONENT_TEST('%isFloat')
+    str = ''
+    ASSERT(.NOT.str%isFloat(),'empty')
+    str = '0.2468'
+    ASSERT(str%isFloat(),'0.2468')
+    str = '+0.2468'
+    ASSERT(str%isFloat(),'with +')
+    str = '-0.2468'
+    ASSERT(str%isFloat(),'with -')
+    str = '-0.2468E000'
+    ASSERT(str%isFloat(),'with e000')
+    str = '-0.2468d000'
+    ASSERT(str%isFloat(),'with e000')
+    str = '-0.2468e000'
+    ASSERT(str%isFloat(),'with e000')
+    str = '-0.2468e+000'
+    ASSERT(str%isFloat(),'with e+000')
+    str = '-0.2468e-000'
+    ASSERT(str%isFloat(),'with e-000')
+    str = '-.2468e-000'
+    ASSERT(.NOT.str%isFloat(),'no leading digit')
+    str = '-0.2468-000'
+    ASSERT(.NOT.str%isFloat(),'mixing exponent symbol')
+    str = '-0.2a68000'
+    ASSERT(.NOT.str%isFloat(),'with a')
+    str = '-0.2a68e-000'
+    ASSERT(.NOT.str%isFloat(),'with a and exponent')
+    str = '-0.2468e-'
+    ASSERT(.NOT.str%isFloat(),'missing exponent')
+    str = '-0.2468e'
+    ASSERT(.NOT.str%isFloat(),'missing exponent')
     
+    COMPONENT_TEST('%isNumeric')
+    str = ''
+    ASSERT(.NOT.str%isNumeric(),'empty')
+    str = '13579'
+    ASSERT(str%isNumeric(),'13579')
+    str = '03579'
+    ASSERT(str%isNumeric(),'with 0')
+    str = '+13579'
+    ASSERT(str%isNumeric(),'with +')
+    str = '-13579'
+    ASSERT(str%isNumeric(),'with -')
+    str = 'e13579'
+    ASSERT(.NOT.str%isNumeric(),'with e')
+    str = '$13579'
+    ASSERT(.NOT.str%isNumeric(),'with $')
+    str = '0.2468'
+    ASSERT(str%isNumeric(),'0.2468')
+    str = '+0.2468'
+    ASSERT(str%isNumeric(),'with +')
+    str = '-0.2468'
+    ASSERT(str%isNumeric(),'with -')
+    str = '-0.2468E000'
+    ASSERT(str%isNumeric(),'with e000')
+    str = '-0.2468d000'
+    ASSERT(str%isNumeric(),'with e000')
+    str = '-0.2468e000'
+    ASSERT(str%isNumeric(),'with e000')
+    str = '-0.2468e+000'
+    ASSERT(str%isNumeric(),'with e+000')
+    str = '-0.2468e-000'
+    ASSERT(str%isNumeric(),'with e-000')
+    str = '-.2468e-000'
+    ASSERT(.NOT.str%isNumeric(),'no leading digit')
+    str = '-0.2468-000'
+    ASSERT(.NOT.str%isNumeric(),'mixing exponent symbol')
+    str = '-0.2a68000'
+    ASSERT(.NOT.str%isNumeric(),'with a')
+    str = '-0.2a68e-000'
+    ASSERT(.NOT.str%isNumeric(),'with a and exponent')
+    str = '-0.2468e-'
+    ASSERT(.NOT.str%isNumeric(),'missing exponent')
+    str = '-0.2468e'
+    ASSERT(.NOT.str%isNumeric(),'missing exponent')
+
+    COMPONENT_TEST('%replace')
+    !Test replacing characters in a string
+    str="AABBAA"
+    str = str%replace("A","B")
+    ASSERT_EQ(CHAR(str),"BBBBBB","replace")
+    str="AACAACAA"
+    str = str%replace("A","Bb")
+    ASSERT_EQ(CHAR(str),"BbBbCBbBbCBbBb","replace")
+    str="AACAACAACC"
+    str = str%replace("AA","c")
+    ASSERT_EQ(CHAR(str),"cCcCcCC","replace")
+    str="AACCAA"
+    str = str%replace("AAA","c")
+    ASSERT_EQ(CHAR(str),"AACCAA","replace")
+   
   ENDSUBROUTINE testStrFunct
 !
 ENDPROGRAM testStrings

--- a/unit_tests/testStrings/testStrings.f90
+++ b/unit_tests/testStrings/testStrings.f90
@@ -38,7 +38,7 @@ SUBROUTINE testUnInit()
   ASSERT_EQ(CHAR(testString),'','CHAR(testString) (uninit)')
   ASSERT_EQ(TRIM(testString),'','TRIM(testString) (uninit)')
 
-  COMPONENT_TEST('Test Clear')
+  COMPONENT_TEST('Test Clear Un-init')
   CALL testString%clear()
   ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
   ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
@@ -59,6 +59,7 @@ SUBROUTINE testAssign_chars()
   ASSERT_EQ(LEN(testString),0,'LEN(testString) (zero-length)')
   ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (zero-length)')
   ASSERT_EQ(TRIM(testString),'','TRIM(testString) (zero-length)')
+  COMPONENT_TEST('Test Clear Assigned string')
   CALL testString%clear()
   ASSERT_EQ(LEN(testString),0,'LEN(testString) (uninit)')
   ASSERT_EQ(LEN_TRIM(testString),0,'LEN_TRIM(testString) (uninit)')
@@ -472,6 +473,16 @@ ENDSUBROUTINE testAssign_chars
     TYPE(StringType), ALLOCATABLE :: str_list(:),ref_list(:)
     INTEGER(SIK) :: iWord
     COMPONENT_TEST('String Split')
+    str = ''
+    str_list = str%split()
+    ASSERT_EQ(SIZE(str_list),1,"splits count")
+    ASSERT_EQ(CHAR(str_list(1)),'',"splits")
+    !Deallocating here just to ensure the proper function of split
+    DEALLOCATE(str_list)
+    str = ''
+    str_list = str%split(' ')
+    ASSERT_EQ(SIZE(str_list),1,"splits count")
+    ASSERT_EQ(CHAR(str_list(1)),'',"splits")
     str = "the"
     str_list = str%split()
     ASSERT_EQ(SIZE(str_list),1,"splits count")


### PR DESCRIPTION
Implements `%replace()` method as a generic. One implementation takes a starting index and optionally a stopping index replacing everything in between with repetitions of a supplied character pattern. The other replaces all occurrences of a specified pattern with a replacement pattern.

To do this it became advantageous to implement `%split()` generically as well. The first implementation, without arguments uses a single space as the delimiter and consumes consecutive delimiters returning an array of strings containing no empty strings. The other implementation utilizes a user supplied delimiter. This does not consume consecutive delimiters and instead returns a string array which may contain empty strings where consecutive delimiters occurred. If the delimiter is not found then both implementations will return a size 1 array containing the original string.

This aimed to be a functional mirror of the python method by the same name.