### PR TITLE
Removes 2 empty #pragma statements that were noticed during development

### DIFF
--- a/src/floatingpointchecks.c
+++ b/src/floatingpointchecks.c
@@ -6,21 +6,20 @@
 / of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
 / can be found in LICENSE.txt in the head directory of this repository.        !
 /+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
-#pragma
 #include <math.h>
 #ifdef WIN32
 #define isnan(x) _isnan(x)
 #define isinf(x) (!_finite(x))
 #endif
-  int isNAN_float_c(float *x){
-    return isnan(*x);
-  }
-  int isNAN_double_c(double *x){
-    return isnan(*x);
-  }
-  int isINF_float_c(float *x){
-    return isinf(*x);
-  }
-  int isINF_double_c(double *x){
-    return isinf(*x);
-  }
+int isNAN_float_c(float *x){
+  return isnan(*x);
+}
+int isNAN_double_c(double *x){
+  return isnan(*x);
+}
+int isINF_float_c(float *x){
+  return isinf(*x);
+}
+int isINF_double_c(double *x){
+  return isinf(*x);
+}

--- a/src/getSysProcInfo.c
+++ b/src/getSysProcInfo.c
@@ -6,7 +6,6 @@
 / of Michigan and Oak Ridge National Laboratory.  The copyright and license    !
 / can be found in LICENSE.txt in the head directory of this repository.        !
 /+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++*/
-#pragma
 #if defined WIN32
 //This is for Windows systems
 #include <Windows.h>


### PR DESCRIPTION
As far as I can tell, these accomplish nothing, so I removed
them to remove compiler warnings about them.