### PR TITLE
Enabling MPI when PETSc is not used.

### DIFF
--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -77,6 +77,10 @@ IMPLICIT NONE
 #include <finclude/petsc.h>
 #endif
 #undef IS
+#else
+#ifdef HAVE_MPI
+#include <mpif.h>
+#endif
 #endif
 
 PRIVATE


### PR DESCRIPTION
An error occurred when MPI is used and PETSc is turned off. Only VectorTypes.f90 had the issue.