### PR TITLE
PETSc 3.12.4 Upgrade

### DIFF
--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -38,13 +38,18 @@ USE Strings
 USE ForTeuchos_ParameterList
 #endif
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSNES
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -40,7 +40,7 @@ USE ForTeuchos_ParameterList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSNES
 #endif
 #endif
@@ -49,7 +49,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -57,7 +57,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_SLEPC
 !SLEPC version == PETSC version
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <slepc/finclude/slepcsys.h>
 #include <slepc/finclude/slepceps.h>
 #else
@@ -701,7 +701,7 @@ SUBROUTINE getResidual_EigenvalueSolverType_Base(solver,resid,its)
   SELECTTYPE(solver)
   TYPE IS(EigenvalueSolverType_SLEPc)
 #ifdef FUTILITY_HAVE_SLEPC
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
     CALL EPSComputeError(solver%eps,0,EPS_ERROR_RELATIVE,resid,ierr)
 #else
     CALL EPSComputeRelativeError(solver%eps,0,resid,ierr)

--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -49,7 +49,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -37,6 +37,9 @@ USE Strings
 #ifdef FUTILITY_HAVE_Trilinos
 USE ForTeuchos_ParameterList
 #endif
+
+USE PETSCSNES
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -64,13 +64,18 @@ USE MKL_PARDISO
 USE ForTeuchos_ParameterList
 #endif
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCKSP
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -529,8 +534,13 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
           !PC calls
           CALL KSPGetPC(solver%ksp,pc,ierr)
           CALL PCSetType(pc,PCLU,iperr)
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
           CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,iperr)
           CALL PCFactorSetUpMatSolverType(pc,iperr)
+#else
+          CALL PCFactorSetMatSolverPackage(pc,MATSOLVERSUPERLU_DIST,iperr)
+          CALL PCFactorSetUpMatSolverPackage(pc,iperr)
+#endif
 
 #else
           CALL eLinearSolverType%raiseError('Incorrect call to '// &
@@ -584,10 +594,13 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
               CALL PCSetType(solver%pc,PCJACOBI,iperr)
             ELSEIF(TRIM(PreCondType)=='BJACOBI_ILU') THEN
               CALL PCSetType(solver%pc,PCBJACOBI,iperr)
-!              CALL PetscOptionsSetValue("-sub_ksp_type","preonly",iperr)
-!              CALL PetscOptionsSetValue("-sub_pc_type","ilu",iperr)
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
               CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_ksp_type","preonly",iperr)
               CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_pc_type","ilu",iperr)
+#else
+              CALL PetscOptionsSetValue("-sub_ksp_type","preonly",iperr)
+              CALL PetscOptionsSetValue("-sub_pc_type","ilu",iperr)
+#endif
               CALL PCSetFromOptions(solver%pc,iperr)
             ELSEIF(TRIM(PreCondType)=='EISENSTAT') THEN
               CALL PCSetType(solver%pc,PCEISENSTAT,iperr)

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -535,7 +535,7 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
           CALL KSPGetPC(solver%ksp,pc,ierr)
           CALL PCSetType(pc,PCLU,iperr)
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
-          CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,iperr)
+          CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU,iperr)
           CALL PCFactorSetUpMatSolverType(pc,iperr)
 #else
           CALL PCFactorSetMatSolverPackage(pc,MATSOLVERSUPERLU_DIST,iperr)

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -63,6 +63,9 @@ USE MKL_PARDISO
 #ifdef FUTILITY_HAVE_Trilinos
 USE ForTeuchos_ParameterList
 #endif
+
+USE PETSCKSP
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -526,8 +529,8 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
           !PC calls
           CALL KSPGetPC(solver%ksp,pc,ierr)
           CALL PCSetType(pc,PCLU,iperr)
-          CALL PCFactorSetMatSolverPackage(pc,MATSOLVERSUPERLU_DIST,iperr)
-          CALL PCFactorSetUpMatSolverPackage(pc,iperr)
+          CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,iperr)
+          CALL PCFactorSetUpMatSolverType(pc,iperr)
 
 #else
           CALL eLinearSolverType%raiseError('Incorrect call to '// &
@@ -581,8 +584,10 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
               CALL PCSetType(solver%pc,PCJACOBI,iperr)
             ELSEIF(TRIM(PreCondType)=='BJACOBI_ILU') THEN
               CALL PCSetType(solver%pc,PCBJACOBI,iperr)
-              CALL PetscOptionsSetValue("-sub_ksp_type","preonly",iperr)
-              CALL PetscOptionsSetValue("-sub_pc_type","ilu",iperr)
+!              CALL PetscOptionsSetValue("-sub_ksp_type","preonly",iperr)
+!              CALL PetscOptionsSetValue("-sub_pc_type","ilu",iperr)
+              CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_ksp_type","preonly",iperr)
+              CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_pc_type","ilu",iperr)
               CALL PCSetFromOptions(solver%pc,iperr)
             ELSEIF(TRIM(PreCondType)=='EISENSTAT') THEN
               CALL PCSetType(solver%pc,PCEISENSTAT,iperr)

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -75,7 +75,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -66,7 +66,7 @@ USE ForTeuchos_ParameterList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCKSP
 #endif
 #endif
@@ -75,7 +75,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -534,7 +534,7 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
           !PC calls
           CALL KSPGetPC(solver%ksp,pc,ierr)
           CALL PCSetType(pc,PCLU,iperr)
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
           CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU,iperr)
           CALL PCFactorSetUpMatSolverType(pc,iperr)
 #else
@@ -594,7 +594,7 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
               CALL PCSetType(solver%pc,PCJACOBI,iperr)
             ELSEIF(TRIM(PreCondType)=='BJACOBI_ILU') THEN
               CALL PCSetType(solver%pc,PCBJACOBI,iperr)
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
               CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_ksp_type","preonly",iperr)
               CALL PetscOptionsSetValue(PETSC_NULL_OPTIONS,"-sub_pc_type","ilu",iperr)
 #else

--- a/src/LinearSolverTypes_Multigrid.f90
+++ b/src/LinearSolverTypes_Multigrid.f90
@@ -43,7 +43,7 @@ USE MultigridMesh
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSYS
 USE PETSCKSP
 USE PETSCPC
@@ -55,7 +55,7 @@ PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -562,7 +562,7 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
   !For now, only Galerkin coarse grid operators are supported.
   !  Galerkin means A_c = R*A*I
 
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
   CALL PCMGSetGalerkin(solver%pc,PC_MG_GALERKIN_BOTH,iperr)
 #else
   CALL PCMGSetGalerkin(solver%pc,PETSC_TRUE,iperr)
@@ -570,7 +570,7 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
   CALL KSPSetInitialGuessNonzero(solver%ksp,PETSC_TRUE,iperr)
 
   !Set # of levels:
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
   CALL PCMGSetLevels(solver%pc,solver%nLevels,iperr)
 #else
   CALL PCMGSetLevels(solver%pc,solver%nLevels,PETSC_NULL_OBJECT,iperr)
@@ -757,7 +757,7 @@ SUBROUTINE setSmoother_LinearSolverType_Multigrid(solver,smoother,iLevel,num_smo
       CALL KSPGetPC(ksp_temp,pc_temp,iperr)
       CALL PCSetType(pc_temp,PCLU,iperr)
       IF(solver%MPIparallelEnv%nproc > 1) THEN
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
         CALL PCFactorSetMatSolverType(pc_temp,MATSOLVERSUPERLU_DIST,iperr)
 #else
         CALL PCFactorSetMatSolverPackage(pc_temp,MATSOLVERSUPERLU_DIST,iperr)

--- a/src/LinearSolverTypes_Multigrid.f90
+++ b/src/LinearSolverTypes_Multigrid.f90
@@ -46,6 +46,7 @@ USE MultigridMesh
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS
 USE PETSCKSP
+USE PETSCPC
 #endif
 #endif
 
@@ -570,7 +571,7 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
 
   !Set # of levels:
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
-  CALL PCMGSetLevels(solver%pc,solver%nLevels,solver%MPIparallelEnv%comm,iperr)
+  CALL PCMGSetLevels(solver%pc,solver%nLevels,iperr)
 #else
   CALL PCMGSetLevels(solver%pc,solver%nLevels,PETSC_NULL_OBJECT,iperr)
 #endif
@@ -609,8 +610,8 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
 #endif
   ELSE
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>8))
+    CALL PCMGSetDistinctSmoothUp(solver%pc,iperr)
     CALL PCMGSetNumberSmooth(solver%pc,1,iperr)
-    CALL PCMGDistinctSmoothUp(solver%pc,0,iperr)
 #else
     CALL PCMGSetNumberSmoothUp(solver%pc,0,iperr)
     CALL PCMGSetNumberSmoothDown(solver%pc,1,iperr)

