### PR TITLE
Add replace_entry interface to ArrayUtils

### DIFF
--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -35,6 +35,7 @@ PUBLIC :: isMonotonic
 PUBLIC :: isIncreasing
 PUBLIC :: isDecreasing
 PUBLIC :: hasAnyRemainder
+PUBLIC :: replaceEntry
 !PUBLIC :: findIntersection
 !Need a routine in here that compares a 1-D array to a 2-D array for a given dimension
 !to see if the 1-D array exists in the 2-D array...
@@ -175,6 +176,14 @@ INTERFACE isIncreasing
   !> @copybrief ArrayUtils::isIncreasing_1DReal
   !> @copydetails ArrayUtils::isIncreasing_1DReal
   MODULE PROCEDURE isIncreasing_1DReal
+ENDINTERFACE
+
+!> @brief Interface to replace an entry of a list with a new list
+!>
+INTERFACE replaceEntry
+  !> @copybrief ArrayUtils::replaceEntry_1DString
+  !> @copydetails ArrayUtils::replaceEntry_1DString
+  MODULE PROCEDURE replaceEntry_1DString
 ENDINTERFACE
 !
 !===============================================================================
@@ -1336,5 +1345,32 @@ FUNCTION hasAnyRemainder(r,tol) RESULT(bool)
   WHERE(ABS(rem) < 1.0E-14_SRK) rem=0.0_SRK
   bool=ANY(rem > 1.0E-14_SRK)
 ENDFUNCTION hasAnyRemainder
+!
+!-------------------------------------------------------------------------------
+!> @brief Replaces an entry in a string list with a list of entries
+!> @param oldlist the original list
+!> @param sublist the new list to insert
+!> @param entry the index of the entry to replace
+!>
+SUBROUTINE replaceEntry_1DString(oldlist,sublist,entry)
+  TYPE(StringType),ALLOCATABLE,INTENT(INOUT) :: oldlist(:)
+  TYPE(StringType),INTENT(IN) :: sublist(:)
+  INTEGER(SIK),INTENT(IN) :: entry
+  !
+  TYPE(StringType),ALLOCATABLE :: tmplist(:)
+
+  REQUIRE(ALLOCATED(oldlist))
+  REQUIRE(entry > 0)
+  REQUIRE(entry <= SIZE(oldlist))
+
+  CALL MOVE_ALLOC(oldlist,tmplist)
+  ALLOCATE(oldlist(SIZE(tmplist)+SIZE(sublist)-1))
+  oldlist(1:entry-1)=tmplist(1:entry-1)
+  oldlist(entry:SIZE(tmplist)-1)=tmplist(entry+1:)
+  IF(SIZE(sublist) > 0) THEN
+    oldlist(SIZE(tmplist):)=sublist(:)
+  ENDIF
+
+ENDSUBROUTINE replaceEntry_1DString
 !
 ENDMODULE ArrayUtils

--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -18,6 +18,7 @@ USE Futility_DBC
 USE IntrType
 USE Sorting
 USE Strings
+USE IO_Strings
 
 IMPLICIT NONE
 PRIVATE
@@ -1366,10 +1367,8 @@ SUBROUTINE replaceEntry_1DString(oldlist,sublist,entry)
   CALL MOVE_ALLOC(oldlist,tmplist)
   ALLOCATE(oldlist(SIZE(tmplist)+SIZE(sublist)-1))
   oldlist(1:entry-1)=tmplist(1:entry-1)
-  oldlist(entry:SIZE(tmplist)-1)=tmplist(entry+1:)
-  IF(SIZE(sublist) > 0) THEN
-    oldlist(SIZE(tmplist):)=sublist(:)
-  ENDIF
+  oldlist(entry:entry+SIZE(sublist)-1)=sublist(:)
+  oldlist(entry+SIZE(sublist):)=tmplist(entry+1:)
 
 ENDSUBROUTINE replaceEntry_1DString
 !

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -32,6 +32,7 @@ REGISTER_SUBTEST('1-D INTEGERS',test1DInts)
 REGISTER_SUBTEST('1-D Strings',test1DStrings)
 REGISTER_SUBTEST('2-D Strings',test2DStrings)
 !REGISTER_SUBTEST('2-D INTEGERS',test2DInts)
