### PR TITLE
Fix superlu_dist issues by using it for serial solvers too

### DIFF
--- a/src/LinearSolverTypes.f90
+++ b/src/LinearSolverTypes.f90
@@ -547,11 +547,7 @@ SUBROUTINE init_LinearSolverType_Base(solver,Params,A)
           CALL KSPGetPC(solver%ksp,pc,ierr)
           CALL PCSetType(pc,PCLU,iperr)
 #if   (((PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>=12)) || (PETSC_VERSION_MAJOR>=4))
-          IF (solver%MPIparallelEnv%nproc>1) THEN
-             CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,iperr)
-          ELSE
-             CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU,iperr)
-          ENDIF
+          CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU_DIST,iperr)
           CALL PCFactorSetUpMatSolverType(pc,iperr)
 #elif (PETSC_VERSION_MAJOR>=3) && (PETSC_VERSION_MINOR>6)
           CALL PCFactorSetMatSolverType(pc,MATSOLVERSUPERLU,iperr)


### PR DESCRIPTION
Just use superlu_dist for both serial and parallel solves to fix valgrind defects