### PR TITLE
Test labels

### DIFF
--- a/ProjectName.cmake
+++ b/ProjectName.cmake
@@ -9,6 +9,8 @@
 
 SET(PROJECT_NAME Futility)
 
+SET(FUTILITY_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 INCLUDE(cmake/Project_Common.cmake)
 
 # Put in hard disables for excluded packages

--- a/unit_tests/testGenReqTables/CMakeLists.txt
+++ b/unit_tests/testGenReqTables/CMakeLists.txt
@@ -8,6 +8,7 @@
 #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 INCLUDE(Futility_CreateUnitTest)
 INCLUDE(Futility_CopyFiles)
+INCLUDE(SetTestLabels)
 
 SET(ADDITIONAL_FILES
   subtest01/testA.inp
@@ -46,9 +47,11 @@ UNSET(ADDITIONAL_FILES)
 ASSERT_DEFINED(Futility_SOURCE_DIR)
 SET(UTILPATH ${Futility_SOURCE_DIR}/cmake/GenerateRequirementsTable.py)
 
-TRIBITS_ADD_ADVANCED_TEST(testGenReqTables
+SET(TESTNAME testGenReqTables)
+TRIBITS_ADD_ADVANCED_TEST(${TESTNAME}
   FAIL_FAST
   TIMEOUT 120
+  ADDED_TEST_NAME_OUT TESTNAME_OUT
   OVERALL_NUM_TOTAL_CORES_USED 1
   
   #Subtest01
@@ -131,5 +134,6 @@ TRIBITS_ADD_ADVANCED_TEST(testGenReqTables
     ARGS ${UTILPATH} --path subtest10/ --ext .inp
     PASS_REGULAR_EXPRESSION "@beginreq was found but @endreq was not found in file"
 )
+SetTestLabels(${TESTNAME_OUT} "BASIC")
 
 UNSET(UTILPATH)


### PR DESCRIPTION
The main purpose here is to make it possible for other projects to consistently locate Futility cmake files via the `Futility_SRC_DIR` variable.  However, I also discovered a test had not been given a test label either, so I fixed that in the process.