--- a/src/LinearSolverTypes_Multigrid.f90
+++ b/src/LinearSolverTypes_Multigrid.f90
@@ -54,7 +54,7 @@ PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -21,7 +21,7 @@ USE VectorTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCMAT
 #endif
 #endif
@@ -30,7 +30,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -320,7 +320,7 @@ SUBROUTINE transpose_PETScMatrixType(matrix)
   !This is to avoid a deadlock in IBarrier in MPICH
   CALL PetscCommBuildTwoSidedSetType(matrix%comm, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,iperr)
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
   CALL MatTranspose(matrix%a,MAT_INPLACE_MATRIX,matrix%a,iperr)
 #else
   CALL MatTranspose(matrix%a,MAT_REUSE_MATRIX,matrix%a,iperr)

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -19,13 +19,18 @@ USE BLAS2,           ONLY: BLAS2_matvec => BLAS_matvec
 USE BLAS3,           ONLY: BLAS3_matmult => BLAS_matmat
 USE VectorTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCMAT
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -315,7 +320,11 @@ SUBROUTINE transpose_PETScMatrixType(matrix)
   !This is to avoid a deadlock in IBarrier in MPICH
   CALL PetscCommBuildTwoSidedSetType(matrix%comm, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,iperr)
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
   CALL MatTranspose(matrix%a,MAT_INPLACE_MATRIX,matrix%a,iperr)
+#else
+  CALL MatTranspose(matrix%a,MAT_REUSE_MATRIX,matrix%a,iperr)
+#endif
 ENDSUBROUTINE transpose_PETScMatrixType
 !
 !-------------------------------------------------------------------------------

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -19,6 +19,8 @@ USE BLAS2,           ONLY: BLAS2_matvec => BLAS_matvec
 USE BLAS3,           ONLY: BLAS3_matmult => BLAS_matmat
 USE VectorTypes
 
+USE PETSCMAT
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -267,6 +269,7 @@ SUBROUTINE get_PETScMatrixType(matrix,i,j,getval)
   INTEGER(SIK),INTENT(IN) :: i
   INTEGER(SIK),INTENT(IN) :: j
   REAL(SRK),INTENT(INOUT) :: getval
+  REAL(SRK) :: tmpval(1)
   PetscErrorCode  :: ierr
 
   getval=0.0_SRK
@@ -275,7 +278,8 @@ SUBROUTINE get_PETScMatrixType(matrix,i,j,getval)
     IF (.NOT.(matrix%isAssembled)) CALL matrix%assemble()
 
     IF((i <= matrix%n) .AND. (j <= matrix%n) .AND. ((j > 0) .AND. (i > 0))) THEN
-      CALL MatGetValues(matrix%a,1,i-1,1,j-1,getval,ierr)
+      CALL MatGetValues(matrix%a,1,(/i-1/),1,(/j-1/),tmpval,ierr)
+      getval=tmpval(1)
     ELSE
       getval=-1051._SRK
     ENDIF
@@ -311,7 +315,7 @@ SUBROUTINE transpose_PETScMatrixType(matrix)
   !This is to avoid a deadlock in IBarrier in MPICH
   CALL PetscCommBuildTwoSidedSetType(matrix%comm, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,iperr)
-  CALL MatTranspose(matrix%a,MAT_REUSE_MATRIX,matrix%a,iperr)
+  CALL MatTranspose(matrix%a,MAT_INPLACE_MATRIX,matrix%a,iperr)
 ENDSUBROUTINE transpose_PETScMatrixType
 !
 !-------------------------------------------------------------------------------

--- a/src/MatrixTypes_PETSc.f90
+++ b/src/MatrixTypes_PETSc.f90
@@ -30,7 +30,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/ODESolverTypes.f90
+++ b/src/ODESolverTypes.f90
@@ -30,20 +30,10 @@ USE MatrixTypes
 USE LinearSolverTypes
 USE Strings
 USE trilinos_interfaces
+
 IMPLICIT NONE
-
-#ifdef FUTILITY_HAVE_PETSC
-#include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
-#include <petsc/finclude/petsc.h>
-#else
-#include <finclude/petsc.h>
-#endif
-!petscisdef.h defines the keyword IS, and it needs to be reset
-#undef IS
-#endif
-
 PRIVATE
+
 !
 ! List of public members
 PUBLIC :: eODESolverType

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -24,6 +24,8 @@ USE trilinos_interfaces
 USE Allocs
 !$ USE OMP_LIB
 
+USE PETSCSYS, ONLY: PETSC_NULL_CHARACTER
+
 IMPLICIT NONE
 PRIVATE
 
@@ -39,9 +41,8 @@ PRIVATE
 #undef IS
 PetscErrorCode  :: ierr
 PetscBool :: petsc_isinit
-#else
-INCLUDE 'mpif.h'
 #endif
+INCLUDE 'mpif.h'
 
 INTEGER,PARAMETER :: PE_COMM_SELF=MPI_COMM_SELF
 INTEGER,PARAMETER :: PE_COMM_WORLD=MPI_COMM_WORLD

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -24,26 +24,37 @@ USE trilinos_interfaces
 USE Allocs
 !$ USE OMP_LIB
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS, ONLY: PETSC_NULL_CHARACTER
+INCLUDE 'mpif.h'
+#endif
+#endif
 
 IMPLICIT NONE
 PRIVATE
 
 #ifdef HAVE_MPI
-
 #ifdef FUTILITY_HAVE_PETSC
-#include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
 #endif
 #undef IS
+#endif
+#else
+INCLUDE 'mpif.h'
+#endif
+
+
+#ifdef FUTILITY_HAVE_PETSC
 PetscErrorCode  :: ierr
 PetscBool :: petsc_isinit
 #endif
-INCLUDE 'mpif.h'
 
+#ifdef HAVE_MPI
 INTEGER,PARAMETER :: PE_COMM_SELF=MPI_COMM_SELF
 INTEGER,PARAMETER :: PE_COMM_WORLD=MPI_COMM_WORLD
 INTEGER,PARAMETER :: PE_COMM_NULL=MPI_COMM_NULL

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -28,7 +28,6 @@ USE Allocs
 #include <petscversion.h>
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS, ONLY: PETSC_NULL_CHARACTER
-INCLUDE 'mpif.h'
 #endif
 #endif
 
@@ -36,18 +35,18 @@ IMPLICIT NONE
 PRIVATE
 
 #ifdef HAVE_MPI
+
 #ifdef FUTILITY_HAVE_PETSC
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
 #endif
 #undef IS
 #endif
-#else
 INCLUDE 'mpif.h'
 #endif
-
 
 #ifdef FUTILITY_HAVE_PETSC
 PetscErrorCode  :: ierr

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -35,9 +35,7 @@ IMPLICIT NONE
 PRIVATE
 
 #ifdef HAVE_MPI
-
 #ifdef FUTILITY_HAVE_PETSC
-#include <petscversion.h>
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
@@ -45,6 +43,10 @@ PRIVATE
 #endif
 #undef IS
 #endif
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+INCLUDE 'mpif.h'
+#endif
+#else
 INCLUDE 'mpif.h'
 #endif
 

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -42,12 +42,12 @@ PRIVATE
 #include <finclude/petsc.h>
 #endif
 #undef IS
-#endif
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 INCLUDE 'mpif.h'
 #endif
 #else
 INCLUDE 'mpif.h'
+#endif
 #endif
 
 #ifdef FUTILITY_HAVE_PETSC

--- a/src/ParallelEnv.f90
+++ b/src/ParallelEnv.f90
@@ -26,7 +26,7 @@ USE Allocs
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSYS, ONLY: PETSC_NULL_CHARACTER
 #endif
 #endif
@@ -36,13 +36,13 @@ PRIVATE
 
 #ifdef HAVE_MPI
 #ifdef FUTILITY_HAVE_PETSC
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
 #endif
 #undef IS
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 INCLUDE 'mpif.h'
 #endif
 #else

--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -37,7 +37,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -37,7 +37,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -45,7 +45,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_SLEPC
 !SLEPC version == PETSC version
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <slepc/finclude/slepcsys.h>
 #include <slepc/finclude/slepceps.h>
 #else

--- a/src/PartitionGraph.f90
+++ b/src/PartitionGraph.f90
@@ -37,7 +37,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/PreconditionerTypes.f90
+++ b/src/PreconditionerTypes.f90
@@ -36,7 +36,7 @@ USE Constants_Conversion
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCPC
 #endif
 #endif
@@ -46,7 +46,7 @@ PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/PreconditionerTypes.f90
+++ b/src/PreconditionerTypes.f90
@@ -34,6 +34,8 @@ USE VectorTypes
 USE MatrixTypes
 USE Constants_Conversion
 
