### PR TITLE
Fix petsc errors to migrate from petsc 3.6 to 3.12

### DIFF
--- a/src/LinearSolverTypes_Multigrid.f90
+++ b/src/LinearSolverTypes_Multigrid.f90
@@ -562,7 +562,7 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
   !For now, only Galerkin coarse grid operators are supported.
   !  Galerkin means A_c = R*A*I
 
-#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>7)) || (PETSC_VERSION_MAJOR>=4))
   CALL PCMGSetGalerkin(solver%pc,PC_MG_GALERKIN_BOTH,iperr)
 #else
   CALL PCMGSetGalerkin(solver%pc,PETSC_TRUE,iperr)
@@ -570,8 +570,8 @@ SUBROUTINE setupPETScMG_LinearSolverType_Multigrid(solver,Params)
   CALL KSPSetInitialGuessNonzero(solver%ksp,PETSC_TRUE,iperr)
 
   !Set # of levels:
-#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
-  CALL PCMGSetLevels(solver%pc,solver%nLevels,iperr)
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>7)) || (PETSC_VERSION_MAJOR>=4))
+  CALL PCMGSetLevels(solver%pc,solver%nLevels,PETSC_NULL_PC,iperr)
 #else
   CALL PCMGSetLevels(solver%pc,solver%nLevels,PETSC_NULL_OBJECT,iperr)
 #endif

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -333,7 +333,6 @@ CONTAINS
 !> @param Params the parameter list
 !>
 SUBROUTINE init_SparseMatrixParam(matrix,Params)
-  CHARACTER(LEN=*),PARAMETER :: myName='init_SparseMatrixParam'
   CLASS(SparseMatrixType),INTENT(INOUT) :: matrix
   CLASS(ParamType),INTENT(IN) :: Params
   TYPE(ParamType) :: validParams

--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -339,6 +339,8 @@ SUBROUTINE init_SparseMatrixParam(matrix,Params)
   TYPE(ParamType) :: validParams
   INTEGER(SIK) :: n,nnz
 
+  REQUIRE(.NOT.matrix%isInit)
+
   !Check to set up required and optional param lists.
   IF(.NOT.MatrixType_Paramsflag) CALL MatrixTypes_Declare_ValidParams()
 
@@ -350,31 +352,23 @@ SUBROUTINE init_SparseMatrixParam(matrix,Params)
   CALL validParams%get('MatrixType->n',n)
   CALL validParams%get('MatrixType->nnz',nnz)
   CALL validParams%clear()
+  REQUIRE(n > 0)
+  REQUIRE(nnz > 0)
 
