### PR TITLE
Fix getUnique to always return allocated array

### DIFF
--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -62,8 +62,7 @@ INTERFACE getDelta
   MODULE PROCEDURE getDelta_1DReal
 ENDINTERFACE getDelta
 
-!> @brief Generic interface to ...
-!>
+!> @brief Generic interface to retrieve the unique entries of an array
 INTERFACE getUnique
   !> @copybrief ArrayUtils::getUnique_1DReal
   !> @copydetails ArrayUtils::getUnique_1DReal
@@ -477,6 +476,8 @@ ENDFUNCTION findNUnique_2DString
 !> @param delta The optional input for whether the array is incremental or not
 !> @param tol The tolerance for comparing two real values
 !>
+!> If the input array is size 0, the output array is allocated to size 0.
+!>
 SUBROUTINE getUnique_1DReal(r,rout,delta,tol)
   REAL(SRK),INTENT(IN) :: r(:)
   REAL(SRK),ALLOCATABLE,INTENT(INOUT) :: rout(:)
@@ -537,6 +538,8 @@ ENDSUBROUTINE getUnique_1DReal
 !> @param rout The 1-D array of unique entries in the array r.
 !> @param delta The optional input for whether the array is incremental or not
 !>
+!> If the input array is size 0, the output array is allocated to size 0.
+!>
 SUBROUTINE getUnique_1DInt(r,rout,delta)
   INTEGER(SIK),INTENT(IN) :: r(:)
   INTEGER(SIK),ALLOCATABLE,INTENT(INOUT) :: rout(:)
@@ -586,6 +589,9 @@ ENDSUBROUTINE getUnique_1DInt
 !> @brief This routine takes an array of strings and returns the array of unique
 !>        entries.
 !> @param r The input array of strings
+!> @param rout the output array of unique strings
+!>
+!> If the input array is size 0, the output array is allocated to size 0.
 !>
 SUBROUTINE getUnique_1DString(r,rout)
   TYPE(StringType),INTENT(IN) :: r(:)
@@ -631,6 +637,8 @@ ENDSUBROUTINE getUnique_1DString
 !>        entries.
 !> @param r The input 2-D array of strings.
 !> @param rout The 1-D array of unique entries in the array r.
+!>
+!> If the input array is size 0, the output array is allocated to size 0.
 !>
 SUBROUTINE getUnique_2DString(r,rout)
   TYPE(StringType),INTENT(IN) :: r(:,:)

--- a/src/ArrayUtils.f90
+++ b/src/ArrayUtils.f90
@@ -524,6 +524,8 @@ SUBROUTINE getUnique_1DReal(r,rout,delta,tol)
 
     !Deallocate
     DEALLOCATE(tmpr)
+  ELSE
+    ALLOCATE(rout(0))
   ENDIF
 ENDSUBROUTINE getUnique_1DReal
 !
@@ -575,6 +577,8 @@ SUBROUTINE getUnique_1DInt(r,rout,delta)
     ENDDO
     !Deallocate
     DEALLOCATE(tmpr)
+  ELSE
+    ALLOCATE(rout(0))
   ENDIF
 ENDSUBROUTINE getUnique_1DInt
 !
@@ -593,11 +597,11 @@ SUBROUTINE getUnique_1DString(r,rout)
   n=SIZE(r,DIM=1)
   ALLOCATE(tmpr(n))
   tmpr=r
+  IF(ALLOCATED(rout)) DEALLOCATE(rout)
 
   !Find the number of unique entries
   sout=findNUnique_1DString(r)
   IF(sout > 0) THEN
-    IF(ALLOCATED(rout)) DEALLOCATE(rout)
     ALLOCATE(rout(sout))
     rout=''
     !remove duplicate entries
@@ -614,6 +618,8 @@ SUBROUTINE getUnique_1DString(r,rout)
         sout=sout+1
       ENDIF
     ENDDO
+  ELSE
+    ALLOCATE(rout(0))
   ENDIF
 
   !Deallocate
@@ -636,11 +642,11 @@ SUBROUTINE getUnique_2DString(r,rout)
   m=SIZE(r,DIM=2)
   ALLOCATE(tmpr(n,m))
   tmpr=r
+  IF(ALLOCATED(rout)) DEALLOCATE(rout)
 
   !Find the number of unique entries
   sout=findNUnique_2DString(r)
   IF(sout > 0) THEN
-    IF(ALLOCATED(rout)) DEALLOCATE(rout)
     ALLOCATE(rout(sout))
     rout=''
     !Remove the duplicate entries
@@ -663,6 +669,8 @@ SUBROUTINE getUnique_2DString(r,rout)
         ENDIF
       ENDDO
     ENDDO
+  ELSE
+    ALLOCATE(rout(0))
   ENDIF
   !Deallocate
   DEALLOCATE(tmpr)

--- a/unit_tests/testArrayUtils/testArrayUtils.f90
+++ b/unit_tests/testArrayUtils/testArrayUtils.f90
@@ -171,7 +171,7 @@ SUBROUTINE test1DReals()
   bool=ALL(tmpr == (/1.0_SRK,1.0000000000100000_SRK,2.0_SRK/))
   ASSERT(bool,'getUnique, 3 unique with TOL')
   CALL getUnique(tmprealarray(1:0),tmpr)
-  ASSERT(.NOT. ALLOCATED(tmpr),'getUnique, size 0 array')
+  ASSERT_EQ(SIZE(tmpr),0,'getUnique, size 0 array')
 
   !
   COMPONENT_TEST('findIndex 1-D Array')
@@ -578,7 +578,7 @@ SUBROUTINE test1DInts()
   bool=ALL(tmpi == (/0,2,5,20,25,40,100/))
   ASSERT(bool,'getUnique, 3 duplicates')
   CALL getUnique(tmpintarray(1:0),tmpi)
-  ASSERT(.NOT. ALLOCATED(tmpi),'getUnique, size 0 array')
+  ASSERT_EQ(SIZE(tmpi),0,'getUnique, size 0 array')
 
 ENDSUBROUTINE test1DInts
 !
@@ -615,7 +615,7 @@ SUBROUTINE test1DStrings()
   tmpstr1a=''
   IF(ALLOCATED(tmps1)) DEALLOCATE(tmps1)
   CALL getUnique(tmpstr1a,tmps1)
-  ASSERT(.NOT.ALLOCATED(tmps1),'empty array')
+  ASSERT_EQ(SIZE(tmps1),0,'empty array')
   tmpstr1a(1)='one'
   tmpstr1a(2)='two'
   tmpstr1a(3)='three'
@@ -677,7 +677,7 @@ SUBROUTINE test2DStrings()
   tmpstr2a=''
   IF(ALLOCATED(tmps1)) DEALLOCATE(tmps1)
   CALL getUnique(tmpstr2a,tmps1)
-  ASSERT(.NOT.ALLOCATED(tmps1),'empty array')
+  ASSERT_EQ(SIZE(tmps1),0,'empty array')
   tmpstr2a(1,1)='one'
   tmpstr2a(1,2)='three'
   tmpstr2a(2,1)='two'


### PR DESCRIPTION
Ensures that an allocated array is always returned by getUnique