+REGISTER_SUBTEST('ReplaceEntry',testReplaceEntry)
 
 FINALIZE_TEST()
 !
@@ -699,5 +700,53 @@ ENDSUBROUTINE test2DStrings
   !findNUnique_2DInt
   !getUnique_2DInt
 !ENDSUBROUTINE test2DInts
+!
+!-------------------------------------------------------------------------------
+SUBROUTINE testReplaceEntry()
+  INTEGER(SIK) :: index
+  TYPE(StringType),ALLOCATABLE :: strlist(:),strsublist(:)
+
+  COMPONENT_TEST('1D Strings')
+  ALLOCATE(strlist(3))
+  strlist(1)='string1'
+  strlist(2)='string 2'
+  strlist(3)='string  3'
+  ALLOCATE(strsublist(0))
+  CALL replaceEntry(strlist,strsublist,2)
+  ASSERT_EQ(SIZE(strlist),2,'0 list replacement')
+  ASSERT_EQ(CHAR(strlist(1)),'string1','strlist(1)')
+  ASSERT_EQ(CHAR(strlist(2)),'string  3','strlist(2)')
+  DEALLOCATE(strsublist)
+  ALLOCATE(strsublist(2))
+  strsublist(1)='test string 1'
+  strsublist(2)='test string  2'
+  CALL replaceEntry(strlist,strsublist,2)
+  ASSERT_EQ(SIZE(strlist),3,'size strlist')
+  ASSERT_EQ(CHAR(strlist(1)),'string1','strlist(1)')
+  ASSERT_EQ(CHAR(strlist(2)),'test string 1','strlist(2)')
+  ASSERT_EQ(CHAR(strlist(3)),'test string  2','strlist(3)')
+  CALL replaceEntry(strlist,strsublist,1)
+  ASSERT_EQ(SIZE(strlist),4,'size strlist')
+  ASSERT_EQ(CHAR(strlist(1)),'test string 1','strlist(1)')
+  ASSERT_EQ(CHAR(strlist(2)),'test string  2','strlist(2)')
+  ASSERT_EQ(CHAR(strlist(3)),'test string 1','strlist(3)')
+  ASSERT_EQ(CHAR(strlist(4)),'test string  2','strlist(4)')
+  CALL replaceEntry(strlist,strsublist,2)
+  ASSERT_EQ(SIZE(strlist),5,'size strlist')
+  ASSERT_EQ(CHAR(strlist(1)),'test string 1','strlist(1)')
+  ASSERT_EQ(CHAR(strlist(2)),'test string 1','strlist(2)')
+  ASSERT_EQ(CHAR(strlist(3)),'test string  2','strlist(3)')
+  ASSERT_EQ(CHAR(strlist(4)),'test string 1','strlist(4)')
+  ASSERT_EQ(CHAR(strlist(5)),'test string  2','strlist(5)')
+  CALL replaceEntry(strlist,strsublist,5)
+  ASSERT_EQ(SIZE(strlist),6,'size strlist')
+  ASSERT_EQ(CHAR(strlist(1)),'test string 1','strlist(1)')
+  ASSERT_EQ(CHAR(strlist(2)),'test string 1','strlist(2)')
+  ASSERT_EQ(CHAR(strlist(3)),'test string  2','strlist(3)')
+  ASSERT_EQ(CHAR(strlist(4)),'test string 1','strlist(4)')
+  ASSERT_EQ(CHAR(strlist(5)),'test string 1','strlist(5)')
+  ASSERT_EQ(CHAR(strlist(6)),'test string  2','strlist(6)')
+  
+ENDSUBROUTINE testReplaceEntry
 !
 ENDPROGRAM testArrayUtils


### PR DESCRIPTION
This allows a single entry of an array to be replaced by an array.  It's basically a convenience function to handle certain types of array resize operations.