### PR TITLE
Remove Call Restriction On Anderson Reset

### DIFF
--- a/src/AndersonAcceleration.f90
+++ b/src/AndersonAcceleration.f90
@@ -296,6 +296,9 @@ SUBROUTINE reset_AndersonAccelerationType(solver,x)
   CLASS(AndersonAccelerationType),INTENT(INOUT) :: solver
   CLASS(VectorType),INTENT(INOUT) :: x
 
+#ifdef HAVE_MPI | FUTILITY_HAVE_Trilinos
+  CHARACTER(LEN=*),PARAMETER :: myName='reset_AndersonAccelerationType'
+#endif
   INTEGER(SIK) :: i,j
 
   REQUIRE(x%n == solver%n)
@@ -310,12 +313,12 @@ SUBROUTINE reset_AndersonAccelerationType(solver,x)
 #ifdef HAVE_MPI
     TYPE IS(NativeDistributedVectorType)
       CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-          '::reset_AndersonAccelerationType - Input vector type not supported!')
+          '::'//myName//' - Input vector type not supported!')
 #endif
 #ifdef FUTILITY_HAVE_Trilinos
     TYPE IS(TrilinosVectorType)
       CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-          '::reset_AndersonAccelerationType - Input vector type not supported!')
+          '::'//myName//' - Input vector type not supported!')
 #endif
     ENDSELECT
 

--- a/src/AndersonAcceleration.f90
+++ b/src/AndersonAcceleration.f90
@@ -296,7 +296,6 @@ SUBROUTINE reset_AndersonAccelerationType(solver,x)
   CLASS(AndersonAccelerationType),INTENT(INOUT) :: solver
   CLASS(VectorType),INTENT(INOUT) :: x
 
-  CHARACTER(LEN=*),PARAMETER :: myName='reset_AndersonAccelerationType'
   INTEGER(SIK) :: i,j
 
   REQUIRE(x%n == solver%n)
@@ -311,12 +310,12 @@ SUBROUTINE reset_AndersonAccelerationType(solver,x)
 #ifdef HAVE_MPI
     TYPE IS(NativeDistributedVectorType)
       CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-          '::'//myName//' - Input vector type not supported!')
+          '::reset_AndersonAccelerationType - Input vector type not supported!')
 #endif
 #ifdef FUTILITY_HAVE_Trilinos
     TYPE IS(TrilinosVectorType)
       CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-          '::'//myName//' - Input vector type not supported!')
+          '::reset_AndersonAccelerationType - Input vector type not supported!')
 #endif
     ENDSELECT
 

--- a/src/AndersonAcceleration.f90
+++ b/src/AndersonAcceleration.f90
@@ -302,33 +302,28 @@ SUBROUTINE reset_AndersonAccelerationType(solver,x)
   REQUIRE(x%n == solver%n)
 
   !If this is the first call to set/reset must actually create vectors of needed type
-  IF(solver%s == 0) THEN
-    IF(.NOT.ALLOCATED(solver%x)) THEN
+  IF(.NOT.ALLOCATED(solver%x)) THEN
 
-      !!!TODO Once missing BLAS interfaces have been added for the following vector types
-      !do away with this error catch to allow use of these with Anderson Acceleration.
+    !!!TODO Once missing BLAS interfaces have been added for the following vector types
+    !do away with this error catch to allow use of these with Anderson Acceleration.
 
-      SELECT TYPE(x)
+    SELECT TYPE(x)
 #ifdef HAVE_MPI
-      TYPE IS(NativeDistributedVectorType)
-        CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-            '::'//myName//' - Input vector type not supported!')
+    TYPE IS(NativeDistributedVectorType)
+      CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
+          '::'//myName//' - Input vector type not supported!')
 #endif
 #ifdef FUTILITY_HAVE_Trilinos
