### PR TITLE
Hotfix for Distributed Matrix Initialization

### DIFF
--- a/src/MatrixTypes_Native.f90
+++ b/src/MatrixTypes_Native.f90
@@ -497,7 +497,7 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
   CALL validParams%get('MatrixType->nnz',nnz_int)
   CALL validParams%get('MatrixType->blockSize',blockSize)
   CALL validParams%get('MatrixType->nlocal',nlocal)
-  nnz=INT(nnz_int,KIND=8)
+  nnz=INT(nnz_int,KIND=SLK)
   IF(nnz_int <= 1) THEN
     IF (validParams%has("MatrixType->dnnz") .AND. validParams%has("MatrixType->onnz")) THEN
       nnz=0_SLK
@@ -507,7 +507,7 @@ SUBROUTINE init_DistributedBandedMatrixParam(matrix,Params)
         nnz=nnz+INT(onnz(i),KIND=SLK)
         nnz=nnz+INT(dnnz(i),KIND=SLK)
       ENDDO
-      CALL MPI_AllReduce(nnz,MPI_IN_PLACE,1,MPI_LONG,MPI_SUM,commID,mpierr)
+      CALL MPI_AllReduce(MPI_IN_PLACE,nnz,1,MPI_LONG,MPI_SUM,commID,mpierr)
     ENDIF
   ENDIF
 


### PR DESCRIPTION
The MPI_IN_PLACE keyword needs to be swapped from the send to recv buffer in an allreduce call.
Current implementation fails (silently) to correctly sum data on some problems (including 3-mini in the native CMFD heavies.

This was not observed before, and I don't know why it is an issue now. The layout of the CMFD matrix should not have changed. The only change made before observing this issue was the update of the MPACT branch to latest master.

Additionally, the documentation for MPI seems to indicate the MPI_IN_PLACE keyword is valid in either the send/recv buffer. However, this is clearly not the case here.