-  IF(.NOT. matrix%isInit) THEN
-    IF((n < 1).OR.(nnz < 1))  THEN
-      CALL eMatrixType%raiseError('Incorrect   input to '// &
-          modName//'::'//myName//' - Input parameters must be '// &
-          'greater than 1!')
-    ELSE
-      matrix%isInit=.TRUE.
-      matrix%n=n
-      matrix%nnz=nnz
-      matrix%jCount=0
-      matrix%iPrev=0
-      matrix%jPrev=0
-      !regardless of sparsity, SIZE(ia)=n+1
-      CALL dmallocA(matrix%ia,matrix%n+1)
-      CALL dmallocA(matrix%a,matrix%nnz)
-      CALL dmallocA(matrix%ja,matrix%nnz)
-      !last entry of ia is known in advanced
-      !this is per the intel MKL format
-      matrix%ia(matrix%n+1)=matrix%nnz+1
-    ENDIF
-  ELSE
-    CALL eMatrixType%raiseError('Incorrect call to '// &
-        modName//'::'//myName//' - MatrixType already initialized')
-  ENDIF
+  matrix%isInit=.TRUE.
+  matrix%n=n
+  matrix%nnz=nnz
+  matrix%jCount=0
+  matrix%iPrev=0
+  matrix%jPrev=0
+  !regardless of sparsity, SIZE(ia)=n+1
+  CALL dmallocA(matrix%ia,matrix%n+1)
+  CALL dmallocA(matrix%a,matrix%nnz)
+  CALL dmallocA(matrix%ja,matrix%nnz)
+  !last entry of ia is known in advanced
+  !this is per the intel MKL format
+  matrix%ia(matrix%n+1)=matrix%nnz+1
+
 ENDSUBROUTINE init_SparseMatrixParam
 !
 !-------------------------------------------------------------------------------

--- a/unit_tests/testLinearSolver/testLinearSolverParallel.f90
+++ b/unit_tests/testLinearSolver/testLinearSolverParallel.f90
@@ -18,10 +18,16 @@ USE MatrixTypes
 USE PreconditionerTypes
 USE LinearSolverTypes
 
+#ifdef FUTILITY_HAVE_PETSC
+#include <petscversion.h>
+#if (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)) || (PETSC_VERSION_MAJOR>=4))
+USE PETSCVEC
+#endif
+#endif
+
 IMPLICIT NONE
 
 !TYPE(ExceptionHandlerType),TARGET :: e
-#ifdef HAVE_MPI
 #ifdef FUTILITY_HAVE_PETSC
 #include <petscversion.h>
 #if ((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=6))
@@ -31,13 +37,19 @@ IMPLICIT NONE
 #endif
 #undef IS
 PetscErrorCode  :: ierr
-CALL PetscInitialize(PETSC_NULL_CHARACTER,ierr)
 #else
+#ifdef HAVE_MPI
 #include <mpif.h>
 INTEGER(SIK) :: ierr
-CALL MPI_Init(ierr)
+#endif
 #endif
 
+#ifdef HAVE_MPI
+CALL MPI_Init(ierr)
+#endif
+#ifdef FUTILITY_HAVE_PETSC
+CALL PetscInitialize(PETSC_NULL_CHARACTER,ierr)
+#endif
 !Configure exception handler for test
 !CALL e%setStopOnError(.FALSE.)
 !CALL e%setQuietMode(.TRUE.)
@@ -64,6 +76,7 @@ CONTAINS
 !
 !-------------------------------------------------------------------------------
 SUBROUTINE testIterativeSolve_GMRES()
+#ifdef HAVE_MPI
   CLASS(LinearSolverType_Base),ALLOCATABLE :: thisLS
   TYPE(ParamType) :: pList
   REAL(SRK),ALLOCATABLE :: thisB(:),dummyvec(:)

--- a/unit_tests/testMatrixTypes/testMatrixTypes.f90
+++ b/unit_tests/testMatrixTypes/testMatrixTypes.f90
@@ -192,48 +192,6 @@ SUBROUTINE testMatrix()
   CALL thisMatrix%clear()
   CALL pList%clear()
 
-  !now check init without m being provided
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  bool = .NOT. thisMatrix%isInit
-  ASSERT(bool, 'sparse%init(...)')
-  CALL thisMatrix%clear()
-
-  !init it twice so on 2nd init, isInit==.TRUE.
-  CALL thisMatrix%init(pList)
-  SELECT TYPE(thisMatrix); TYPE IS(SparseMatrixType)
-    thisMatrix%nnz=1
-  ENDSELECT
-  CALL thisMatrix%init(pList)
-  SELECT TYPE(thisMatrix); TYPE IS(SparseMatrixType)
-    ASSERT(thisMatrix%nnz==1, 'sparse%init(...)')
-  ENDSELECT
-  !init with n<1
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%add('MatrixType->nnz',10_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  !n<1, and m not provided
-  CALL pList%add('MatrixType->n',-1_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-  CALL thisMatrix%clear()
-  CALL pList%clear()
-  !init with m<1
-  CALL pList%add('MatrixType->n',10_SNK)
-  CALL pList%add('MatrixType->nnz',-10_SNK)
-  CALL pList%validate(pList,optListMat)
-  CALL thisMatrix%init(pList) !expect exception
-  ASSERT(.NOT.thisMatrix%isInit, 'sparse%init(...)')
-  CALL thisMatrix%clear()
-
   !test setShape
   COMPONENT_TEST("sparse%setshape")
   !intend to make: [1 0 2]


### PR DESCRIPTION
Adds need ifdef/USE statements to get Futility tests building in 8.3 with new TPLs