### PR TITLE
Fix a preprocessor statement in ParallelEnv

### DIFF
--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -597,7 +597,7 @@ ENDSUBROUTINE partition_greedy_ParEnvType
 !-------------------------------------------------------------------------------
 !> @brief Initializes an MPI environment type object.
 SUBROUTINE init_MPI_Env_type(myPE,PEparam)
-#ifdef HAVE_MPI || FUTILITY_HAVE_PETSC
+#if defined(HAVE_MPI) || defined(FUTILITY_HAVE_PETSC)
   CHARACTER(LEN=*),PARAMETER :: myName='init_MPI_Env_type'
 #endif
   CLASS(MPI_EnvType),INTENT(INOUT) :: myPE


### PR DESCRIPTION
Fixes an incorrect preprocessor symbol in ParallelEnv.  The `||` operator cannot be used with `#ifdef`.  If multiple variables are defined, they need to be checked using `#if defined(var1) || defined(var2)`.

Also using this to test fixes for the travis-ci hooks.