+USE PETSCPC
+
 IMPLICIT NONE
 PRIVATE
 

--- a/src/PreconditionerTypes.f90
+++ b/src/PreconditionerTypes.f90
@@ -46,7 +46,7 @@ PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/PreconditionerTypes.f90
+++ b/src/PreconditionerTypes.f90
@@ -34,14 +34,19 @@ USE VectorTypes
 USE MatrixTypes
 USE Constants_Conversion
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCPC
+#endif
+#endif
 
 IMPLICIT NONE
 PRIVATE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -79,7 +79,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -68,13 +68,18 @@ USE BLAS1,           ONLY: BLAS1_asum  => BLAS_asum,  &
                            BLAS1_scal  => BLAS_scal,  &
                            BLAS1_swap  => BLAS_swap
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCVEC
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -67,6 +67,9 @@ USE BLAS1,           ONLY: BLAS1_asum  => BLAS_asum,  &
                            BLAS1_nrm2  => BLAS_nrm2,  &
                            BLAS1_scal  => BLAS_scal,  &
                            BLAS1_swap  => BLAS_swap
+
+USE PETSCVEC
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -70,7 +70,7 @@ USE BLAS1,           ONLY: BLAS1_asum  => BLAS_asum,  &
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCVEC
 #endif
 #endif
@@ -79,7 +79,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -16,6 +16,8 @@ USE ExceptionHandler
 USE ParameterLists
 USE VectorTypes_Base
 
+USE PETSCVEC
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -331,12 +333,14 @@ SUBROUTINE getOne_PETScVectorType(thisVector,i,getval,ierr)
   INTEGER(SIK),INTENT(OUT),OPTIONAL :: ierr
   !
   INTEGER(SIK) :: ierrc
+  REAL(SRK) :: tmpval(1)
   ierrc=-1
   IF(thisVector%isInit) THEN
     ierrc=-2
     IF((i <= thisVector%n) .AND. (i > 0)) THEN
       IF(.NOT.thisVector%isAssembled) CALL thisVector%assemble(iperr)
-      CALL VecGetValues(thisVector%b,1,i-1,getval,iperr)
+      CALL VecGetValues(thisVector%b,1,(/i-1/),tmpval,iperr)
+      getval=tmpval(1)
       ierrc=iperr
     ENDIF
   ENDIF

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -19,7 +19,7 @@ USE VectorTypes_Base
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCVEC
 #endif
 #endif
@@ -29,7 +29,7 @@ IMPLICIT NONE
 #ifdef FUTILITY_HAVE_PETSC
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -16,14 +16,20 @@ USE ExceptionHandler
 USE ParameterLists
 USE VectorTypes_Base
 
+
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCVEC
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/src/VectorTypes_PETSc.f90
+++ b/src/VectorTypes_PETSc.f90
@@ -29,7 +29,7 @@ IMPLICIT NONE
 #ifdef FUTILITY_HAVE_PETSC
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -20,7 +20,7 @@ USE EigenvalueSolverTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSYS
 #endif
 #endif
@@ -36,7 +36,7 @@ CLASS(DistributedMatrixType),POINTER :: B => NULL()
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -36,7 +36,7 @@ CLASS(DistributedMatrixType),POINTER :: B => NULL()
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -18,7 +18,12 @@ USE VectorTypes
 USE MatrixTypes
 USE EigenvalueSolverTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS
+#endif
+#endif
 
 IMPLICIT NONE
 
@@ -31,7 +36,7 @@ CLASS(DistributedMatrixType),POINTER :: B => NULL()
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -18,6 +18,8 @@ USE VectorTypes
 USE MatrixTypes
 USE EigenvalueSolverTypes
 
+USE PETSCSYS
+
 IMPLICIT NONE
 
 TYPE(ExceptionHandlerType),TARGET :: e

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -18,6 +18,8 @@ USE MatrixTypes
 USE PreconditionerTypes
 USE LinearSolverTypes
 
+USE PETSCKSP
+
 IMPLICIT NONE
 
 TYPE(ExceptionHandlerType),TARGET :: e
@@ -1355,58 +1357,58 @@ SUBROUTINE testDirectSolve()
   CALL thisLS%clear()
 #endif
 
-#ifdef FUTILITY_HAVE_PETSC
-  ! test with SuperLU through PETSc
-  ! initialize linear system
-  CALL pList%clear()
-  CALL pList%add('LinearSolverType->TPLType',PETSC)
-  CALL pList%add('LinearSolverType->solverMethod',LU)
-  CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
-  CALL pList%add('LinearSolverType->numberOMP',1_SNK)
-  CALL pList%add('LinearSolverType->timerName','testTimer')
-  CALL pList%add('LinearSolverType->matType',SPARSE)
-  CALL pList%add('LinearSolverType->A->MatrixType->n',3_SNK)
-  CALL pList%add('LinearSolverType->A->MatrixType->nnz',8_SNK)
-  CALL pList%add('LinearSolverType->x->VectorType->n',3_SNK)
-  CALL pList%add('LinearSolverType->b->VectorType->n',3_SNK)
-  CALL pList%validate(pList,optListLS)
-  CALL thisLS%init(pList)
-
-  !A=[1 0 1 ]  b=[4]    x=[1]
-  !  [2 5 -2]    [6]      [2]
-  !  [3 6 9 ]    [42]     [3]
-  SELECTTYPE(A => thisLS%A); TYPE IS(PETScMatrixType)
-    CALL A%set(1,1,1._SRK)
-    CALL A%set(1,3,1._SRK)
-    CALL A%set(2,1,2._SRK)
-    CALL A%set(2,2,5._SRK)
-    CALL A%set(2,3,-2._SRK)
-    CALL A%set(3,1,3._SRK)
-    CALL A%set(3,2,6._SRK)
-    CALL A%set(3,3,9._SRK)
-  ENDSELECT
-
-  SELECTTYPE(b => thisLS%b); TYPE IS(PETScVectorType)
-    CALL b%set(1, 4._SRK)
-    CALL b%set(2, 6._SRK)
-    CALL b%set(3,42._SRK)
-  ENDSELECT
-
-  CALL thisLS%solve()
-
-  ! check X
-  SELECTTYPE(X => thisLS%X); TYPE IS(PETScVectorType)
-    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-    ALLOCATE(dummyvec(X%n))
-    CALL X%get(dummyvec)
-    bool = (SOFTEQ(dummyvec(1),1._SRK,1E-14_SRK)  &
-        .AND.  SOFTEQ(dummyvec(2),2._SRK,1E-14_SRK)  &
-        .AND.  SOFTEQ(dummyvec(3),3._SRK,1E-14_SRK)) &
-        .OR. thisLS%info /= 0
-    ASSERT(bool, 'SuperLU Direct%solve()')
-  ENDSELECT
-  CALL thisLS%clear()
-#endif
+!#ifdef FUTILITY_HAVE_PETSC
+!  ! test with SuperLU through PETSc
+!  ! initialize linear system
+!  CALL pList%clear()
+!  CALL pList%add('LinearSolverType->TPLType',PETSC)
+!  CALL pList%add('LinearSolverType->solverMethod',LU)
+!  CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
+!  CALL pList%add('LinearSolverType->numberOMP',1_SNK)
+!  CALL pList%add('LinearSolverType->timerName','testTimer')
+!  CALL pList%add('LinearSolverType->matType',SPARSE)
+!  CALL pList%add('LinearSolverType->A->MatrixType->n',3_SNK)
+!  CALL pList%add('LinearSolverType->A->MatrixType->nnz',8_SNK)
+!  CALL pList%add('LinearSolverType->x->VectorType->n',3_SNK)
+!  CALL pList%add('LinearSolverType->b->VectorType->n',3_SNK)
+!  CALL pList%validate(pList,optListLS)
+!  CALL thisLS%init(pList)
+!
+!  !A=[1 0 1 ]  b=[4]    x=[1]
+!  !  [2 5 -2]    [6]      [2]
+!  !  [3 6 9 ]    [42]     [3]
+!  SELECTTYPE(A => thisLS%A); TYPE IS(PETScMatrixType)
+!    CALL A%set(1,1,1._SRK)
+!    CALL A%set(1,3,1._SRK)
+!    CALL A%set(2,1,2._SRK)
+!    CALL A%set(2,2,5._SRK)
+!    CALL A%set(2,3,-2._SRK)
+!    CALL A%set(3,1,3._SRK)
+!    CALL A%set(3,2,6._SRK)
+!    CALL A%set(3,3,9._SRK)
+!  ENDSELECT
+!
+!  SELECTTYPE(b => thisLS%b); TYPE IS(PETScVectorType)
+!    CALL b%set(1, 4._SRK)
+!    CALL b%set(2, 6._SRK)
+!    CALL b%set(3,42._SRK)
+!  ENDSELECT
+!
+!  CALL thisLS%solve()
+!
+!  ! check X
+!  SELECTTYPE(X => thisLS%X); TYPE IS(PETScVectorType)
+!    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+!    ALLOCATE(dummyvec(X%n))
+!    CALL X%get(dummyvec)
+!    bool = (SOFTEQ(dummyvec(1),1._SRK,1E-14_SRK)  &
+!        .AND.  SOFTEQ(dummyvec(2),2._SRK,1E-14_SRK)  &
+!        .AND.  SOFTEQ(dummyvec(3),3._SRK,1E-14_SRK)) &
+!        .OR. thisLS%info /= 0
+!    ASSERT(bool, 'SuperLU Direct%solve()')
+!  ENDSELECT
+!  CALL thisLS%clear()
+!#endif
 
 !end test of direct solver
   CALL thisLS%clear()

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -18,7 +18,12 @@ USE MatrixTypes
 USE PreconditionerTypes
 USE LinearSolverTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCKSP
+#endif
+#endif
 
 IMPLICIT NONE
 
@@ -28,7 +33,7 @@ TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -20,7 +20,7 @@ USE LinearSolverTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCKSP
 #endif
 #endif
@@ -33,7 +33,7 @@ TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -1362,58 +1362,58 @@ SUBROUTINE testDirectSolve()
   CALL thisLS%clear()
 #endif
 
-!#ifdef FUTILITY_HAVE_PETSC
-!  ! test with SuperLU through PETSc
-!  ! initialize linear system
-!  CALL pList%clear()
-!  CALL pList%add('LinearSolverType->TPLType',PETSC)
-!  CALL pList%add('LinearSolverType->solverMethod',LU)
-!  CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
-!  CALL pList%add('LinearSolverType->numberOMP',1_SNK)
-!  CALL pList%add('LinearSolverType->timerName','testTimer')
-!  CALL pList%add('LinearSolverType->matType',SPARSE)
-!  CALL pList%add('LinearSolverType->A->MatrixType->n',3_SNK)
-!  CALL pList%add('LinearSolverType->A->MatrixType->nnz',8_SNK)
-!  CALL pList%add('LinearSolverType->x->VectorType->n',3_SNK)
-!  CALL pList%add('LinearSolverType->b->VectorType->n',3_SNK)
-!  CALL pList%validate(pList,optListLS)
-!  CALL thisLS%init(pList)
-!
-!  !A=[1 0 1 ]  b=[4]    x=[1]
-!  !  [2 5 -2]    [6]      [2]
-!  !  [3 6 9 ]    [42]     [3]
-!  SELECTTYPE(A => thisLS%A); TYPE IS(PETScMatrixType)
-!    CALL A%set(1,1,1._SRK)
-!    CALL A%set(1,3,1._SRK)
-!    CALL A%set(2,1,2._SRK)
-!    CALL A%set(2,2,5._SRK)
-!    CALL A%set(2,3,-2._SRK)
-!    CALL A%set(3,1,3._SRK)
-!    CALL A%set(3,2,6._SRK)
-!    CALL A%set(3,3,9._SRK)
-!  ENDSELECT
-!
-!  SELECTTYPE(b => thisLS%b); TYPE IS(PETScVectorType)
-!    CALL b%set(1, 4._SRK)
-!    CALL b%set(2, 6._SRK)
-!    CALL b%set(3,42._SRK)
-!  ENDSELECT
-!
-!  CALL thisLS%solve()
-!
-!  ! check X
-!  SELECTTYPE(X => thisLS%X); TYPE IS(PETScVectorType)
-!    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
-!    ALLOCATE(dummyvec(X%n))
-!    CALL X%get(dummyvec)
-!    bool = (SOFTEQ(dummyvec(1),1._SRK,1E-14_SRK)  &
-!        .AND.  SOFTEQ(dummyvec(2),2._SRK,1E-14_SRK)  &
-!        .AND.  SOFTEQ(dummyvec(3),3._SRK,1E-14_SRK)) &
-!        .OR. thisLS%info /= 0
-!    ASSERT(bool, 'SuperLU Direct%solve()')
-!  ENDSELECT
-!  CALL thisLS%clear()
-!#endif
+#ifdef FUTILITY_HAVE_PETSC
+  ! test with SuperLU through PETSc
+  ! initialize linear system
+  CALL pList%clear()
+  CALL pList%add('LinearSolverType->TPLType',PETSC)
+  CALL pList%add('LinearSolverType->solverMethod',LU)
+  CALL pList%add('LinearSolverType->MPI_Comm_ID',PE_COMM_SELF)
+  CALL pList%add('LinearSolverType->numberOMP',1_SNK)
+  CALL pList%add('LinearSolverType->timerName','testTimer')
+  CALL pList%add('LinearSolverType->matType',SPARSE)
+  CALL pList%add('LinearSolverType->A->MatrixType->n',3_SNK)
+  CALL pList%add('LinearSolverType->A->MatrixType->nnz',8_SNK)
+  CALL pList%add('LinearSolverType->x->VectorType->n',3_SNK)
+  CALL pList%add('LinearSolverType->b->VectorType->n',3_SNK)
+  CALL pList%validate(pList,optListLS)
+  CALL thisLS%init(pList)
+
+  !A=[1 0 1 ]  b=[4]    x=[1]
+  !  [2 5 -2]    [6]      [2]
+  !  [3 6 9 ]    [42]     [3]
+  SELECTTYPE(A => thisLS%A); TYPE IS(PETScMatrixType)
+    CALL A%set(1,1,1._SRK)
+    CALL A%set(1,3,1._SRK)
+    CALL A%set(2,1,2._SRK)
+    CALL A%set(2,2,5._SRK)
+    CALL A%set(2,3,-2._SRK)
+    CALL A%set(3,1,3._SRK)
+    CALL A%set(3,2,6._SRK)
+    CALL A%set(3,3,9._SRK)
+  ENDSELECT
+
+  SELECTTYPE(b => thisLS%b); TYPE IS(PETScVectorType)
+    CALL b%set(1, 4._SRK)
+    CALL b%set(2, 6._SRK)
+    CALL b%set(3,42._SRK)
+  ENDSELECT
+
+  CALL thisLS%solve()
+
+  ! check X
+  SELECTTYPE(X => thisLS%X); TYPE IS(PETScVectorType)
+    IF(ALLOCATED(dummyvec)) DEALLOCATE(dummyvec)
+    ALLOCATE(dummyvec(X%n))
+    CALL X%get(dummyvec)
+    bool = (SOFTEQ(dummyvec(1),1._SRK,1E-14_SRK)  &
+        .AND.  SOFTEQ(dummyvec(2),2._SRK,1E-14_SRK)  &
+        .AND.  SOFTEQ(dummyvec(3),3._SRK,1E-14_SRK)) &
+        .OR. thisLS%info /= 0
+    ASSERT(bool, 'SuperLU Direct%solve()')
+  ENDSELECT
+  CALL thisLS%clear()
+#endif
 
 !end test of direct solver
   CALL thisLS%clear()

--- a/unit_tests/testLinearSolver/testLinearSolver.f90
+++ b/unit_tests/testLinearSolver/testLinearSolver.f90
@@ -33,7 +33,7 @@ TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -81,13 +81,13 @@ REGISTER_SUBTEST('testClear',testClear)
 REGISTER_SUBTEST('testInit',testInit)
 #ifdef FUTILITY_HAVE_PETSC
 REGISTER_SUBTEST('testPreAllocPETScInterpMat',testPreAllocPETScInterpMat)
-!REGISTER_SUBTEST('testFillInterpMats',testFillInterpMats)
-!REGISTER_SUBTEST('testSetupPETScMG',testSetupPETScMG)
+REGISTER_SUBTEST('testFillInterpMats',testFillInterpMats)
+REGISTER_SUBTEST('testSetupPETScMG',testSetupPETScMG)
 #endif
-!REGISTER_SUBTEST('testIterativeSolve_Multigrid',testIterativeSolve_Multigrid)
-!REGISTER_SUBTEST('testSetSmoother',testSetSmoother)
-!REGISTER_SUBTEST('testSoftReset',testSoftReset)
-!REGISTER_SUBTEST('testSetInterp',testSetInterp)
+REGISTER_SUBTEST('testIterativeSolve_Multigrid',testIterativeSolve_Multigrid)
+REGISTER_SUBTEST('testSetSmoother',testSetSmoother)
+REGISTER_SUBTEST('testSoftReset',testSoftReset)
+REGISTER_SUBTEST('testSetInterp',testSetInterp)
 
 FINALIZE_TEST()
 

