### PR TITLE
Removing implicit instantiation because it caused issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
  - grep -v '^\(mpif\.h\)' make.out | grep -i -B 4 'unused \(parameter\|\(PRIVATE module \)*variable\)' | grep -A 4 '\.f90' |& tee warnings.out
  - (exit `grep -c '\.f90' warnings.out`)
  - git clone https://github.com/CASL/Trilinos.git
- - docker run -v $PWD:/mnt/Futility mbairdphys/vera_tpls /bin/bash -c "mkdir /build && cd /build && /bin/bash /mnt/Futility/build_scripts/build_on_docker.sh -DFutility_ENABLE_DBC:BOOL=ON -DCMAKE_C_FLAGS='-w' -DCMAKE_CXX_FLAGS='-w' /mnt/Futility -DFutility_ENABLE_Stratimikos=OFF && make -j2 && ctest -j2"
+ - docker run -v $PWD:/mnt/Futility mbairdphys/vera_tpls /bin/bash -c "mkdir /build && cd /build && /bin/bash /mnt/Futility/build_scripts/build_on_docker.sh -DFutility_ENABLE_DBC:BOOL=ON -DCMAKE_C_FLAGS='-w' -DCMAKE_CXX_FLAGS='-w' -DTpetra_INST_INT_INT=OFF /mnt/Futility -DFutility_ENABLE_Stratimikos=OFF && make -j2 && ctest -j2"
 
 branches:
   only:

--- a/cmake/Settings_Common.cmake
+++ b/cmake/Settings_Common.cmake
@@ -47,10 +47,6 @@ IF(DEFINED ${PROJECT_NAME}_ENABLE_Teuchos)
   ENDIF()
 ENDIF()
 
-# Reduce template instantiations
-SET(Tpetra_INST_INT_INT OFF CACHE BOOL
-  "Don't need int global ordinal in Tpetra." )
-
 ## used to be after call to project
 
 # Pull in the TriBITS system and execute


### PR DESCRIPTION
Using the implicit instantiation worked fine for the Futility tests but caused issues when a fuller version of MPACT was compiled.  Moved the implicit instantiation to a command line option to save wall time.