### PR TITLE
Add fieldData to vtkMeshType to aid VTU filled boundary edits

### DIFF
--- a/src/VTKFiles.f90
+++ b/src/VTKFiles.f90
@@ -190,6 +190,9 @@ TYPE :: VTKMeshType
   REAL(SRK),ALLOCATABLE :: y(:)
   !> The z coordinates of the vertices in the mesh
   REAL(SRK),ALLOCATABLE :: z(:)
+  !> The field data to write to each file
+  !This is currently used for material IDs for VTU edits
+  INTEGER(SIK),ALLOCATABLE :: fieldData(:)
 !
 !List of type-bound procedures (methods) for the VTK Mesh type
   CONTAINS
@@ -395,6 +398,7 @@ CONTAINS
     IF(ALLOCATED(myVTKMesh%x)) DEALLOCATE(myVTKMesh%x)
     IF(ALLOCATED(myVTKMesh%y)) DEALLOCATE(myVTKMesh%y)
     IF(ALLOCATED(myVTKMesh%z)) DEALLOCATE(myVTKMesh%z)
+    IF(ALLOCATED(myVTKMesh%fieldData)) DEALLOCATE(myVTKMesh%fieldData)
   ENDSUBROUTINE clear_VTKMeshType
 !
 !-------------------------------------------------------------------------------

--- a/src/VTUFiles.f90
+++ b/src/VTUFiles.f90
@@ -199,6 +199,21 @@ SUBROUTINE writeMesh_VTUXMLFileType(myVTKFile,vtkMesh)
           sint=myVTKFile%mesh%numPoints
           aline=myVTKFile%mesh%numCells
           WRITE(funit,'(a)') '  <UnstructuredGrid>'
+          IF(ALLOCATED(myVTKFile%mesh%fieldData)) THEN
+            n=SIZE(myVTKFile%mesh%fieldData)
+            WRITE(funit,'(a)') '    <FieldData>'
+            WRITE(funit,'(a)') '      <DataArray type="Int32" Name="MaterialIds" NumberOfTuples="'// &
+                str(n)//'" format="ascii">'
+            i=0
+            DO WHILE(i < n)
+              i=i+1
+              IF(MOD(i,10) == 1) WRITE(funit,'(a)',ADVANCE='NO') '       '
+              WRITE(funit,'(a,i0)',ADVANCE='NO') " ",myVTKFile%mesh%fieldData(i)
+              IF(MOD(i,10) == 0 .OR. i == n) WRITE(funit,'(a)',ADVANCE='YES') ""
+            ENDDO
+            WRITE(funit,'(a)') '      </DataArray>'
+            WRITE(funit,'(a)') '    </FieldData>'
+          ENDIF
           WRITE(funit,'(a)') '    <Piece NumberOfPoints="'//TRIM(sint)// &
               '" NumberOfCells="'//TRIM(aline)//'">'
           WRITE(funit,'(a)') '      <Points>'


### PR DESCRIPTION
This is needed for certain types of integer data to plot correctly as boundary plots.