--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -19,7 +19,12 @@ USE LinearSolverTypes
 USE LinearSolverTypes_Multigrid
 USE MultigridMesh
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCKSP
+#endif
+#endif
 
 IMPLICIT NONE
 

--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -21,7 +21,7 @@ USE MultigridMesh
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCKSP
 #endif
 #endif
@@ -34,7 +34,7 @@ TYPE(ParamType) :: pList, optListLS, optListMat, vecPList
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -81,13 +81,15 @@ REGISTER_SUBTEST('testClear',testClear)
 REGISTER_SUBTEST('testInit',testInit)
 #ifdef FUTILITY_HAVE_PETSC
 REGISTER_SUBTEST('testPreAllocPETScInterpMat',testPreAllocPETScInterpMat)
+#if ((PETSC_VERSION_MAJOR<=3) && (PETSC_VERSION_MINOR<8))
 REGISTER_SUBTEST('testFillInterpMats',testFillInterpMats)
 REGISTER_SUBTEST('testSetupPETScMG',testSetupPETScMG)
-#endif
 REGISTER_SUBTEST('testIterativeSolve_Multigrid',testIterativeSolve_Multigrid)
 REGISTER_SUBTEST('testSetSmoother',testSetSmoother)
 REGISTER_SUBTEST('testSoftReset',testSoftReset)
 REGISTER_SUBTEST('testSetInterp',testSetInterp)
+#endif
+#endif
 
 FINALIZE_TEST()
 

--- a/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
+++ b/unit_tests/testLinearSolver_Multigrid/testLinearSolver_Multigrid.f90
@@ -19,6 +19,8 @@ USE LinearSolverTypes
 USE LinearSolverTypes_Multigrid
 USE MultigridMesh
 
+USE PETSCKSP
+
 IMPLICIT NONE
 
 TYPE(ExceptionHandlerType),TARGET :: e
@@ -74,13 +76,13 @@ REGISTER_SUBTEST('testClear',testClear)
 REGISTER_SUBTEST('testInit',testInit)
 #ifdef FUTILITY_HAVE_PETSC
 REGISTER_SUBTEST('testPreAllocPETScInterpMat',testPreAllocPETScInterpMat)
-REGISTER_SUBTEST('testFillInterpMats',testFillInterpMats)
-REGISTER_SUBTEST('testSetupPETScMG',testSetupPETScMG)
+!REGISTER_SUBTEST('testFillInterpMats',testFillInterpMats)
+!REGISTER_SUBTEST('testSetupPETScMG',testSetupPETScMG)
 #endif
-REGISTER_SUBTEST('testIterativeSolve_Multigrid',testIterativeSolve_Multigrid)
-REGISTER_SUBTEST('testSetSmoother',testSetSmoother)
-REGISTER_SUBTEST('testSoftReset',testSoftReset)
-REGISTER_SUBTEST('testSetInterp',testSetInterp)
+!REGISTER_SUBTEST('testIterativeSolve_Multigrid',testIterativeSolve_Multigrid)
+!REGISTER_SUBTEST('testSetSmoother',testSetSmoother)
+!REGISTER_SUBTEST('testSoftReset',testSoftReset)
+!REGISTER_SUBTEST('testSetInterp',testSetInterp)
 
 FINALIZE_TEST()
 

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -21,13 +21,18 @@ USE ParallelEnv
 USE VectorTypes
 USE MatrixTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCMAT
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -23,7 +23,7 @@ USE MatrixTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCMAT
 #endif
 #endif
@@ -32,7 +32,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -32,7 +32,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -21,6 +21,8 @@ USE ParallelEnv
 USE VectorTypes
 USE MatrixTypes
 
+USE PETSCMAT
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -96,7 +98,7 @@ SUBROUTINE testMatrix()
   INTEGER(SIK) :: ia_vals(4)
   INTEGER(SIK) :: ja_vals(6)
   REAL(SRK) :: a_vals(6),x(3),y(3),val
-  REAL(SRK) :: dummy
+  REAL(SRK) :: dummy,dummy1(1)
   REAL(SRK),ALLOCATABLE :: dummyvec(:), dummyvec2(:)
   LOGICAL(SBK) :: bool
 #ifdef FUTILITY_HAVE_PETSC
@@ -1852,14 +1854,14 @@ SUBROUTINE testMatrix()
     CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
     thisMatrix%isAssembled=.TRUE.
 
