### PR TITLE
Relaxed nnz requirement on serial banded matrices

### DIFF
--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -695,6 +695,7 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
 
   ALLOCATE(diagRank(thisMatrix%counter))
   ALLOCATE(idxOrig(thisMatrix%counter))
+  IF (thisMatrix%isAssembled) RETURN
   DO i=1,thisMatrix%counter
     iLong=INT(thisMatrix%iTmp(i),kind=SLK)
     jLong=INT(thisMatrix%jTmp(i),kind=SLK)
@@ -1369,6 +1370,7 @@ SUBROUTINE set_BandedMatrixType(matrix,i,j,setval)
   IF((j <= matrix%m) .AND. (i <= matrix%n) .AND. (i >= 1) .AND. (j >= 1)) THEN
     IF(.NOT. matrix%isAssembled) THEN
       ! If it is not assembled, add to tmp variables
+      REQUIRE(matrix%counter < matrix%nnz)
       matrix%counter=matrix%counter+1
       matrix%iTmp(matrix%counter)=i
       matrix%jTmp(matrix%counter)=j

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -444,7 +444,8 @@ SUBROUTINE init_BandedMatrixParam(matrix,Params)
 
   ! Pull Data From Parameter List
   CALL validParams%get('MatrixType->n',n)
-  CALL validParams%get('MatrixType->m',m)
+  m=n
+  IF (validParams%has('MatrixType->m')) CALL validParams%get('MatrixType->m',m)
   CALL validParams%get('MatrixType->nnz',nnz)
   CALL validParams%clear()
 
@@ -691,11 +692,10 @@ SUBROUTINE assemble_BandedMatrixType(thisMatrix)
   INTEGER(SLK),ALLOCATABLE :: diagRank(:)
 
   REQUIRE(thisMatrix%isInit)
-  REQUIRE(thisMatrix%nnz == thisMatrix%counter)
 
-  ALLOCATE(diagRank(SIZE(thisMatrix%iTmp)))
-  ALLOCATE(idxOrig(SIZE(thisMatrix%iTmp)))
-  DO i=1,SIZE(thisMatrix%iTmp)
+  ALLOCATE(diagRank(thisMatrix%counter))
+  ALLOCATE(idxOrig(thisMatrix%counter))
+  DO i=1,thisMatrix%counter
     iLong=INT(thisMatrix%iTmp(i),kind=SLK)
     jLong=INT(thisMatrix%jTmp(i),kind=SLK)
     nLong=INT(thisMatrix%n,kind=SLK)

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -1402,6 +1402,30 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%set(3,3,5._SRK)
   CALL thisMatrix%set(3,4,6._SRK)
   CALL thisMatrix%set(4,4,7._SRK)
+
+  ! The banded matrix should be able to assemble without all entries
+  SELECT TYPE(thisMatrix)
+  TYPE IS(BandedMatrixType)
+    CALL thisMatrix%assemble()
+    bool = .TRUE.
+    bool = bool .AND. thisMatrix%bands(1)%elem(1) == 1
+    bool = bool .AND. thisMatrix%bands(1)%elem(2) == 3
+    bool = bool .AND. thisMatrix%bands(1)%elem(3) == 5
+    bool = bool .AND. thisMatrix%bands(1)%elem(4) == 7
+    bool = bool .AND. thisMatrix%bands(2)%elem(1) == 2
+    bool = bool .AND. thisMatrix%bands(2)%elem(2) == 6
+    ASSERT(bool, 'banded%set(...)')
+  ENDSELECT
+  CALL thisMatrix%clear()
+
+  ! Set should work for all nnz entries set
+  CALL thisMatrix%init(pList)
+  CALL thisMatrix%set(1,1,1._SRK)
+  CALL thisMatrix%set(1,2,2._SRK)
+  CALL thisMatrix%set(2,2,3._SRK)
+  CALL thisMatrix%set(3,3,5._SRK)
+  CALL thisMatrix%set(3,4,6._SRK)
+  CALL thisMatrix%set(4,4,7._SRK)
   CALL thisMatrix%set(4,2,9._SRK)
   SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
@@ -1414,6 +1438,27 @@ SUBROUTINE testMatrix()
     bool = bool .AND. thisMatrix%bands(3)%elem(1) == 2
     bool = bool .AND. thisMatrix%bands(3)%elem(2) == 6
     bool = bool .AND. thisMatrix%bands(1)%elem(1) == 9
+    ASSERT(bool, 'banded%set(...)')
+  ENDSELECT
+
+  ! Set should work post-assemble
+  CALL thisMatrix%set(1,1,-1._SRK)
+  CALL thisMatrix%set(1,2,-2._SRK)
+  CALL thisMatrix%set(2,2,-3._SRK)
+  CALL thisMatrix%set(3,3,-5._SRK)
+  CALL thisMatrix%set(3,4,-6._SRK)
+  CALL thisMatrix%set(4,4,-7._SRK)
+  CALL thisMatrix%set(4,2,-9._SRK)
+  SELECT TYPE(thisMatrix)
+  TYPE IS(BandedMatrixType)
+    bool = .TRUE.
+    bool = bool .AND. thisMatrix%bands(2)%elem(1) == -1
+    bool = bool .AND. thisMatrix%bands(2)%elem(2) == -3
+    bool = bool .AND. thisMatrix%bands(2)%elem(3) == -5
+    bool = bool .AND. thisMatrix%bands(2)%elem(4) == -7
+    bool = bool .AND. thisMatrix%bands(3)%elem(1) == -2
+    bool = bool .AND. thisMatrix%bands(3)%elem(2) == -6
+    bool = bool .AND. thisMatrix%bands(1)%elem(1) == -9
     ASSERT(bool, 'banded%set(...)')
   ENDSELECT
   CALL thisMatrix%clear()
@@ -1502,9 +1547,7 @@ SUBROUTINE testMatrix()
   SELECT TYPE(thisMatrix)
   TYPE IS(BandedMatrixType)
     CALL thisMatrix%assemble()
-    WRITE(*,*) "calling matvec"
     CALL BLAS_matvec(THISMATRIX=thisMatrix,X=dummyvec,Y=dummyvec2,ALPHA=1.0_SRK,BETA=0.0_SRK)
-    WRITE(*,*) "finished matvec call"
     DO i=1,4
       bool = ABS(dummyvec2(i)) < 1E-6
       ASSERT(bool, 'banded%matvec(...)')


### PR DESCRIPTION
The serial banded matrix requires an exact nnz value count to function. However, this was improved for the parallel versions, which instead treat nnz as an upper bound.

This MR updates the serial behavior to match the parallel behavior, which resolves several ongoing problems with implementing native CMFD in the serial debug test cases.