### PR TITLE
Add constructor for string types

### DIFF
--- a/src/Strings.f90
+++ b/src/Strings.f90
@@ -134,6 +134,12 @@ TYPE :: StringType
     !FINAL :: clean_str
 ENDTYPE StringType
 
+INTERFACE StringType
+  !> @copybrief Strings::charToStringType
+  !> @copydetails Strings::charToStringType
+  MODULE PROCEDURE charToStringType
+ENDINTERFACE
+
 !> @brief Overloads the Fortran intrinsic procedure CHAR() so
 !> a string type argument may be passed.
 INTERFACE CHAR
@@ -1358,5 +1364,15 @@ FUNCTION isNumeric_str(this) RESULT(bool)
   LOGICAL(SBK) :: bool
   bool = this%isInteger() .OR. this%isFloat()
 ENDFUNCTION isNumeric_str
+!
+!-------------------------------------------------------------------------------
+!> @brief Constructor for a @c StringType from a character
+!> @param char the character to use
+!> @returns string the resulting @c StringType object
+FUNCTION charToStringType(char) RESULT(string)
+  CHARACTER(LEN=*),INTENT(IN) :: char
+  TYPE(StringType) :: string
+  string=char
+ENDFUNCTION charToStringType
 !
 ENDMODULE Strings

--- a/src/Strings.f90
+++ b/src/Strings.f90
@@ -1369,7 +1369,7 @@ ENDFUNCTION isNumeric_str
 !> @brief Constructor for a @c StringType from a character
 !> @param char the character to use
 !> @returns string the resulting @c StringType object
-FUNCTION charToStringType(char) RESULT(string)
+ELEMENTAL FUNCTION charToStringType(char) RESULT(string)
   CHARACTER(LEN=*),INTENT(IN) :: char
   TYPE(StringType) :: string
   string=char

--- a/unit_tests/testStrings/testStrings.f90
+++ b/unit_tests/testStrings/testStrings.f90
@@ -23,6 +23,7 @@ REGISTER_SUBTEST('Array Assignments',testAssign_arrays)
 REGISTER_SUBTEST('Operator Overloading',testOperators)
 REGISTER_SUBTEST('Intrinsics',testIntrinsic)
 REGISTER_SUBTEST('string_functs',testStrFunct)
+REGISTER_SUBTEST('constructor',testConstructor)
 FINALIZE_TEST()
 !
 !-------------------------------------------------------------------------------
@@ -861,5 +862,22 @@ SUBROUTINE testStrFunct()
   ASSERT_EQ(CHAR(str_list(3)),'','string with multiple delimter found')
 
 ENDSUBROUTINE testStrFunct
+SUBROUTINE testConstructor
+  TYPE(StringType) :: test0
+  TYPE(StringType),ALLOCATABLE :: test1(:)
+
+  COMPONENT_TEST('Scalar')
+  test0=StringType('test 0')
+  ASSERT_EQ(CHAR(test0),'test 0','constructor')
+
+  COMPONENT_TEST('Array')
+  test1=StringType((/'test 1','test 2','test 3'/))
+  ASSERT(ALLOCATED(test1),'ALLOCATED constructor')
+  ASSERT_EQ(SIZE(test1),3,'SIZE constructor')
+  ASSERT_EQ(CHAR(test1(1)),'test 1','array(1)')
+  ASSERT_EQ(CHAR(test1(2)),'test 2','array(2)')
+  ASSERT_EQ(CHAR(test1(3)),'test 3','array(3)')
+  
+ENDSUBROUTINE testConstructor
 !
 ENDPROGRAM testStrings


### PR DESCRIPTION
Adds a constructor for string types.  This allows interfaces to be defined
only taking in string types, and the client code can simply cast native characters
to the string type in the call to the routine if needed.  Specifically this can
be useful for testing where hard-coded strings will be common.