-    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-    bool = dummy==1._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==1._SRK
     ASSERT(bool, 'petscsparse%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscsparse%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-    bool = dummy==3._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==3._SRK
     ASSERT(bool, 'petscsparse%set(...)')
   ENDSELECT
 
@@ -1896,17 +1898,17 @@ SUBROUTINE testMatrix()
     CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
     thisMatrix%isAssembled=.TRUE.
 
-    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-    bool = dummy==1._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==1._SRK
     ASSERT(bool, 'petscsparse%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscsparse%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscsparse%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-    bool = dummy==3._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==3._SRK
     ASSERT(bool, 'petscsparse%set(...)')
   ENDSELECT
   !check matrix that hasnt been init, i,j out of bounds
@@ -2194,14 +2196,14 @@ SUBROUTINE testMatrix()
     CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
     thisMatrix%isAssembled=.TRUE.
 
-    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-    bool = dummy==1._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==1._SRK
     ASSERT(bool, 'petscdense%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscdense%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-    bool = dummy==3._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==3._SRK
     ASSERT(bool, 'petscdense%set(...)')
   ENDSELECT
   CALL thisMatrix%clear()
@@ -2223,17 +2225,17 @@ SUBROUTINE testMatrix()
     CALL MatAssemblyEnd(thisMatrix%a,MAT_FINAL_ASSEMBLY,ierr)
     thisMatrix%isAssembled=.TRUE.
 
-    CALL MatGetValues(thisMatrix%a,1,0,1,0,dummy,ierr)
-    bool = dummy==1._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==1._SRK
     ASSERT(bool, 'petscdense%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,0,1,1,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/0/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscdense%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,0,dummy,ierr)
-    bool = dummy==2._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/0/),dummy1,ierr)
+    bool = dummy1(1)==2._SRK
     ASSERT(bool, 'petscdense%set(...)')
-    CALL MatGetValues(thisMatrix%a,1,1,1,1,dummy,ierr)
-    bool = dummy==3._SRK
+    CALL MatGetValues(thisMatrix%a,1,(/1/),1,(/1/),dummy1,ierr)
+    bool = dummy1(1)==3._SRK
     ASSERT(bool, 'petscdense%set(...)')
   ENDSELECT
   !check matrix that hasnt been init, i,j out of bounds

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -107,7 +107,8 @@ SUBROUTINE testMatrix()
   REAL(SRK),ALLOCATABLE :: dummyvec(:), dummyvec2(:)
   LOGICAL(SBK) :: bool
 #ifdef FUTILITY_HAVE_PETSC
-  INTEGER(SIK) :: matsize1,matsize2,dummy1(1)
+  INTEGER(SIK) :: matsize1,matsize2
+  REAL(SRK) :: dummy1(1)
   CLASS(VectorType),ALLOCATABLE :: xPETScVector,yPETScVector
 #endif
 #ifdef FUTILITY_HAVE_Trilinos

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -21,7 +21,7 @@ USE MatrixTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCMAT
 #endif
 #endif
@@ -30,7 +30,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -19,6 +19,7 @@ USE ParallelEnv
 USE VectorTypes
 USE MatrixTypes
 
+USE PETSCMAT
 
 IMPLICIT NONE
 

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -30,7 +30,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypesParallel.f90
@@ -19,13 +19,18 @@ USE ParallelEnv
 USE VectorTypes
 USE MatrixTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCMAT
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -81,6 +81,8 @@ USE MatrixTypes
 USE ODESolverTypes
 USE testODEInterface
 
+USE PETSCSYS
+
 IMPLICIT NONE
 
 TYPE(ExceptionHandlerType),TARGET :: e

--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -81,7 +81,12 @@ USE MatrixTypes
 USE ODESolverTypes
 USE testODEInterface
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS
+#endif
+#endif
 
 IMPLICIT NONE
 
@@ -92,7 +97,7 @@ CLASS(ODESolverInterface_Base),POINTER :: f
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -83,7 +83,7 @@ USE testODEInterface
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSYS
 #endif
 #endif
@@ -97,7 +97,7 @@ CLASS(ODESolverInterface_Base),POINTER :: f
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testODESolver/testODESolver.f90
+++ b/unit_tests/testODESolver/testODESolver.f90
@@ -97,7 +97,7 @@ CLASS(ODESolverInterface_Base),POINTER :: f
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
+++ b/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
@@ -8,16 +8,21 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testParTPLPETSC
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCSYS
 USE PETSCVEC
 USE PETSCMAT
 USE PETSCKSP
 USE PETSCPC
+#endif
+#endif
 
 IMPLICIT NONE
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -302,8 +307,13 @@ SUBROUTINE testPETSC_KSP_SuperLU
 
   !PC calls
   CALL PCSetType(pc,PCLU,ierr)
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
   CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,ierr)
   CALL PCFactorSetUpMatSolverType(pc,ierr)
+#else
+  CALL PCFactorSetMatSolverPackage(pc,MATSOLVERSUPERLU_DIST,ierr)
+  CALL PCFactorSetUpMatSolverPackage(pc,ierr)
+#endif
   CALL PCFactorGetMatrix(pc,F,ierr)
 
   !test KSPSolve

--- a/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
+++ b/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
@@ -8,6 +8,12 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testParTPLPETSC
 
+USE PETSCSYS
+USE PETSCVEC
+USE PETSCMAT
+USE PETSCKSP
+USE PETSCPC
+
 IMPLICIT NONE
 
 #include <petscversion.h>
@@ -73,7 +79,7 @@ SUBROUTINE testPETSC_KSP
   KSP :: ksp
   PetscReal :: rtol,abstol,dtol
   PetscInt  :: maxits,restart
-  REAL(SRK) :: getval
+  REAL(SRK) :: getval(1)
 
   !test KSPCreate
   CALL KSPCreate(MPI_COMM_WORLD,ksp,ierr)
@@ -187,29 +193,29 @@ SUBROUTINE testPETSC_KSP
   !test KSPSolve
   CALL KSPSolve(ksp,b,x,ierr)
   IF(rank == 0) THEN
-    CALL VecGetValues(x,1,0,getval,ierr)
-    IF(ABS(getval-2.12_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/0/),getval,ierr)
+    IF(ABS(getval(1)-2.12_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,0,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 1) THEN
-    CALL VecGetValues(x,1,1,getval,ierr)
-    IF(ABS(getval-3.24_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/1/),getval,ierr)
+    IF(ABS(getval(1)-3.24_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,1,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 2) THEN
-    CALL VecGetValues(x,1,2,getval,ierr)
-    IF(ABS(getval-3.16_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/2/),getval,ierr)
+    IF(ABS(getval(1)-3.16_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 3) THEN
-    CALL VecGetValues(x,1,3,getval,ierr)
-    IF(ABS(getval-1.98_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/3/),getval,ierr)
+    IF(ABS(getval(1)-1.98_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
@@ -237,7 +243,7 @@ SUBROUTINE testPETSC_KSP_SuperLU
   PC  :: pc
   PetscReal :: rtol,abstol,dtol
   PetscInt  :: maxits,restart
-  REAL(SRK) :: getval
+  REAL(SRK) :: getval(1)
 
   IF(rank == 0) WRITE(*,*)
   IF(rank == 0) WRITE(*,*) 'Testing with SuperLU'
@@ -296,36 +302,36 @@ SUBROUTINE testPETSC_KSP_SuperLU
 
   !PC calls
   CALL PCSetType(pc,PCLU,ierr)
-  CALL PCFactorSetMatSolverPackage(pc,MATSOLVERSUPERLU_DIST,ierr)
-  CALL PCFactorSetUpMatSolverPackage(pc,ierr)
+  CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,ierr)
+  CALL PCFactorSetUpMatSolverType(pc,ierr)
   CALL PCFactorGetMatrix(pc,F,ierr)
 
   !test KSPSolve
   CALL KSPSolve(ksp,b,x,ierr)
   IF(rank == 0) THEN
-    CALL VecGetValues(x,1,0,getval,ierr)
-    IF(ABS(getval-2.12_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/0/),getval,ierr)
+    IF(ABS(getval(1)-2.12_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,0,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 1) THEN
-    CALL VecGetValues(x,1,1,getval,ierr)
-    IF(ABS(getval-3.24_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/1/),getval,ierr)
+    IF(ABS(getval(1)-3.24_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,1,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 2) THEN
-    CALL VecGetValues(x,1,2,getval,ierr)
-    IF(ABS(getval-3.16_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/2/),getval,ierr)
+    IF(ABS(getval(1)-3.16_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF
   ENDIF
   IF(rank == 3) THEN
-    CALL VecGetValues(x,1,3,getval,ierr)
-    IF(ABS(getval-1.98_SRK)>1E-13 .OR. ierr /= 0) THEN
+    CALL VecGetValues(x,1,(/3/),getval,ierr)
+    IF(ABS(getval(1)-1.98_SRK)>1E-13 .OR. ierr /= 0) THEN
       WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [KSPSolve] FAILED!'
       STOP 666
     ENDIF

--- a/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
+++ b/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
@@ -22,7 +22,7 @@ USE PETSCPC
 IMPLICIT NONE
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
+++ b/unit_tests/testParTPLPETSC/testParTPLPETSC.f90
@@ -10,7 +10,7 @@ PROGRAM testParTPLPETSC
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCSYS
 USE PETSCVEC
 USE PETSCMAT
@@ -22,7 +22,7 @@ USE PETSCPC
 IMPLICIT NONE
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -307,7 +307,7 @@ SUBROUTINE testPETSC_KSP_SuperLU
 
   !PC calls
   CALL PCSetType(pc,PCLU,ierr)
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
   CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,ierr)
   CALL PCFactorSetUpMatSolverType(pc,ierr)
 #else

--- a/unit_tests/testPartitionGraph/testPartitionGraph.f90
+++ b/unit_tests/testPartitionGraph/testPartitionGraph.f90
@@ -26,14 +26,14 @@ TYPE(ExceptionHandlerType),POINTER :: e
 
 #ifdef FUTILITY_HAVE_SLEPC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
 #endif
 
 !SLEPC version == PETSC version
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <slepc/finclude/slepc.h>
 #else
 #include <finclude/slepc.h>

--- a/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
+++ b/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
@@ -15,14 +15,14 @@ USE ParameterLists
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCPC
 #endif
 #endif
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
+++ b/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
@@ -13,11 +13,16 @@ USE MatrixTypes
 USE PreconditionerTypes
 USE ParameterLists
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCPC
+#endif
+#endif
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
+++ b/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
@@ -12,6 +12,9 @@ USE VectorTypes
 USE MatrixTypes
 USE PreconditionerTypes
 USE ParameterLists
+
+USE PETSCPC
+
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
@@ -430,7 +433,7 @@ SUBROUTINE testPCShell()
   PetscErrorCode :: ierr
 
   INTEGER(SIK) :: i,niters
-  REAL(SRK) :: val,resid
+  REAL(SRK) :: val(1),resid
   TYPE(PETScMatrixType) :: matrix
   CLASS(PreconditionerType),POINTER :: shellPC
 
@@ -497,13 +500,13 @@ SUBROUTINE testPCShell()
   FINFO() niters,resid
   val=-1.0
   DO i=1,3
-    CALL VecGetValues(x,1,i-1,val,ierr)
+    CALL VecGetValues(x,1,(/i-1/),val,ierr)
     IF(i==2) THEN
-      ASSERT(val.APPROXEQ.2.0_SRK,'ksp sol')
+      ASSERT(val(1).APPROXEQ.2.0_SRK,'ksp sol')
     ELSE
-      ASSERT(val.APPROXEQ.1.5_SRK,'ksp sol')
+      ASSERT(val(1).APPROXEQ.1.5_SRK,'ksp sol')
     ENDIF
-    FINFO() i, val
+    FINFO() i, val(1)
   ENDDO
   CALL KSPDestroy(ksp,ierr)
 
@@ -548,13 +551,13 @@ SUBROUTINE testPCShell()
   FINFO() niters,resid
   val=-1.0
   DO i=1,3
-    CALL VecGetValues(x,1,i-1,val,ierr)
+    CALL VecGetValues(x,1,(/i-1/),val,ierr)
     IF(i==2) THEN
-      ASSERT(val.APPROXEQ.2.0_SRK,'ksp sol')
+      ASSERT(val(1).APPROXEQ.2.0_SRK,'ksp sol')
     ELSE
-      ASSERT(val.APPROXEQ.1.5_SRK,'ksp sol')
+      ASSERT(val(1).APPROXEQ.1.5_SRK,'ksp sol')
     ENDIF
-    FINFO() i, val
+    FINFO() i, val(1)
   ENDDO
 
   CALL MatDestroy(A,ierr)

--- a/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
+++ b/unit_tests/testPreconditionerTypes/testPreconditionerTypes.f90
@@ -22,7 +22,7 @@ USE PETSCPC
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testTPLPETSC/testTPLPETSC.f90
+++ b/unit_tests/testTPLPETSC/testTPLPETSC.f90
@@ -10,7 +10,7 @@ PROGRAM testTPLPETSC
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCVEC
 USE PETSCMAT
 USE PETSCKSP
@@ -20,7 +20,7 @@ USE PETSCKSP
 IMPLICIT NONE
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>
@@ -591,7 +591,7 @@ SUBROUTINE testPETSC_MAT
   !test MatTranspose
   CALL PetscCommBuildTwoSidedSetType(MPI_COMM_WORLD, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,ierr)
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
   CALL MatTranspose(A,MAT_INPLACE_MATRIX,A,ierr)
 #else
   CALL MatTranspose(A,MAT_REUSE_MATRIX,A,ierr)

--- a/unit_tests/testTPLPETSC/testTPLPETSC.f90
+++ b/unit_tests/testTPLPETSC/testTPLPETSC.f90
@@ -8,9 +8,14 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testTPLPETSC
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCVEC
 USE PETSCMAT
 USE PETSCKSP
+#endif
+#endif
 
 IMPLICIT NONE
 
@@ -586,7 +591,11 @@ SUBROUTINE testPETSC_MAT
   !test MatTranspose
   CALL PetscCommBuildTwoSidedSetType(MPI_COMM_WORLD, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,ierr)
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
   CALL MatTranspose(A,MAT_INPLACE_MATRIX,A,ierr)
+#else
+  CALL MatTranspose(A,MAT_REUSE_MATRIX,A,ierr)
+#endif
   CALL MatGetValues(A,1,(/0/),1,(/0/),getval,ierr)
   IF(getval(1) /= 1.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr) FAILED!'

--- a/unit_tests/testTPLPETSC/testTPLPETSC.f90
+++ b/unit_tests/testTPLPETSC/testTPLPETSC.f90
@@ -8,6 +8,10 @@
 !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 PROGRAM testTPLPETSC
 
+USE PETSCVEC
+USE PETSCMAT
+USE PETSCKSP
+
 IMPLICIT NONE
 
 #include <petscversion.h>
@@ -68,7 +72,7 @@ CONTAINS
 !-------------------------------------------------------------------------------
 SUBROUTINE testPETSC_VEC
   Vec :: b,x
-  REAL(SRK) :: getval
+  REAL(SRK) :: getval(1)
 
   !test VecCreate
   CALL VecCreate(MPI_COMM_WORLD,b,ierr)
@@ -159,19 +163,19 @@ SUBROUTINE testPETSC_VEC
   WRITE(*,*) '  Passed: CALL VecAssembly...(...)'
 
   !test VecGetValues
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [VecSetValue] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [VecSetValue] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 7.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [VecSetValue] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 7.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [VecSetValue] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [VecSetValue] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [VecSetValue] FAILED!'
     STOP 666
   ENDIF
 
@@ -183,19 +187,19 @@ SUBROUTINE testPETSC_VEC
   ENDIF
   CALL VecAssemblyBegin(b,ierr)
   CALL VecAssemblyEnd(b,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 6.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [VecSet] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 6.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [VecSet] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 6.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [VecSet] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 6.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [VecSet] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 6.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [VecSet] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 6.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [VecSet] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL VecSet(...)'
@@ -219,61 +223,61 @@ SUBROUTINE testPETSC_VEC
   CALL VecAssemblyEnd(x,ierr)
 
   !test VecNorm
-  CALL VecNorm(b,NORM_1,getval,ierr)
-  IF(getval /= 15.0_SRK .OR. ierr /= 0) THEN
+  CALL VecNorm(b,NORM_1,getval(1),ierr)
+  IF(getval(1) /= 15.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL VecNorm(b,NORM_1,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL VecNorm(x,NORM_1,getval,ierr)
-  IF(getval /= 16.0_SRK .OR. ierr /= 0) THEN
+  CALL VecNorm(x,NORM_1,getval(1),ierr)
+  IF(getval(1) /= 16.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL VecNorm(x,NORM_1,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL VecNorm(b,NORM_2,getval,ierr)
-  IF(getval /= 9.4339811320566032_SRK .OR. ierr /= 0) THEN
+  CALL VecNorm(b,NORM_2,getval(1),ierr)
+  IF(getval(1) /= 9.4339811320566032_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL VecNorm(b,NORM_2,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL VecNorm(x,NORM_2,getval,ierr)
-  IF(getval /= 10.488088481701515_SRK .OR. ierr /= 0) THEN
+  CALL VecNorm(x,NORM_2,getval(1),ierr)
+  IF(getval(1) /= 10.488088481701515_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL VecNorm(x,NORM_2,getval,ierr) FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL VecNorm(...)'
 
   CALL VecAXPY(b,3.0_SRK,x,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 10.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [VecAXPY] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 10.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [VecAXPY] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 35.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [VecAXPY] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 35.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [VecAXPY] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 18.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [VecAXPY] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 18.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [VecAXPY] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL VecAXPY(...)'
 
   !test VecCopy by copying b into x
   CALL VecCopy(b,x,ierr)
-  CALL VecGetValues(x,1,0,getval,ierr)
-  IF(getval /= 10.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,0,getval,ierr) [VecCopy] FAILED!'
+  CALL VecGetValues(x,1,(/0/),getval,ierr)
+  IF(getval(1) /= 10.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/0/),getval,ierr) [VecCopy] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,1,getval,ierr)
-  IF(getval /= 35.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,1,getval,ierr) [VecCopy] FAILED!'
+  CALL VecGetValues(x,1,(/1/),getval,ierr)
+  IF(getval(1) /= 35.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/1/),getval,ierr) [VecCopy] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,2,getval,ierr)
-  IF(getval /= 18.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [VecCopy] FAILED!'
+  CALL VecGetValues(x,1,(/2/),getval,ierr)
+  IF(getval(1) /= 18.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/2/),getval,ierr) [VecCopy] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL VecCopy(...)'
@@ -291,8 +295,8 @@ SUBROUTINE testPETSC_VEC
   CALL VecAssemblyEnd(x,ierr)
 
   !test VecTDot
-  CALL VecTDot(b,x,getval,ierr)
-  IF(getval /= 95.0_SRK .OR. ierr /= 0) THEN
+  CALL VecTDot(b,x,getval(1),ierr)
+  IF(getval(1) /= 95.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL VecTDot(b,x,getval,ierr) FAILED!'
     STOP 666
   ENDIF
@@ -300,53 +304,53 @@ SUBROUTINE testPETSC_VEC
 
   !test VecScale
   CALL VecScale(b,4.0_SRK,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 16.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [VecScale] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 16.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [VecScale] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 32.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [VecScale] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 32.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [VecScale] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 12.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [VecScale] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 12.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [VecScale] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL VecScale(...)'
 
   !test VecSwap
   CALL VecSwap(b,x,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 9.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 9.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,0,getval,ierr)
-  IF(getval /= 16.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,0,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(x,1,(/0/),getval,ierr)
+  IF(getval(1) /= 16.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/0/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,1,getval,ierr)
-  IF(getval /= 32.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,1,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(x,1,(/1/),getval,ierr)
+  IF(getval(1) /= 32.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/1/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,2,getval,ierr)
-  IF(getval /= 12.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [VecSwap] FAILED!'
+  CALL VecGetValues(x,1,(/2/),getval,ierr)
+  IF(getval(1) /= 12.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/2/),getval,ierr) [VecSwap] FAILED!'
     STOP 666
   ENDIF
 
@@ -371,7 +375,7 @@ ENDSUBROUTINE testPETSC_VEC
 SUBROUTINE testPETSC_MAT
   Vec :: b,x
   Mat :: A
-  REAL(SRK) :: getval
+  REAL(SRK) :: getval(1)
 
   !test MatCreate
   CALL MatCreate(MPI_COMM_WORLD,A,ierr)
@@ -476,48 +480,48 @@ SUBROUTINE testPETSC_MAT
   WRITE(*,*) '  Passed: CALL MatAssembly...(...)'
 
   !test MatGetValues
-  CALL MatGetValues(A,1,0,1,0,getval,ierr)
-  IF(getval /= 1.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/0/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 1.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,1,getval,ierr)
-  IF(getval /= 3.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/0/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 3.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,2,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/0/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,1,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,0,getval,ierr)
-  IF(getval /= 6.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 6.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,1,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,2,getval,ierr)
-  IF(getval /= 8.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 8.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,2,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,0,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,1,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,2,getval,ierr)
-  IF(getval /= 4.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 4.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,3,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
@@ -543,38 +547,38 @@ SUBROUTINE testPETSC_MAT
   !      6 2 8       2
   !      5 2 4]      4]
   CALL MatMult(A,x,b,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 32.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [MatMult] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 32.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [MatMult] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 72.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [MatMult] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 72.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [MatMult] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 50.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [MatMult] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 50.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [MatMult] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL MatMult(...)'
 
   !test MatMultTransport
   CALL MatMultTranspose(A,x,b,ierr)
-  CALL VecGetValues(b,1,0,getval,ierr)
-  IF(getval /= 38.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,0,getval,ierr) [MatMultTranspose] FAILED!'
+  CALL VecGetValues(b,1,(/0/),getval,ierr)
+  IF(getval(1) /= 38.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/0/),getval,ierr) [MatMultTranspose] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,1,getval,ierr)
-  IF(getval /= 30.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,1,getval,ierr) [MatMultTranspose] FAILED!'
+  CALL VecGetValues(b,1,(/1/),getval,ierr)
+  IF(getval(1) /= 30.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/1/),getval,ierr) [MatMultTranspose] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(b,1,2,getval,ierr)
-  IF(getval /= 62.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(b,1,2,getval,ierr) [MatMultTranspose] FAILED!'
+  CALL VecGetValues(b,1,(/2/),getval,ierr)
+  IF(getval(1) /= 62.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(b,1,(/2/),getval,ierr) [MatMultTranspose] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL MatMultTranspose(...)'
@@ -582,97 +586,97 @@ SUBROUTINE testPETSC_MAT
   !test MatTranspose
   CALL PetscCommBuildTwoSidedSetType(MPI_COMM_WORLD, &
       PETSC_BUILDTWOSIDED_ALLREDUCE,ierr)
-  CALL MatTranspose(A,MAT_REUSE_MATRIX,A,ierr)
-  CALL MatGetValues(A,1,0,1,0,getval,ierr)
-  IF(getval /= 1.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,1,getval,ierr) FAILED!'
+  CALL MatTranspose(A,MAT_INPLACE_MATRIX,A,ierr)
+  CALL MatGetValues(A,1,(/0/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 1.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,1,getval,ierr)
-  IF(getval /= 6.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/0/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 6.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,2,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/0/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,1,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,0,getval,ierr)
-  IF(getval /= 3.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 3.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,1,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,2,getval,ierr)
-  IF(getval /= 2.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 2.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,2,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,0,getval,ierr)
-  IF(getval /= 5.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 5.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,1,getval,ierr)
-  IF(getval /= 8.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 8.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,2,getval,ierr)
-  IF(getval /= 4.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 4.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,3,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL MatTranspose(...)'
 
   CALL MatZeroEntries(A,ierr)
-  CALL MatGetValues(A,1,0,1,0,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/0/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,1,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,1,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/0/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,0,1,2,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/0/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,1,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,0,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,1,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,2,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/1/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,1,1,2,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/1/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,2,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,0,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,1,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/0/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/1/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,1,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,2,getval,ierr) FAILED!'
+  CALL MatGetValues(A,1,(/2/),1,(/1/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL MatGetValues(A,1,3,1,(/2/),getval,ierr) FAILED!'
     STOP 666
   ENDIF
-  CALL MatGetValues(A,1,2,1,2,getval,ierr)
-  IF(getval /= 0.0_SRK .OR. ierr /= 0) THEN
+  CALL MatGetValues(A,1,(/2/),1,(/2/),getval,ierr)
+  IF(getval(1) /= 0.0_SRK .OR. ierr /= 0) THEN
     WRITE(*,*) 'CALL MatGetValues(A,1,3,1,3,getval,ierr) FAILED!'
     STOP 666
   ENDIF
@@ -693,7 +697,7 @@ SUBROUTINE testPETSC_KSP
   KSP :: ksp
   PetscReal :: rtol,abstol,dtol
   PetscInt  :: maxits,restart
-  REAL(SRK) :: getval
+  REAL(SRK) :: getval(1)
 
   !test KSPCreate
   CALL KSPCreate(MPI_COMM_WORLD,ksp,ierr)
@@ -806,19 +810,19 @@ SUBROUTINE testPETSC_KSP
 
   !test KSPSolve
   CALL KSPSolve(ksp,b,x,ierr)
-  CALL VecGetValues(x,1,0,getval,ierr)
-  IF(ABS(getval-0.4_SRK)>1E-13 .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,0,getval,ierr) [KSPSolve] FAILED!'
+  CALL VecGetValues(x,1,(/0/),getval,ierr)
+  IF(ABS(getval(1)-0.4_SRK)>1E-13 .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/0/),getval,ierr) [KSPSolve] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,1,getval,ierr)
-  IF(ABS(getval+0.2_SRK)>1E-13 .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,1,getval,ierr) [KSPSolve] FAILED!'
+  CALL VecGetValues(x,1,(/1/),getval,ierr)
+  IF(ABS(getval(1)+0.2_SRK)>1E-13 .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/1/),getval,ierr) [KSPSolve] FAILED!'
     STOP 666
   ENDIF
-  CALL VecGetValues(x,1,2,getval,ierr)
-  IF(ABS(getval-0.6_SRK)>1E-13 .OR. ierr /= 0) THEN
-    WRITE(*,*) 'CALL VecGetValues(x,1,2,getval,ierr) [KSPSolve] FAILED!'
+  CALL VecGetValues(x,1,(/2/),getval,ierr)
+  IF(ABS(getval(1)-0.6_SRK)>1E-13 .OR. ierr /= 0) THEN
+    WRITE(*,*) 'CALL VecGetValues(x,1,(/2/),getval,ierr) [KSPSolve] FAILED!'
     STOP 666
   ENDIF
   WRITE(*,*) '  Passed: CALL KSPSolve(...)'

--- a/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
+++ b/unit_tests/testTPLSLEPC/testTPLSLEPC.f90
@@ -11,7 +11,7 @@ PROGRAM testTPLSLEPC
 IMPLICIT NONE
 
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #include <slepc/finclude/slepc.h>
 #else
@@ -194,7 +194,7 @@ SUBROUTINE testEX1F()
       CALL EPSGetEigenpair(eps,i,kr,ki,PETSC_NULL_OBJECT,PETSC_NULL_OBJECT,ierr)
 
       ! Compute the relative error associated to each eigenpair
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
       CALL EPSComputeError(eps,i,EPS_ERROR_RELATIVE,error,ierr)
 #else
       CALL EPSComputeRelativeError(eps,i,error,ierr)

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -29,7 +29,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -18,13 +18,18 @@ USE ParameterLists
 USE ParallelEnv
 USE VectorTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCVEC
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -18,6 +18,8 @@ USE ParameterLists
 USE ParallelEnv
 USE VectorTypes
 
+USE PETSCVEC
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
@@ -721,7 +723,7 @@ SUBROUTINE testVector()
 
     !now compare actual values with expected
     DO i=1,6
-      CALL VecGetValues(thisVector%b,1,i-1,dummy,ierr)
+      CALL VecGetValues(thisVector%b,1,(/i-1/),(/dummy/),ierr)
       bool = .NOT.(dummy /= i .AND. iverr /= 0)
       ASSERT(bool, 'petscvec%setOne(...)')
     ENDDO
@@ -758,7 +760,7 @@ SUBROUTINE testVector()
 
     CALL VecGetSize(thisVector%b,vecsize,ierr)
     DO i=1,vecsize
-      CALL VecGetValues(thisVector%b,1,i-1,dummy,ierr)
+      CALL VecGetValues(thisVector%b,1,(/i-1/),(/dummy/),ierr)
       ASSERT(dummy /= 1._SRK, 'petscvec%setOne(...)')
     ENDDO
     WRITE(*,*) '  Passed: CALL petscvec%setOne(...)'

--- a/unit_tests/testVectorTypes/testVectorTypes.f90
+++ b/unit_tests/testVectorTypes/testVectorTypes.f90
@@ -20,7 +20,7 @@ USE VectorTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCVEC
 #endif
 #endif
@@ -29,7 +29,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -29,7 +29,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -18,13 +18,18 @@ USE ParameterLists
 USE ParallelEnv
 USE VectorTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
 USE PETSCVEC
+#endif
+#endif
 
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if ((PETSC_VERSION_MAJOR==3) && (PETSC_VERSION_MINOR==6))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -18,6 +18,8 @@ USE ParameterLists
 USE ParallelEnv
 USE VectorTypes
 
+USE PETSCVEC
+
 IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC

--- a/unit_tests/testVectorTypes/testVectorTypesParallel.f90
+++ b/unit_tests/testVectorTypes/testVectorTypesParallel.f90
@@ -20,7 +20,7 @@ USE VectorTypes
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
 USE PETSCVEC
 #endif
 #endif
@@ -29,7 +29,7 @@ IMPLICIT NONE
 
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
-#if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6)) || (PETSC_VERSION_MAJOR>=4))
 #include <petsc/finclude/petsc.h>
 #else
 #include <finclude/petsc.h>


### PR DESCRIPTION
This MR encompasses the changes necessary to use PETSc 3.12.4.  I think eventually, we'll want to consider deprecating older versions of PETSc support, but at present should preserve any previous versions supported.