### PR TITLE
Fixes defects in testEigenvalueSolver

### DIFF
--- a/src/EigenvalueSolverTypes.f90
+++ b/src/EigenvalueSolverTypes.f90
@@ -562,6 +562,7 @@ SUBROUTINE init_EigenvalueSolverType_Anasazi(solver,MPIEnv,Params)
     CALL tmpPL%add('VectorType->nlocal',nlocal)
     CALL solver%X%init(tmpPL)
     CALL solver%X_scale%init(tmpPL)
+    CALL tmpPL%clear()
     SELECTTYPE(x=>solver%X); TYPE IS(TrilinosVectorType)
       CALL Anasazi_SetX(solver%eig,x%b)
     ENDSELECT
@@ -798,8 +799,10 @@ SUBROUTINE clear_EigenvalueSolverType_Anasazi(solver)
   NULLIFY(solver%A)
   NULLIFY(solver%B)
   CALL solver%x_scale%clear()
-  IF(solver%X%isInit) CALL solver%X%clear()
-  CALL Preconditioner_Destroy(solver%pc)
+  IF(ASSOCIATED(solver%X)) THEN
+    IF(solver%X%isInit) CALL solver%X%clear()
+    DEALLOCATE(solver%X)
+  ENDIF
   CALL Anasazi_Destroy(solver%eig)
 #endif
   solver%isInit=.FALSE.

--- a/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
+++ b/unit_tests/testEigenvalueSolver/testEigenvalueSolver.f90
@@ -293,7 +293,7 @@ SUBROUTINE testClearAnasazi()
   ASSERT(testEVS%k==0.0_SRK,'%k')
   ASSERT(.NOT. ASSOCIATED(testEVS%A),'%A')
   ASSERT(.NOT. ASSOCIATED(testEVS%B),'%B')
-  ASSERT(.NOT. (testEVS%X%isInit) ,'%x')
+  ASSERT(.NOT. ASSOCIATED(testEVS%X) ,'%x')
   SELECTTYPE(testEVS); TYPE IS(EigenvalueSolverType_Anasazi)
 #ifdef FUTILITY_HAVE_Trilinos
     ASSERT(.NOT. testEVS%x_scale%isInit,'%x_scale')


### PR DESCRIPTION
Something was being cleared twice in Trilinos due to how we
were calling various functions.  This fixes that issue and
fixes 2 other unrelated valgrind defects.  The test now passes
in release-debug with no memory leaks or other valgrind defects.