-      TYPE IS(TrilinosVectorType)
-        CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-            '::'//myName//' - Input vector type not supported!')
-#endif
-      ENDSELECT
-
-      CALL VectorResembleAlloc(solver%x,x,solver%depth+1)
-      CALL VectorResembleAlloc(solver%Gx,x,solver%depth+1)
-      CALL VectorResembleAlloc(solver%r,x,solver%depth+1)
-      CALL VectorResembleAlloc(solver%tmpvec,x)
-    ELSE
+    TYPE IS(TrilinosVectorType)
       CALL solver%ce%exceptHandler%raiseError('Incorrect call to '//modName// &
-          '::'//myName//' - At least one step required before reseting!')
-    ENDIF
+          '::'//myName//' - Input vector type not supported!')
+#endif
+    ENDSELECT
+
+    CALL VectorResembleAlloc(solver%x,x,solver%depth+1)
+    CALL VectorResembleAlloc(solver%Gx,x,solver%depth+1)
+    CALL VectorResembleAlloc(solver%r,x,solver%depth+1)
+    CALL VectorResembleAlloc(solver%tmpvec,x)
   ENDIF
 
   !Reset iteration counter

--- a/src/VectorTypes.f90
+++ b/src/VectorTypes.f90
@@ -448,6 +448,7 @@ SUBROUTINE VectorResembleAllocScal(dest, source, inparams)
   CALL dest%init(params)
 
   IF(PRESENT(inparams)) CALL inparams%clear()
+  CALL params%clear()
 
 ENDSUBROUTINE VectorResembleAllocScal
 !
@@ -526,6 +527,8 @@ SUBROUTINE VectorResembleAllocArray(dest, source, nvec, inparams)
   ENDDO
 
   IF(PRESENT(inparams)) CALL inparams%clear()
+  CALL params%clear()
+  
 ENDSUBROUTINE VectorResembleAllocArray
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testAndersonAcceleration/testAndersonAcceleration.f90
+++ b/unit_tests/testAndersonAcceleration/testAndersonAcceleration.f90
@@ -22,12 +22,11 @@ IMPLICIT NONE
 
 TYPE(FutilityComputingEnvironment),TARGET :: ce
 TYPE(ExceptionHandlerType),TARGET :: exceptHandler
-TYPE(ParamType) :: pList
 TYPE(AndersonAccelerationType) :: testAndAcc
 CLASS(VectorType),ALLOCATABLE :: mySol,exSol,inSol,tmpvec
-TYPE(ParamType)vecparams
-REAL(SRK) :: tmp1,tmp2
 TYPE(StochasticSamplingType) :: NativeRNG
+TYPE(ParamType) :: pList,vecparams
+REAL(SRK) :: tmp1,tmp2
 
 ALLOCATE(RealVectorType :: mySol,exSol,inSol,tmpvec)
 CALL vecparams%add("VectorType->n",10000_SIK)
@@ -66,6 +65,10 @@ CALL pList%add('AndersonAccelerationType->beta',0.5_SRK)
 CALL pList%add('AndersonAccelerationType->start',1)
 CALL NativeRNG%clear()
 CALL NativeRNG%init(RNG_MCNP_STD)
+CALL mySol%clear()
+CALL exSol%clear()
+CALL inSol%clear()
+CALL tmpvec%clear()
 DEALLOCATE(mySol,exSol,inSol,tmpvec)
 ALLOCATE(PETScVectorType :: mySol,exSol,inSol,tmpvec)
 CALL vecparams%add('VectorType->MPI_Comm_ID',PE_COMM_SELF)
@@ -82,9 +85,17 @@ REGISTER_SUBTEST('testStep(Distrib)',testStep)
 #endif
 !!!TODO: When support for TrilinosVectors and NativeDistributed are added, add testing for them
 
+CALL mySol%clear()
+CALL exSol%clear()
+CALL inSol%clear()
+CALL tmpvec%clear()
+DEALLOCATE(mySol,exSol,inSol,tmpvec)
+CALL NativeRNG%clear()
+CALL pList%clear()
+CALL vecparams%clear()
+
 FINALIZE_TEST()
 
-CALL pList%clear()
 CALL ce%clear()
 !
 !===============================================================================


### PR DESCRIPTION
The native Anderson Acceleration ability had a restriction in place that required that a solution step be taken at least once before the solver was reset. This normally makes sense, however, for multistate cases where only a single iteration will be taken on a state this restriction becomes a problem. This MR simply removes the restriction.