### PR TITLE
Enable editing pvtu files for serial cases

### DIFF
--- a/src/VTUFiles.f90
+++ b/src/VTUFiles.f90
@@ -465,7 +465,7 @@ SUBROUTINE writepvtu_VTUXMLFileType(fileobj,funit,case,filen,procs,rank)
   INTEGER(SIK) :: i,j,iord
   CHARACTER(LEN=128) :: fname,fmtStr
   !
-  IF((procs>1).AND.rank == 0) THEN
+  IF(rank == 0) THEN
     sint='fsr_'//TRIM(case)//'/'
     CALL SlashRep(sint)
     OPEN(unit=funit,file=TRIM(sint)//TRIM(filen)//'.pvtu')


### PR DESCRIPTION
This enables serial cases to write pvtu files, which provides nothing more than a user convenience when using the written files in visit.